### PR TITLE
push per-thread statistics to parent immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.2-dev
+ - don't shuffle order of weighted task sets when launching clients
+
 ## 0.7.1 May 26, 2020
  - no longer compile Reqwest blocking client
  - remove need to declare `use std::boxed::Box` in load tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.7.2-dev
  - don't shuffle order of weighted task sets when launching clients
+ - remove GooseClientMode as it serves no useful purpose
+ - push statistics from client threads to parent in real-time
 
 ## 0.7.1 May 26, 2020
  - no longer compile Reqwest blocking client

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.7.1"
+version = "0.7.2-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["loadtesting", "performance", "web", "framework", "tool"]
 license = "Apache-2.0"
 
 [dependencies]
-crossbeam = "0.7"
 ctrlc = "3.1"
 futures = "0.3"
 http = "0.2"
@@ -27,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 simplelog = "0.7"
 structopt = "0.3"
-tokio = { version = "0.2.20", features = ["rt-core", "time"] }
+tokio = { version = "0.2.20", features = ["rt-core", "time", "sync"] }
 url = "2.1"
 
 # optional dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["loadtesting", "performance", "web", "framework", "tool"]
 license = "Apache-2.0"
 
 [dependencies]
+crossbeam = "0.7"
 ctrlc = "3.1"
 futures = "0.3"
 http = "0.2"

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -213,27 +213,27 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         ("form_id", &form_id[1]),
                         ("op", "Save"),
                     ];
-                    let request_builder =
-                        client.goose_post(&comment_path);
+                    let request_builder = client.goose_post(&comment_path);
                     let response = client.goose_send(request_builder.form(&params)).await;
                     match response {
-                        Ok(r) => {
-                            match r.text().await {
-                                Ok(html) => {
-                                    if !html.contains(&comment_body) {
-                                        eprintln!("no comment showed up after posting to {}", &comment_path);
-                                        client.set_failure(&GooseMethod::POST, &comment_path);
-                                    }
-                                }
-                                Err(e) => {
+                        Ok(r) => match r.text().await {
+                            Ok(html) => {
+                                if !html.contains(&comment_body) {
                                     eprintln!(
-                                        "unexpected error when posting to {}: {}",
-                                        &comment_path, e
+                                        "no comment showed up after posting to {}",
+                                        &comment_path
                                     );
                                     client.set_failure(&GooseMethod::POST, &comment_path);
                                 }
                             }
-                        }
+                            Err(e) => {
+                                eprintln!(
+                                    "unexpected error when posting to {}: {}",
+                                    &comment_path, e
+                                );
+                                client.set_failure(&GooseMethod::POST, &comment_path);
+                            }
+                        },
                         // Goose will catch this error.
                         Err(_) => (),
                     }

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -97,12 +97,14 @@ async fn drupal_loadtest_front_page(client: &mut GooseClient) {
             }
             Err(e) => {
                 eprintln!("failed to parse front page: {}", e);
-                client.set_failure();
+                // @TODO
+                //client.set_failure();
             }
         },
         Err(e) => {
             eprintln!("unexpected error when loading front page: {}", e);
-            client.set_failure();
+            // @TODO
+            //client.set_failure();
         }
     }
 }
@@ -131,7 +133,8 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_build_id on page: /user page");
-                            client.set_failure();
+                            // @TODO
+                            //client.set_failure();
                             return;
                         }
                     };
@@ -152,7 +155,8 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                 }
                 Err(e) => {
                     eprintln!("unexpected error when loading /user page: {}", e);
-                    client.set_failure();
+                    // @TODO
+                    //client.set_failure();
                 }
             }
         }
@@ -175,7 +179,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_build_id found on node/{}", &nid);
-                            client.set_failure();
+                            // @TODO
+                            // client.set_failure();
                             return;
                         }
                     };
@@ -185,7 +190,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_token found on node/{}", &nid);
-                            client.set_failure();
+                            // @TODO
+                            //client.set_failure();
                             return;
                         }
                     };
@@ -195,7 +201,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_id found on node/{}", &nid);
-                            client.set_failure();
+                            // @TODO
+                            //client.set_failure();
                             return;
                         }
                     };
@@ -220,7 +227,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                                 Ok(html) => {
                                     if !html.contains(&comment_body) {
                                         eprintln!("no comment showed up after posting to comment/reply/{}", &nid);
-                                        client.set_failure();
+                                        // @TODO
+                                        //client.set_failure();
                                     }
                                 }
                                 Err(e) => {
@@ -228,7 +236,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                                         "unexpected error when posting to comment/reply/{}: {}",
                                         &nid, e
                                     );
-                                    client.set_failure();
+                                    // @TODO
+                                    //client.set_failure();
                                 }
                             }
                         }
@@ -238,7 +247,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                 }
                 Err(e) => {
                     eprintln!("unexpected error when loading node/{} page: {}", &nid, e);
-                    client.set_failure();
+                    // @TODO
+                    //client.set_failure();
                 }
             }
         }

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -97,14 +97,12 @@ async fn drupal_loadtest_front_page(client: &mut GooseClient) {
             }
             Err(e) => {
                 eprintln!("failed to parse front page: {}", e);
-                // @TODO
-                //client.set_failure();
+                client.set_failure(&GooseMethod::GET, "/");
             }
         },
         Err(e) => {
             eprintln!("unexpected error when loading front page: {}", e);
-            // @TODO
-            //client.set_failure();
+            client.set_failure(&GooseMethod::GET, "/");
         }
     }
 }
@@ -133,8 +131,7 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_build_id on page: /user page");
-                            // @TODO
-                            //client.set_failure();
+                            client.set_failure(&GooseMethod::GET, "/user");
                             return;
                         }
                     };
@@ -155,8 +152,7 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                 }
                 Err(e) => {
                     eprintln!("unexpected error when loading /user page: {}", e);
-                    // @TODO
-                    //client.set_failure();
+                    client.set_failure(&GooseMethod::GET, "/user");
                 }
             }
         }
@@ -168,7 +164,9 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
 /// Post a comment.
 async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
     let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
-    let response = client.get(format!("/node/{}", &nid).as_str()).await;
+    let node_path = format!("node/{}", &nid);
+    let comment_path = format!("/comment/reply/{}", &nid);
+    let response = client.get(&node_path).await;
     match response {
         Ok(r) => {
             match r.text().await {
@@ -178,9 +176,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                     let form_build_id = match re.captures(&html) {
                         Some(f) => f,
                         None => {
-                            eprintln!("no form_build_id found on node/{}", &nid);
-                            // @TODO
-                            // client.set_failure();
+                            eprintln!("no form_build_id found on {}", &node_path);
+                            client.set_failure(&GooseMethod::GET, &node_path);
                             return;
                         }
                     };
@@ -189,9 +186,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                     let form_token = match re.captures(&html) {
                         Some(f) => f,
                         None => {
-                            eprintln!("no form_token found on node/{}", &nid);
-                            // @TODO
-                            //client.set_failure();
+                            eprintln!("no form_token found on {}", &node_path);
+                            client.set_failure(&GooseMethod::GET, &node_path);
                             return;
                         }
                     };
@@ -200,9 +196,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                     let form_id = match re.captures(&html) {
                         Some(f) => f,
                         None => {
-                            eprintln!("no form_id found on node/{}", &nid);
-                            // @TODO
-                            //client.set_failure();
+                            eprintln!("no form_id found on {}", &node_path);
+                            client.set_failure(&GooseMethod::GET, &node_path);
                             return;
                         }
                     };
@@ -219,25 +214,23 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         ("op", "Save"),
                     ];
                     let request_builder =
-                        client.goose_post(format!("/comment/reply/{}", &nid).as_str());
+                        client.goose_post(&comment_path);
                     let response = client.goose_send(request_builder.form(&params)).await;
                     match response {
                         Ok(r) => {
                             match r.text().await {
                                 Ok(html) => {
                                     if !html.contains(&comment_body) {
-                                        eprintln!("no comment showed up after posting to comment/reply/{}", &nid);
-                                        // @TODO
-                                        //client.set_failure();
+                                        eprintln!("no comment showed up after posting to {}", &comment_path);
+                                        client.set_failure(&GooseMethod::POST, &comment_path);
                                     }
                                 }
                                 Err(e) => {
                                     eprintln!(
-                                        "unexpected error when posting to comment/reply/{}: {}",
-                                        &nid, e
+                                        "unexpected error when posting to {}: {}",
+                                        &comment_path, e
                                     );
-                                    // @TODO
-                                    //client.set_failure();
+                                    client.set_failure(&GooseMethod::POST, &comment_path);
                                 }
                             }
                         }
@@ -246,9 +239,8 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                     }
                 }
                 Err(e) => {
-                    eprintln!("unexpected error when loading node/{} page: {}", &nid, e);
-                    // @TODO
-                    //client.set_failure();
+                    eprintln!("unexpected error when loading {} page: {}", &node_path, e);
+                    client.set_failure(&GooseMethod::GET, &node_path);
                 }
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,8 @@
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use rand::Rng;
-use std::{sync::mpsc, time};
+use std::time;
+use tokio::sync::mpsc;
 
 use crate::get_worker_id;
 use crate::goose::{GooseClient, GooseClientCommand, GooseTaskSet};
@@ -10,7 +11,7 @@ pub async fn client_main(
     thread_number: usize,
     thread_task_set: GooseTaskSet,
     mut thread_client: GooseClient,
-    thread_receiver: mpsc::Receiver<GooseClientCommand>,
+    mut thread_receiver: mpsc::UnboundedReceiver<GooseClientCommand>,
     worker: bool,
 ) {
     if worker {

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -260,7 +260,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 use std::{future::Future, pin::Pin, time::Instant};
-use std::sync::mpsc;
+use crossbeam::crossbeam_channel;
 use url::Url;
 
 use crate::GooseConfiguration;
@@ -662,7 +662,7 @@ pub struct GooseClient {
     /// A [`reqwest.client`](https://docs.rs/reqwest/*/reqwest/struct.Client.html) instance
     pub client: Client,
     /// Channel
-    pub parent: Option<mpsc::Sender<GooseRawRequest>>,
+    pub parent: Option<crossbeam_channel::Sender<GooseRawRequest>>,
     /// Optional global host, can be overridden per-task-set or via the cli.
     pub default_host: Option<String>,
     /// Optional per-task-set .host.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -425,19 +425,6 @@ impl GooseTaskSet {
     }
 }
 
-/// Tracks the current run-mode of a client.
-#[derive(Debug, Clone, PartialEq)]
-pub enum GooseClientMode {
-    /// Clients are briefly in the INIT mode when first allocated.
-    INIT,
-    /// Clients are briefly in the HATCHING mode when setting things up.
-    HATCHING,
-    /// Clients spend most of their time in the RUNNING mode, executing tasks.
-    RUNNING,
-    /// Clients are briefly in the EXITING mode when stopping.
-    EXITING,
-}
-
 /// Commands sent between the parent and client threads, and between manager and
 /// worker processes.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -659,8 +646,6 @@ pub struct GooseClient {
     pub config: GooseConfiguration,
     /// An index into the internal `GooseTest.weighted_clients, indicating which weighted GooseTaskSet is running.
     pub weighted_clients_index: usize,
-    /// The current run mode of this client, see `enum GooseClientMode`.
-    pub mode: GooseClientMode,
     /// A weighted list of all tasks that run when the client first starts.
     pub weighted_on_start_tasks: Vec<Vec<usize>>,
     /// A weighted list of all tasks that this client runs once started.
@@ -715,7 +700,6 @@ impl GooseClient {
             max_wait,
             // A value of max_value() indicates this client isn't fully initialized yet.
             weighted_clients_index: usize::max_value(),
-            mode: GooseClientMode::INIT,
             weighted_on_start_tasks: Vec::new(),
             weighted_tasks: Vec::new(),
             weighted_bucket: 0,
@@ -1900,7 +1884,6 @@ mod tests {
         assert_eq!(client.min_wait, 0);
         assert_eq!(client.max_wait, 0);
         assert_eq!(client.weighted_clients_index, usize::max_value());
-        assert_eq!(client.mode, GooseClientMode::INIT);
         assert_eq!(client.weighted_on_start_tasks.len(), 0);
         assert_eq!(client.weighted_tasks.len(), 0);
         assert_eq!(client.weighted_bucket, 0);
@@ -1918,7 +1901,6 @@ mod tests {
         assert_eq!(client.min_wait, 0);
         assert_eq!(client.max_wait, 0);
         assert_eq!(client.weighted_clients_index, usize::max_value());
-        assert_eq!(client.mode, GooseClientMode::INIT);
         assert_eq!(client.weighted_on_start_tasks.len(), 0);
         assert_eq!(client.weighted_tasks.len(), 0);
         assert_eq!(client.weighted_bucket, 0);

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -457,7 +457,7 @@ fn goose_method_from_method(method: Method) -> GooseMethod {
         Method::POST => GooseMethod::POST,
         Method::PUT => GooseMethod::PUT,
         _ => {
-            error!("unsupported metehod: {}", method);
+            error!("unsupported method: {}", method);
             std::process::exit(1);
         }
     }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -514,11 +514,6 @@ impl GooseRawRequest {
     }
 
     /*
-     * @TODO:
-    fn set_success(&mut self, success: bool) {
-        self.success = success;
-    }
-
     fn set_load_test_hash(&mut self, load_test_hash: u64) {
         self.load_test_hash = load_test_hash;
     }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -252,7 +252,6 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
-use crossbeam::crossbeam_channel;
 use http::method::Method;
 use http::StatusCode;
 use reqwest::Error;
@@ -261,6 +260,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 use std::{future::Future, pin::Pin, time::Instant};
+use tokio::sync::mpsc;
 use url::Url;
 
 use crate::GooseConfiguration;
@@ -633,7 +633,7 @@ pub struct GooseClient {
     /// A [`reqwest.client`](https://docs.rs/reqwest/*/reqwest/struct.Client.html) instance
     pub client: Client,
     /// Channel
-    pub parent: Option<crossbeam_channel::Sender<GooseRawRequest>>,
+    pub parent: Option<mpsc::UnboundedSender<GooseRawRequest>>,
     /// Optional global host, can be overridden per-task-set or via the cli.
     pub default_host: Option<String>,
     /// Optional per-task-set .host.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -477,8 +477,6 @@ fn goose_method_from_method(method: Method) -> GooseMethod {
 }
 
 pub struct GooseRawRequest {
-    /// The path being requested.
-    pub path: String,
     /// The method being used (ie, GET, POST, etc).
     pub method: GooseMethod,
     /// The optional name of the request.
@@ -495,9 +493,8 @@ pub struct GooseRawRequest {
     pub load_test_hash: u64,
 }
 impl GooseRawRequest {
-    pub fn new(path: String, method: GooseMethod, name: String) -> Self {
+    pub fn new(method: GooseMethod, name: String) -> Self {
         GooseRawRequest {
-            path,
             method,
             name,
             response_time: 0,
@@ -1124,7 +1121,7 @@ impl GooseClient {
                     None => path.to_string(),
                 },
             };
-            let mut raw_request = GooseRawRequest::new(path.clone(), method, request_name.clone());
+            let mut raw_request = GooseRawRequest::new(method, request_name.clone());
             raw_request.set_response_time(elapsed.as_millis());
             match &response {
                 Ok(r) => {

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -252,6 +252,7 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
+use crossbeam::crossbeam_channel;
 use http::method::Method;
 use http::StatusCode;
 use reqwest::Error;
@@ -260,7 +261,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 use std::{future::Future, pin::Pin, time::Instant};
-use crossbeam::crossbeam_channel;
 use url::Url;
 
 use crate::GooseConfiguration;
@@ -470,8 +470,8 @@ fn goose_method_from_method(method: Method) -> GooseMethod {
         Method::POST => GooseMethod::POST,
         Method::PUT => GooseMethod::PUT,
         _ => {
-                error!("unsupported metehod: {}", method);
-                std::process::exit(1);
+            error!("unsupported metehod: {}", method);
+            std::process::exit(1);
         }
     }
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -489,8 +489,6 @@ pub struct GooseRawRequest {
     pub success: bool,
     /// Whether or not we're updating a previous request.
     pub update: bool,
-    /// Load test hash.
-    pub load_test_hash: u64,
 }
 impl GooseRawRequest {
     pub fn new(method: GooseMethod, name: String) -> Self {
@@ -501,7 +499,6 @@ impl GooseRawRequest {
             status_code: None,
             success: true,
             update: false,
-            load_test_hash: 0,
         }
     }
 
@@ -512,12 +509,6 @@ impl GooseRawRequest {
     fn set_status_code(&mut self, status_code: Option<StatusCode>) {
         self.status_code = status_code;
     }
-
-    /*
-    fn set_load_test_hash(&mut self, load_test_hash: u64) {
-        self.load_test_hash = load_test_hash;
-    }
-    */
 }
 
 /// Statistics collected about a path-method pair, (for example `/index`-`GET`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,8 +315,6 @@ use crossbeam::crossbeam_channel::unbounded;
 use lazy_static::lazy_static;
 #[cfg(feature = "gaggle")]
 use nng::Socket;
-use rand::seq::SliceRandom;
-use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use simplelog::*;
 use structopt::StructOpt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1412,41 +1412,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn max_response_time() {
-        let mut max_response_time = 99;
-        // Update max response time to a higher value.
-        max_response_time = update_max_response_time(max_response_time, 101);
-        assert_eq!(max_response_time, 101);
-        // Max response time doesn't update when updating with a lower value.
-        max_response_time = update_max_response_time(max_response_time, 1);
-        assert_eq!(max_response_time, 101);
-    }
-
-    #[test]
-    fn min_response_time() {
-        let mut min_response_time = 11;
-        // Update min response time to a lower value.
-        min_response_time = update_min_response_time(min_response_time, 9);
-        assert_eq!(min_response_time, 9);
-        // Min response time doesn't update when updating with a lower value.
-        min_response_time = update_min_response_time(min_response_time, 22);
-        assert_eq!(min_response_time, 9);
-        // Min response time doesn't update when updating with a 0 value.
-        min_response_time = update_min_response_time(min_response_time, 0);
-        assert_eq!(min_response_time, 9);
-    }
-
-    #[test]
-    fn response_time_merge() {
-        let mut global_response_times: BTreeMap<usize, usize> = BTreeMap::new();
-        let local_response_times: BTreeMap<usize, usize> = BTreeMap::new();
-        global_response_times =
-            merge_response_times(global_response_times, local_response_times.clone());
-        // @TODO: how can we do useful testing of private method and objects?
-        assert_eq!(&global_response_times, &local_response_times);
-    }
-
-    #[test]
     fn valid_host() {
         // We can only test valid domains, as we exit on failure.
         // @TODO: rework so we don't exit on failure

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -991,10 +991,10 @@ impl GooseAttack {
                 while message.is_ok() {
                     received_message = true;
                     let raw_request = message.unwrap();
-                    let key = format!("{:?} {}", raw_request.method, raw_request.path);
+                    let key = format!("{:?} {}", raw_request.method, raw_request.name);
                     let mut merge_request = match self.merged_requests.get(&key) {
                         Some(m) => m.clone(),
-                        None => GooseRequest::new(&raw_request.path, raw_request.method, raw_request.load_test_hash),
+                        None => GooseRequest::new(&raw_request.name, raw_request.method, raw_request.load_test_hash),
                     };
                     merge_request.set_response_time(raw_request.response_time);
                     merge_request.set_status_code(raw_request.status_code);
@@ -1067,10 +1067,10 @@ impl GooseAttack {
                     let mut message = parent_receiver.try_recv();
                     while message.is_ok() {
                         let raw_request = message.unwrap();
-                        let key = format!("{:?} {}", raw_request.method, raw_request.path);
+                        let key = format!("{:?} {}", raw_request.method, raw_request.name);
                         let mut merge_request = match self.merged_requests.get(&key) {
                             Some(m) => m.clone(),
-                            None => GooseRequest::new(&raw_request.path, raw_request.method, raw_request.load_test_hash),
+                            None => GooseRequest::new(&raw_request.name, raw_request.method, raw_request.load_test_hash),
                         };
                         merge_request.set_response_time(raw_request.response_time);
                         merge_request.set_status_code(raw_request.status_code);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1407,43 +1407,6 @@ fn is_valid_host(host: &str) -> bool {
         }
     }
 }
-
-/// A helper function that merges together response times.
-///
-/// Used in `lib.rs` to merge together per-thread response times, and in `stats.rs`
-/// to aggregate all response times.
-pub fn merge_response_times(
-    mut global_response_times: BTreeMap<usize, usize>,
-    local_response_times: BTreeMap<usize, usize>,
-) -> BTreeMap<usize, usize> {
-    // Iterate over client response times, and merge into global response times.
-    for (response_time, count) in &local_response_times {
-        let counter = match global_response_times.get(&response_time) {
-            // We've seen this response_time before, increment counter.
-            Some(c) => *c + count,
-            // First time we've seen this response time, initialize counter.
-            None => *count,
-        };
-        global_response_times.insert(*response_time, counter);
-    }
-    global_response_times
-}
-
-// Update global minimum response time based on local resposne time.
-fn update_min_response_time(mut global_min: usize, min: usize) -> usize {
-    if global_min == 0 || (min > 0 && min < global_min) {
-        global_min = min;
-    }
-    global_min
-}
-
-// Update global maximum response time based on local resposne time.
-fn update_max_response_time(mut global_max: usize, max: usize) -> usize {
-    if global_max < max {
-        global_max = max;
-    }
-    global_max
-}
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -992,11 +992,7 @@ impl GooseAttack {
                     let key = format!("{:?} {}", raw_request.method, raw_request.name);
                     let mut merge_request = match self.merged_requests.get(&key) {
                         Some(m) => m.clone(),
-                        None => GooseRequest::new(
-                            &raw_request.name,
-                            raw_request.method,
-                            raw_request.load_test_hash,
-                        ),
+                        None => GooseRequest::new(&raw_request.name, raw_request.method, 0),
                     };
                     merge_request.set_response_time(raw_request.response_time);
                     merge_request.set_status_code(raw_request.status_code);
@@ -1072,11 +1068,7 @@ impl GooseAttack {
                         let key = format!("{:?} {}", raw_request.method, raw_request.name);
                         let mut merge_request = match self.merged_requests.get(&key) {
                             Some(m) => m.clone(),
-                            None => GooseRequest::new(
-                                &raw_request.name,
-                                raw_request.method,
-                                raw_request.load_test_hash,
-                            ),
+                            None => GooseRequest::new(&raw_request.name, raw_request.method, 0),
                         };
                         merge_request.set_response_time(raw_request.response_time);
                         merge_request.set_status_code(raw_request.status_code);

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::{thread, time};
@@ -67,6 +67,96 @@ fn pipe_closed(_pipe: Pipe, event: PipeEvent) {
         }
         _ => {}
     }
+}
+
+/// A helper function that merges together response times.
+///
+/// Used in `lib.rs` to merge together per-thread response times, and in `stats.rs`
+/// to aggregate all response times.
+pub fn merge_response_times(
+    mut global_response_times: BTreeMap<usize, usize>,
+    local_response_times: BTreeMap<usize, usize>,
+) -> BTreeMap<usize, usize> {
+    // Iterate over client response times, and merge into global response times.
+    for (response_time, count) in &local_response_times {
+        let counter = match global_response_times.get(&response_time) {
+            // We've seen this response_time before, increment counter.
+            Some(c) => *c + count,
+            // First time we've seen this response time, initialize counter.
+            None => *count,
+        };
+        global_response_times.insert(*response_time, counter);
+    }
+    global_response_times
+}
+
+// Update global minimum response time based on local resposne time.
+pub fn update_min_response_time(mut global_min: usize, min: usize) -> usize {
+    if global_min == 0 || (min > 0 && min < global_min) {
+        global_min = min;
+    }
+    global_min
+}
+
+// Update global maximum response time based on local resposne time.
+pub fn update_max_response_time(mut global_max: usize, max: usize) -> usize {
+    if global_max < max {
+        global_max = max;
+    }
+    global_max
+}
+
+/// Merge per-client-statistics from client thread into global parent statistics
+fn merge_from_worker(
+    parent_request: &GooseRequest,
+    client_request: &GooseRequest,
+    config: &GooseConfiguration,
+) -> GooseRequest {
+    // Make a mutable copy where we can merge things
+    let mut merged_request = parent_request.clone();
+    // Iterate over client response times, and merge into global response time
+    merged_request.response_times = merge_response_times(
+        merged_request.response_times,
+        client_request.response_times.clone(),
+    );
+    // Increment total response time counter.
+    merged_request.total_response_time += &client_request.total_response_time;
+    // Increment count of how many resposne counters we've seen.
+    merged_request.response_time_counter += &client_request.response_time_counter;
+    // If client had new fastest response time, update global fastest response time.
+    merged_request.min_response_time = update_min_response_time(
+        merged_request.min_response_time,
+        client_request.min_response_time,
+    );
+    // If client had new slowest response time, update global slowest resposne time.
+    merged_request.max_response_time = update_max_response_time(
+        merged_request.max_response_time,
+        client_request.max_response_time,
+    );
+    // Increment total success counter.
+    merged_request.success_count += &client_request.success_count;
+    // Increment total fail counter.
+    merged_request.fail_count += &client_request.fail_count;
+    // Only accrue overhead of merging status_code_counts if we're going to display the results
+    if config.status_codes {
+        for (status_code, count) in &client_request.status_code_counts {
+            let new_count;
+            // Add client count into global count
+            if let Some(existing_status_code_count) =
+                merged_request.status_code_counts.get(&status_code)
+            {
+                new_count = *existing_status_code_count + *count;
+            }
+            // No global count exists yet, so start with client count
+            else {
+                new_count = *count;
+            }
+            merged_request
+                .status_code_counts
+                .insert(*status_code, new_count);
+        }
+    }
+    merged_request
 }
 
 pub fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
@@ -212,7 +302,7 @@ pub fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                                 if let Some(parent_request) =
                                     goose_attack.merged_requests.get(&request_key)
                                 {
-                                    merged_request = crate::merge_from_client(
+                                    merged_request = merge_from_worker(
                                         parent_request,
                                         &request,
                                         &goose_attack.configuration,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,2 +1,2 @@
-pub use crate::goose::{GooseClient, GooseTask, GooseTaskSet};
+pub use crate::goose::{GooseClient, GooseMethod, GooseTask, GooseTaskSet};
 pub use crate::{task, taskset, GooseAttack};

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -464,7 +464,6 @@ mod test {
         assert_eq!(&global_response_times, &local_response_times);
     }
 
-
     #[test]
     fn max_response_time_percentile() {
         let mut response_times: BTreeMap<usize, usize> = BTreeMap::new();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -3,9 +3,10 @@ use std::collections::{BTreeMap, HashMap};
 use std::f32;
 
 use crate::goose::GooseRequest;
-use crate::{
-    merge_response_times, update_max_response_time, update_min_response_time, util, GooseAttack,
+use crate::manager::{
+    merge_response_times, update_max_response_time, update_min_response_time,
 };
+use crate::{util, GooseAttack};
 
 /// Get the response time that a certain number of percent of the requests finished within.
 fn calculate_response_time_percentile(


### PR DESCRIPTION
In the current implementation, each Goose client thread processes requests and maintains statistics, which are pushed up to the client every 15 seconds. 

The intent of this PR is to instead push the raw requests/response details to the parent immediately, offloading the overhead of calculating statistics so clients can run as quickly as possible. This will primarily benefit a Goose Attack if the load test server isn't already using 100% of the CPU.

### Performance:
**Crossbeam**
- With a non-starved CPU we're seeing a ~2% performance improvement
- With a starved CPU we're seeing a ~2-3% performance improvement

**Tokio mpsc**
- With a non-starved CPU we're seeing a ~2.1% performance improvement
- With a starved CPU we're seeing a ~1-2% performance improvement

The raw numbers:

- https://docs.google.com/spreadsheets/d/18qW_ZTWeY5apSSIeGhT298DzVA0IIs2kHxq9wAbkgGE/edit#gid=0

I'm leaning toward using Tokio mpsc as Tokio is already a dependency, and it's definitely preferred you don't starve the load test server for the most reliable numbers.