### PR TITLE
don't shuffle weighted task sets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,8 +612,6 @@ impl GooseAttack {
             let mut weighted_sets = vec![index; weight];
             weighted_task_sets.append(&mut weighted_sets);
         }
-        // Shuffle the weighted list of task sets
-        weighted_task_sets.shuffle(&mut thread_rng());
 
         // Allocate a state for each client that will be spawned.
         info!("initializing client states...");


### PR DESCRIPTION
Currently goose shuffles task sets after it weights them. 

For example, if a test plan defines Task Set A with a weight of 3, and Task Set B with a weight of 1, when the test runs it builds a weighted list: "AAAB", it then shuffles this list for example, "AABA". Now, say we spin up 6 clients it'll launch "AAABAA". 

Now, if it runs again, the shuffle may order the weighted list "ABAA" and when we spin up 6 clients it'll instead launch "ABAAAB".  Thus when we run the same load test two times in a row we end up generating different load (5 A's and 1 B the first time, 4 A's and 2 B's the second time).

This PR removes the shuffle of weighted task sets, so two tests with the same # of clients will always launch the same clients. Clients are launched in the order they're defined. (So after this commit we'd consistently launch "AAABAA".)