### PR TITLE
Consistency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,7 +823,7 @@ impl GooseAttack {
 
             #[cfg(not(feature = "gaggle"))]
             {
-                error!("goose must be recompiled with `--features gaggle` to start in manager mode");
+                error!("goose must be recompiled with `--features gaggle` to start in worker mode");
                 std::process::exit(1);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@
 //! 
 //! Have you ever been attacked by a goose?
 //! 
-//! Goose is a load testing tool based on [Locust](https://locust.io/).
+//! Goose is a load testing tool inspired by [Locust](https://locust.io/).
 //! User behavior is defined with standard Rust code.
 //! 
-//! Goose load tests are built by creating an application with Cargo,
-//! and declaring a dependency on the Goose library.
+//! Goose load tests, called Goose Attacks, are built by creating an application
+//! with Cargo, and declaring a dependency on the Goose library.
 //! 
 //! Goose uses the [`reqwest::blocking`](https://docs.rs/reqwest/*/reqwest/blocking/)
 //! API to provide a convenient HTTP client. (Async support is on the roadmap, also
@@ -69,7 +69,7 @@
 //! ```
 //! 
 //! We pass the `request_builder` object to `goose_send` which builds and executes it, also
-//! collecting useful statistics which can be viewed with the `--print-stats` flag.
+//! collecting useful statistics.
 //! 
 //! Once all our tasks are created, we edit the main function to initialize goose and register
 //! the tasks. In this very simple example we only have two tasks to register, while in a real
@@ -101,12 +101,12 @@
 //! ### Running the Goose load test
 //! 
 //! Attempts to run our example will result in an error, as we have not yet defined the
-//! host against which this loadtest should be run. We intentionally do not hard code the
+//! host against which this load test should be run. We intentionally do not hard code the
 //! host in the individual tasks, as this allows us to run the test against different
 //! environments, such as local and staging.
 //! 
 //! ```bash
-//! $ cargo run --release -- 
+//! $ cargo run --release
 //!    Compiling loadtest v0.1.0 (~/loadtest)
 //!     Finished release [optimized] target(s) in 1.52s
 //!      Running `target/release/loadtest`
@@ -116,25 +116,23 @@
 //! options to customize our load test.
 //! 
 //! ```bash
-//! $ cargo run --release -- --host http://dev.local --print-stats -t 30s -v
+//! $ cargo run --release -- --host http://dev.local -t 30s -v
 //! ```
 //! 
 //! The first option we specified is `--host`, and in this case tells Goose to run the load test
-//! against an 8-core VM on my local network. The `--print-stats` flag configures Goose to collect
-//! statistics as the load test runs, printing running statistics during the test and final summary
-//! statistics when finished. The `-t 30s` option tells Goose to end the load test after 30 seconds
-//! (for real load tests you'll certainly want to run it longer, you can use `m` to specify minutes
-//! and `h` to specify hours. For example, `-t 1h30m` would run the load test for 1 hour 30 minutes).
-//! Finally, the `-v` flag tells goose to display INFO and higher level logs to stdout, giving more
-//! insight into what is happening. (Additional `-v` flags will result in considerably more debug
-//! output, and are not recommended for running actual load tests; they're only useful if you're
-//! trying to debug Goose itself.)
+//! against an 8-core VM on my local network. The `-t 30s` option tells Goose to end the load test
+//! after 30 seconds (for real load tests you'll certainly want to run it longer, you can use `m` to
+//! specify minutes and `h` to specify hours. For example, `-t 1h30m` would run the load test for 1
+//! hour 30 minutes). Finally, the `-v` flag tells goose to display INFO and higher level logs to
+//! stdout, giving more insight into what is happening. (Additional `-v` flags will result in
+//! considerably more debug output, and are not recommended for running actual load tests; they're
+//! only useful if you're trying to debug Goose itself.)
 //! 
 //! Running the test results in the following output (broken up to explain it as it goes):
 //! 
 //! ```bash
 //!    Finished release [optimized] target(s) in 0.05s
-//!     Running `target/release/loadtest --host 'http://dev.local' --print-stats -t 30s -v`
+//!     Running `target/release/loadtest --host 'http://dev.local' -t 30s -v`
 //! 05:56:30 [ INFO] Output verbosity level: INFO
 //! 05:56:30 [ INFO] Logfile verbosity level: INFO
 //! 05:56:30 [ INFO] Writing to log file: goose.log
@@ -313,6 +311,7 @@ use crate::goose::{GooseTaskSet, GooseTask, GooseClient, GooseClientMode, GooseC
 
 #[cfg(not(feature = "gaggle"))]
 #[derive(Debug)]
+/// Socket used for coordinating a Gaggle, a distributed load test.
 pub struct Socket {}
 
 /// Internal global state for load test.
@@ -837,7 +836,7 @@ impl GooseAttack {
         }
     }
 
-    /// Called internally in local-mode and gaggle-mode.
+    /// Called internally in single-process mode and distributed load test gaggle-mode.
     pub fn launch_clients(mut self, mut started: time::Instant, sleep_duration: time::Duration, socket: Option<Socket>) -> GooseAttack {
         trace!("launch clients: started({:?}) sleep_duration({:?}) socket({:?})", started, sleep_duration, socket);
         // Collect client threads in a vector for when we want to stop them later.
@@ -1084,7 +1083,7 @@ impl GooseAttack {
     }
 }
 
-/// CLI options available when launching a Goose loadtest.
+/// CLI options available when launching a Goose load test.
 #[derive(StructOpt, Debug, Default, Clone, Serialize, Deserialize)]
 #[structopt(name = "client")]
 pub struct GooseConfiguration {
@@ -1335,7 +1334,10 @@ fn is_valid_host(host: &str) -> bool {
     }
 }
 
-// Merge local response times into global response times.
+/// A helper function that merges together response times.
+///
+/// Used in `lib.rs` to merge together per-thread response times, and in `stats.rs`
+/// to aggregate all response times.
 pub fn merge_response_times(
     mut global_response_times: BTreeMap<usize, usize>,
     local_response_times: BTreeMap<usize, usize>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,10 +349,10 @@ impl GooseAttack {
     /// ```rust,no_run
     ///     use goose::GooseAttack;
     ///
-    ///     let mut goose_state = GooseAttack::initialize();
+    ///     let mut goose_attack = GooseAttack::initialize();
     /// ```
     pub fn initialize() -> GooseAttack {
-        let goose_state = GooseAttack {
+        let goose_attack = GooseAttack {
             task_sets: Vec::new(),
             task_sets_hash: 0,
             weighted_clients: Vec::new(),
@@ -365,7 +365,7 @@ impl GooseAttack {
             active_clients: 0,
             merged_requests: HashMap::new(),
         };
-        goose_state.setup()
+        goose_attack.setup()
     }
 
     /// Initialize a GooseAttack with an already loaded configuration.
@@ -377,7 +377,7 @@ impl GooseAttack {
     ///     use structopt::StructOpt;
     ///
     ///     let configuration = GooseConfiguration::from_args();
-    ///     let mut goose_state = GooseAttack::initialize_with_config(configuration);
+    ///     let mut goose_attack = GooseAttack::initialize_with_config(configuration);
     /// ```
     pub fn initialize_with_config(config: GooseConfiguration) -> GooseAttack {
         GooseAttack {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -234,27 +234,27 @@ fn print_status_codes(requests: &HashMap<String, GooseRequest>) {
 }
 
 /// Display running and ending statistics
-pub fn print_final_stats(goose_state: &GooseAttack, elapsed: usize) {
-    if !goose_state.configuration.worker {
+pub fn print_final_stats(goose_attack: &GooseAttack, elapsed: usize) {
+    if !goose_attack.configuration.worker {
         info!("printing final statistics after {} seconds...", elapsed);
         // 1) print request and fail statistics.
-        print_requests_and_fails(&goose_state.merged_requests, elapsed);
+        print_requests_and_fails(&goose_attack.merged_requests, elapsed);
         // 2) print respones time statistics, with percentiles
-        print_response_times(&goose_state.merged_requests, true);
+        print_response_times(&goose_attack.merged_requests, true);
         // 3) print status_codes
-        if goose_state.configuration.status_codes {
-            print_status_codes(&goose_state.merged_requests);
+        if goose_attack.configuration.status_codes {
+            print_status_codes(&goose_attack.merged_requests);
         }
     }
 }
 
-pub fn print_running_stats(goose_state: &GooseAttack, elapsed: usize) {
-    if !goose_state.configuration.worker && goose_state.merged_requests.len() > 0 {
+pub fn print_running_stats(goose_attack: &GooseAttack, elapsed: usize) {
+    if !goose_attack.configuration.worker && goose_attack.merged_requests.len() > 0 {
         info!("printing running statistics after {} seconds...", elapsed);
         // 1) print request and fail statistics.
-        print_requests_and_fails(&goose_state.merged_requests, elapsed);
+        print_requests_and_fails(&goose_attack.merged_requests, elapsed);
         // 2) print respones time statistics, without percentiles
-        print_response_times(&goose_state.merged_requests, false);
+        print_response_times(&goose_attack.merged_requests, false);
         println!();
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -15,9 +15,9 @@ fn pipe_closed(_pipe: Pipe, event: PipeEvent) {
     }
 }
 
-pub fn worker_main(state: &GooseAttack) {
+pub fn worker_main(goose_attack: &GooseAttack) {
     // Creates a TCP address. @TODO: add optional support for UDP.
-    let address = format!("{}://{}:{}", "tcp", state.configuration.manager_host, state.configuration.manager_port);
+    let address = format!("{}://{}:{}", "tcp", goose_attack.configuration.manager_host, goose_attack.configuration.manager_port);
     info!("worker connecting to manager at {}", &address);
 
     // Create a request socket.
@@ -63,9 +63,9 @@ pub fn worker_main(state: &GooseAttack) {
     requests.insert("load_test_hash".to_string(), GooseRequest::new(
         "none",
         GooseMethod::GET,
-        state.task_sets_hash,
+        goose_attack.task_sets_hash,
     ));
-    debug!("sending load test hash to manager: {}", state.task_sets_hash);
+    debug!("sending load test hash to manager: {}", goose_attack.task_sets_hash);
     push_stats_to_manager(&manager, &requests, false);
 
     // Only send load_test_hash one time.
@@ -119,7 +119,7 @@ pub fn worker_main(state: &GooseAttack) {
                 initializer.min_wait,
                 initializer.max_wait,
                 &initializer.config,
-                state.task_sets_hash,
+                goose_attack.task_sets_hash,
             ));
             if hatch_rate == None {
                 hatch_rate = Some(1.0 / (initializer.config.hatch_rate as f32 / (initializer.config.expect_workers as f32)));
@@ -168,18 +168,18 @@ pub fn worker_main(state: &GooseAttack) {
     info!("entering gaggle mode, starting load test");
     let sleep_duration = time::Duration::from_secs_f32(hatch_rate.unwrap());
 
-    let mut goose_state = GooseAttack::initialize_with_config(config.clone());
-    goose_state.task_sets = state.task_sets.clone();
+    let mut goose_attack = GooseAttack::initialize_with_config(config.clone());
+    goose_attack.task_sets = goose_attack.task_sets.clone();
     if config.run_time != "" {
-        goose_state.run_time = util::parse_timespan(&config.run_time);
-        info!("run_time = {}", goose_state.run_time);
+        goose_attack.run_time = util::parse_timespan(&config.run_time);
+        info!("run_time = {}", goose_attack.run_time);
     }
     else {
-        goose_state.run_time = 0;
+        goose_attack.run_time = 0;
     }
-    goose_state.weighted_clients = weighted_clients;
-    goose_state.configuration.worker = true;
-    goose_state.launch_clients(started, sleep_duration, Some(manager));
+    goose_attack.weighted_clients = weighted_clients;
+    goose_attack.configuration.worker = true;
+    goose_attack.launch_clients(started, sleep_duration, Some(manager));
 }
 
 pub fn push_stats_to_manager(manager: &Socket, requests: &HashMap<String, GooseRequest>, get_response: bool) -> bool {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -168,18 +168,18 @@ pub fn worker_main(goose_attack: &GooseAttack) {
     info!("entering gaggle mode, starting load test");
     let sleep_duration = time::Duration::from_secs_f32(hatch_rate.unwrap());
 
-    let mut goose_attack = GooseAttack::initialize_with_config(config.clone());
-    goose_attack.task_sets = goose_attack.task_sets.clone();
+    let mut worker_goose_attack = GooseAttack::initialize_with_config(config.clone());
+    worker_goose_attack.task_sets = goose_attack.task_sets.clone();
     if config.run_time != "" {
-        goose_attack.run_time = util::parse_timespan(&config.run_time);
-        info!("run_time = {}", goose_attack.run_time);
+        worker_goose_attack.run_time = util::parse_timespan(&config.run_time);
+        info!("run_time = {}", worker_goose_attack.run_time);
     }
     else {
-        goose_attack.run_time = 0;
+        worker_goose_attack.run_time = 0;
     }
-    goose_attack.weighted_clients = weighted_clients;
-    goose_attack.configuration.worker = true;
-    goose_attack.launch_clients(started, sleep_duration, Some(manager));
+    worker_goose_attack.weighted_clients = weighted_clients;
+    worker_goose_attack.configuration.worker = true;
+    worker_goose_attack.launch_clients(started, sleep_duration, Some(manager));
 }
 
 pub fn push_stats_to_manager(manager: &Socket, requests: &HashMap<String, GooseRequest>, get_response: bool) -> bool {


### PR DESCRIPTION
consistently refer to `GooseAttack` as `goose_attack`, removing old references to `goose_state`.