### PR TITLE
verify manager and workers are running same load test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## 0.6.1-dev
  - replace `unsafe` code blocks with lazy_static singleton
+ - perform checksum to confirm workers are running same load test,
+   `--no-hash-check` to ignore
 
 ## 0.6.1 May 16, 2020
- - replace --print-stats with --no-stats, default to printing stats
+ - replace `--print-stats` with `--no-stats`, default to printing stats
  - make gaggle an optional compile-time feature
  - GooseState is now GooseAttack
 

--- a/README.md
+++ b/README.md
@@ -161,28 +161,30 @@ optimized code. This can generate considerably more load test traffic.
 
 ## Simple Example
 
-Passing the included `simple` example the `-h` flag you can see the
-run-time configuration options available to Goose load tests:
+The `-h` flag will show all run-time configuration options available to Goose
+load tests. For example, pass the `-h` flag to the `simple` example,
+`cargo run --example simple -- --no-hash-check -h`:
 
 ```
 client 0.6.1
-CLI options available when launching a Goose loadtest, provided by StructOpt
+CLI options available when launching a Goose loadtest
 
 USAGE:
     simple [FLAGS] [OPTIONS]
 
 FLAGS:
-    -h, --help            Prints help information
-    -l, --list            Shows list of all possible Goose tasks and exits
-    -g, --log-level       Log level (-g, -gg, -ggg, etc.)
-        --manager         Enables manager mode
-        --only-summary    Only prints summary stats
-        --no-stats        Don't print stats in the console
-        --reset-stats     Resets statistics once hatching has been completed
-        --status-codes    Includes status code counts in console stats
-    -V, --version         Prints version information
-    -v, --verbose         Debug level (-v, -vv, -vvv, etc.)
-        --worker          Enables worker mode
+    -h, --help             Prints help information
+    -l, --list             Shows list of all possible Goose tasks and exits
+    -g, --log-level        Log level (-g, -gg, -ggg, etc.)
+        --manager          Enables manager mode
+        --no-hash-check    Ignore worker load test checksum
+        --no-stats         Don't print stats in the console
+        --only-summary     Only prints summary stats
+        --reset-stats      Resets statistics once hatching has been completed
+        --status-codes     Includes status code counts in console stats
+    -V, --version          Prints version information
+    -v, --verbose          Debug level (-v, -vv, -vvv, etc.)
+        --worker           Enables worker mode
 
 OPTIONS:
     -c, --clients <clients>                        Number of concurrent Goose users (defaults to available CPUs)

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ Goose is a Rust load testing tool, based on Locust.
 - [ ] gaggle support (distributed Geese)
   - [x] 1:n manager:worker processes
   - [x] make gaggle mode optional (adds cmake requirement)
-  - [ ] load test checksum, warn/err if workers are running different tests
+  - [x] load test checksum, warn/err if workers are running different tests
   - [ ] code cleanup, better code re-use
 - [ ] async clients
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1619,7 +1619,7 @@ mod tests {
 
     #[test]
     fn goose_request() {
-        let mut request = GooseRequest::new("/", GooseMethod::GET);
+        let mut request = GooseRequest::new("/", GooseMethod::GET, 0);
         assert_eq!(request.path, "/".to_string());
         assert_eq!(request.method, GooseMethod::GET);
         assert_eq!(request.response_times.len(), 0);
@@ -1826,7 +1826,7 @@ mod tests {
     #[test]
     fn goose_client() {
         let configuration = GooseConfiguration::default();
-        let mut client = GooseClient::new(0, 0, Some("http://example.com/".to_string()), None, 0, 0, &configuration);
+        let mut client = GooseClient::new(0, 0, Some("http://example.com/".to_string()), None, 0, 0, &configuration, 0);
         assert_eq!(client.task_sets_index, 0);
         assert_eq!(client.default_host, Some("http://example.com/".to_string()));
         assert_eq!(client.task_set_host, None);
@@ -1879,16 +1879,16 @@ mod tests {
 
         // Returns new GooseRequest if never set before.
         let request = client.get_request("/foo", &GooseMethod::GET);
-        assert_eq!(request, GooseRequest::new("/foo", GooseMethod::GET));
+        assert_eq!(request, GooseRequest::new("/foo", GooseMethod::GET, 0));
 
         // Store a GooseRequest objet and confirm we can them retreive it.
-        let mut request = GooseRequest::new("/", GooseMethod::GET);
+        let mut request = GooseRequest::new("/", GooseMethod::GET, 0);
         request.set_response_time(55);
         request.set_status_code(Some(StatusCode::OK));
         client.set_request("/", &GooseMethod::GET, request.clone());
         let restored_request = client.get_request("/", &GooseMethod::GET);
         // This is not an empty request object.
-        assert_ne!(restored_request, GooseRequest::new("/", GooseMethod::GET));
+        assert_ne!(restored_request, GooseRequest::new("/", GooseMethod::GET, 0));
         // This is the request we stored.
         assert_eq!(&request, &restored_request);
 
@@ -1898,7 +1898,7 @@ mod tests {
         client.set_request("/", &GooseMethod::GET, request.clone());
         let restored_request_again = client.get_request("/", &GooseMethod::GET);
         // This is not an empty request object.
-        assert_ne!(restored_request, GooseRequest::new("/", GooseMethod::GET));
+        assert_ne!(restored_request, GooseRequest::new("/", GooseMethod::GET, 0));
         // This is not first request we stored.
         assert_ne!(&request, &restored_request);
         // This is the new request we stored.
@@ -1919,7 +1919,7 @@ mod tests {
         assert_eq!(url, "https://www.example.com/path/to/resource");
 
         // Create a second client, this time setting a task_set_host.
-        let mut client2 = GooseClient::new(0, 0, Some("http://www.example.com/".to_string()), Some("http://www2.example.com/".to_string()), 1, 3, &configuration);
+        let mut client2 = GooseClient::new(0, 0, Some("http://www.example.com/".to_string()), Some("http://www2.example.com/".to_string()), 1, 3, &configuration, 0);
         assert_eq!(client2.default_host, Some("http://www.example.com/".to_string()));
         assert_eq!(client2.task_set_host, Some("http://www2.example.com/".to_string()));
         assert_eq!(client2.min_wait, 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1142,7 +1142,7 @@ pub struct GooseConfiguration {
     #[structopt(long)]
     manager: bool,
 
-    /// Ignore worker load test hash
+    /// Ignore worker load test checksum
     #[structopt(long)]
     no_hash_check: bool,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,6 +716,18 @@ impl GooseAttack {
                 error!("The --status-codes option is only available to the manager");
                 std::process::exit(1);
             }
+
+            if self.configuration.no_hash_check {
+                error!("The --no-hash-check option is only available to the manager");
+                std::process::exit(1);
+            }
+        }
+
+        if !self.configuration.manager && !self.configuration.worker {
+            if self.configuration.no_hash_check {
+                error!("The --no-hash-check option is only available when running in manager mode");
+                std::process::exit(1);
+            }
         }
 
         // Configure number of client threads to launch per second, defaults to 1.
@@ -1072,7 +1084,7 @@ impl GooseAttack {
     }
 }
 
-/// CLI options available when launching a Goose loadtest, provided by StructOpt.
+/// CLI options available when launching a Goose loadtest.
 #[derive(StructOpt, Debug, Default, Clone, Serialize, Deserialize)]
 #[structopt(name = "client")]
 pub struct GooseConfiguration {
@@ -1129,6 +1141,10 @@ pub struct GooseConfiguration {
     /// Enables manager mode
     #[structopt(long)]
     manager: bool,
+
+    /// Ignore worker load test hash
+    #[structopt(long)]
+    no_hash_check: bool,
 
     /// Required when in manager mode, how many workers to expect
     #[structopt(long, required=false, default_value="0")]

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -189,10 +189,6 @@ pub fn manager_main(mut state: GooseAttack) -> GooseAttack {
                             debug!("requests statistics received: {:?}", requests.len());
                             for (request_key, request) in requests {
                                 trace!("request_key: {}", request_key);
-                                if request.load_test_hash != state.task_sets_hash {
-                                    error!("worker is running a different load test");
-                                    std::process::exit(1);
-                                }
                                 let merged_request;
                                 if let Some(parent_request) = state.merged_requests.get(&request_key) {
                                     merged_request = crate::merge_from_client(parent_request, &request, &state.configuration);
@@ -293,6 +289,31 @@ pub fn manager_main(mut state: GooseAttack) -> GooseAttack {
                     }
                     // We need another worker, accept the connection.
                     else {
+                        // Validate worker load test hash.
+                        match requests.get("load_test_hash") {
+                            Some(r) => {
+                                if r.load_test_hash != state.task_sets_hash {
+                                    if state.configuration.no_hash_check {
+                                        warn!("worker is running a different load test, ignoring")
+                                    }
+                                    else {
+                                        error!("worker is running a different load test, set --no-hash-check to ignore");
+                                        std::process::exit(1);
+                                    }
+                                }
+
+                            },
+                            None => {
+                                if state.configuration.no_hash_check {
+                                    warn!("worker is running a different load test, ignoring")
+                                }
+                                else {
+                                    error!("worker is running a different load test, set --no-hash-check to ignore");
+                                    std::process::exit(1);
+                                }
+                            }
+                        };
+
                         workers.insert(pipe);
                         info!("worker {} of {} connected", workers.len(), state.configuration.expect_workers);
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -189,6 +189,10 @@ pub fn manager_main(mut state: GooseAttack) -> GooseAttack {
                             debug!("requests statistics received: {:?}", requests.len());
                             for (request_key, request) in requests {
                                 trace!("request_key: {}", request_key);
+                                if request.load_test_hash != state.task_sets_hash {
+                                    error!("worker is running a different load test");
+                                    std::process::exit(1);
+                                }
                                 let merged_request;
                                 if let Some(parent_request) = state.merged_requests.get(&request_key) {
                                     merged_request = crate::merge_from_client(parent_request, &request, &state.configuration);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use nng::*;
 
 use crate::{GooseAttack, GooseConfiguration};
-use crate::goose::{GooseRequest, GooseClient, GooseClientCommand};
+use crate::goose::{GooseRequest, GooseClient, GooseClientCommand, GooseMethod};
 use crate::manager::GooseClientInitializer;
 use crate::util;
 
@@ -58,8 +58,18 @@ pub fn worker_main(state: &GooseAttack) {
     }
 
     // Let manager know we're ready to work -- push empty HashMap.
-    let requests: HashMap<String, GooseRequest> = HashMap::new();
+    let mut requests: HashMap<String, GooseRequest> = HashMap::new();
+    // "Fake" request for manager to validate this worker's load test hash.
+    requests.insert("load_test_hash".to_string(), GooseRequest::new(
+        "none",
+        GooseMethod::GET,
+        state.task_sets_hash,
+    ));
+    debug!("sending load test hash to manager: {}", state.task_sets_hash);
     push_stats_to_manager(&manager, &requests, false);
+
+    // Only send load_test_hash one time.
+    requests = HashMap::new();
 
     let mut hatch_rate: Option<f32> = None;
     let mut config: GooseConfiguration = GooseConfiguration::default();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -109,6 +109,7 @@ pub fn worker_main(state: &GooseAttack) {
                 initializer.min_wait,
                 initializer.max_wait,
                 &initializer.config,
+                state.task_sets_hash,
             ));
             if hatch_rate == None {
                 hatch_rate = Some(1.0 / (initializer.config.hatch_rate as f32 / (initializer.config.expect_workers as f32)));


### PR DESCRIPTION
 - hash the load test
 - workers push hash to manager to validate
 - exit if hashes don't match
 - introduce `--no-hash-check` flag to optionally ignored mismatched load tests