### PR TITLE
reimplement set_success and set_failure, fix #40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - don't shuffle order of weighted task sets when launching clients
  - remove GooseClientMode as it serves no useful purpose
  - push statistics from client threads to parent in real-time
+ - simplify `set_failure` and `set_success` to pass in request
 
 ## 0.7.1 May 26, 2020
  - no longer compile Reqwest blocking client

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -82,7 +82,7 @@ fn main() {
 
 /// View the front page.
 async fn drupal_loadtest_front_page(client: &mut GooseClient) {
-    let response = client.get("/").await;
+    let mut response = client.get("/").await;
 
     // Grab some static assets from the front page.
     match response.response {
@@ -97,12 +97,12 @@ async fn drupal_loadtest_front_page(client: &mut GooseClient) {
             }
             Err(e) => {
                 eprintln!("failed to parse front page: {}", e);
-                client.set_failure(&response.request);
+                client.set_failure(&mut response.request);
             }
         },
         Err(e) => {
             eprintln!("unexpected error when loading front page: {}", e);
-            client.set_failure(&response.request);
+            client.set_failure(&mut response.request);
         }
     }
 }
@@ -121,7 +121,7 @@ async fn drupal_loadtest_profile_page(client: &mut GooseClient) {
 
 /// Log in.
 async fn drupal_loadtest_login(client: &mut GooseClient) {
-    let response = client.get("/user").await;
+    let mut response = client.get("/user").await;
     match response.response {
         Ok(r) => {
             match r.text().await {
@@ -131,7 +131,7 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_build_id on page: /user page");
-                            client.set_failure(&response.request);
+                            client.set_failure(&mut response.request);
                             return;
                         }
                     };
@@ -152,7 +152,7 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                 }
                 Err(e) => {
                     eprintln!("unexpected error when loading /user page: {}", e);
-                    client.set_failure(&response.request);
+                    client.set_failure(&mut response.request);
                 }
             }
         }
@@ -166,7 +166,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
     let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);
-    let response = client.get(&node_path).await;
+    let mut response = client.get(&node_path).await;
     match response.response {
         Ok(r) => {
             match r.text().await {
@@ -177,7 +177,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_build_id found on {}", &node_path);
-                            client.set_failure(&response.request);
+                            client.set_failure(&mut response.request);
                             return;
                         }
                     };
@@ -187,7 +187,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_token found on {}", &node_path);
-                            client.set_failure(&response.request);
+                            client.set_failure(&mut response.request);
                             return;
                         }
                     };
@@ -197,7 +197,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_id found on {}", &node_path);
-                            client.set_failure(&response.request);
+                            client.set_failure(&mut response.request);
                             return;
                         }
                     };
@@ -214,7 +214,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         ("op", "Save"),
                     ];
                     let request_builder = client.goose_post(&comment_path);
-                    let response = client.goose_send(request_builder.form(&params)).await;
+                    let mut response = client.goose_send(request_builder.form(&params)).await;
                     match response.response {
                         Ok(r) => match r.text().await {
                             Ok(html) => {
@@ -223,7 +223,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                                         "no comment showed up after posting to {}",
                                         &comment_path
                                     );
-                                    client.set_failure(&response.request);
+                                    client.set_failure(&mut response.request);
                                 }
                             }
                             Err(e) => {
@@ -231,7 +231,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                                     "unexpected error when posting to {}: {}",
                                     &comment_path, e
                                 );
-                                client.set_failure(&response.request);
+                                client.set_failure(&mut response.request);
                             }
                         },
                         // Goose will catch this error.
@@ -240,7 +240,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                 }
                 Err(e) => {
                     eprintln!("unexpected error when loading {} page: {}", &node_path, e);
-                    client.set_failure(&response.request);
+                    client.set_failure(&mut response.request);
                 }
             }
         }

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -137,7 +137,7 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                     };
 
                     // Log the user in.
-                    let uid: usize = rand::thread_rng().gen_range(3, 5_002);
+                    let uid = rand::thread_rng().gen_range(3, 5_002);
                     let username = format!("user{}", uid);
                     let params = [
                         ("name", username.as_str()),

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -97,12 +97,12 @@ async fn drupal_loadtest_front_page(client: &mut GooseClient) {
             }
             Err(e) => {
                 eprintln!("failed to parse front page: {}", e);
-                client.set_failure(&response);
+                client.set_failure(&response.request);
             }
         },
         Err(e) => {
             eprintln!("unexpected error when loading front page: {}", e);
-            client.set_failure(&response);
+            client.set_failure(&response.request);
         }
     }
 }
@@ -131,7 +131,7 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_build_id on page: /user page");
-                            client.set_failure(&response);
+                            client.set_failure(&response.request);
                             return;
                         }
                     };
@@ -152,7 +152,7 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                 }
                 Err(e) => {
                     eprintln!("unexpected error when loading /user page: {}", e);
-                    client.set_failure(&response);
+                    client.set_failure(&response.request);
                 }
             }
         }
@@ -177,7 +177,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_build_id found on {}", &node_path);
-                            client.set_failure(&response);
+                            client.set_failure(&response.request);
                             return;
                         }
                     };
@@ -187,7 +187,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_token found on {}", &node_path);
-                            client.set_failure(&response);
+                            client.set_failure(&response.request);
                             return;
                         }
                     };
@@ -197,7 +197,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         Some(f) => f,
                         None => {
                             eprintln!("no form_id found on {}", &node_path);
-                            client.set_failure(&response);
+                            client.set_failure(&response.request);
                             return;
                         }
                     };
@@ -223,7 +223,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                                         "no comment showed up after posting to {}",
                                         &comment_path
                                     );
-                                    client.set_failure(&response);
+                                    client.set_failure(&response.request);
                                 }
                             }
                             Err(e) => {
@@ -231,7 +231,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                                     "unexpected error when posting to {}: {}",
                                     &comment_path, e
                                 );
-                                client.set_failure(&response);
+                                client.set_failure(&response.request);
                             }
                         },
                         // Goose will catch this error.
@@ -240,7 +240,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                 }
                 Err(e) => {
                     eprintln!("unexpected error when loading {} page: {}", &node_path, e);
-                    client.set_failure(&response);
+                    client.set_failure(&response.request);
                 }
             }
         }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1194,10 +1194,10 @@ impl GooseClient {
 
     /// Manually mark a request as a success.
     ///
-    /// By default, Goose will consider any response with a 2xx status code as a success. It may be
-    /// valid in your test for a non-2xx HTTP status code to be returned. A copy of your original
-    /// request is returned with the response, and must be included when setting a request as a
-    /// success.
+    /// By default, Goose will consider any response with a 2xx status code as a success.
+    /// It may be valid in your test for a non-2xx HTTP status code to be returned. A copy
+    /// of your original request is returned with the response, and a mutable copy must be
+    /// included when setting a request as a success.
     ///
     /// # Example
     /// ```rust
@@ -1207,33 +1207,33 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a GET request.
     ///     async fn get_function(client: &mut GooseClient) {
-    ///         let response = client.get("/404").await;
+    ///         let mut response = client.get("/404").await;
     ///         match &response.response {
     ///             Ok(r) => {
     ///                 // We expect a 404 here.
     ///                 if r.status() == 404 {
-    ///                     client.set_success(&response.request);
+    ///                     client.set_success(&mut response.request);
     ///                 }
     ///             },
     ///             Err(_) => (),
     ///         }
     ///     }
     /// ````
-    pub fn set_success(&mut self, request: &GooseRawRequest) {
+    pub fn set_success(&mut self, request: &mut GooseRawRequest) {
         // Only send update if this was previously not a success.
         if !request.success {
-            let mut update_request = request.clone();
-            update_request.success = true;
-            update_request.update = true;
-            self.send_to_parent(&update_request);
+            request.success = true;
+            request.update = true;
+            self.send_to_parent(&request);
         }
     }
 
     /// Manually mark a request as a failure.
     ///
-    /// By default, Goose will consider any response with a 2xx status code as a success. You may require
-    /// more advanced logic, in which a 2xx status code is actually a failure. A copy of your original
-    /// request is returned with the response, and must be included when setting a request as a failure.
+    /// By default, Goose will consider any response with a 2xx status code as a success.
+    /// You may require more advanced logic, in which a 2xx status code is actually a
+    /// failure. A copy of your original request is returned with the response, and a
+    /// mutable copy must be included when setting a request as a failure.
     ///
     /// # Example
     /// ```rust
@@ -1242,7 +1242,7 @@ impl GooseClient {
     ///     let mut task = task!(loadtest_index_page);
     ///
     ///     async fn loadtest_index_page(client: &mut GooseClient) {
-    ///         let response = client.set_request_name("index").get("/").await;
+    ///         let mut response = client.set_request_name("index").get("/").await;
     ///         // Extract the response Result.
     ///         match response.response {
     ///             Ok(r) => {
@@ -1254,11 +1254,11 @@ impl GooseClient {
     ///                             // was a failure.
     ///                             if !text.contains("this string must exist") {
     ///                                 // As this is a named request, pass in the name not the URL
-    ///                                 client.set_failure(&response.request);
+    ///                                 client.set_failure(&mut response.request);
     ///                             }
     ///                         }
     ///                         // Empty page, this is a failure.
-    ///                         Err(_) => client.set_failure(&response.request),
+    ///                         Err(_) => client.set_failure(&mut response.request),
     ///                     }
     ///                 }
     ///             },
@@ -1267,13 +1267,12 @@ impl GooseClient {
     ///         }
     ///     }
     /// ````
-    pub fn set_failure(&mut self, request: &GooseRawRequest) {
+    pub fn set_failure(&mut self, request: &mut GooseRawRequest) {
         // Only send update if this was previously a success.
         if request.success {
-            let mut update_request = request.clone();
-            update_request.success = false;
-            update_request.update = true;
-            self.send_to_parent(&update_request);
+            request.success = false;
+            request.update = true;
+            self.send_to_parent(&request);
         }
     }
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -463,6 +463,12 @@ fn goose_method_from_method(method: Method) -> GooseMethod {
     }
 }
 
+/// The request that Goose is making. Client threads send this data to the parent thread
+/// when statistics are enabled. This request object must be provided to calls to
+/// [`set_success`](https://docs.rs/goose/*/goose/goose/struct.GooseClient.html#method.set_success)
+/// or
+/// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseClient.html#method.set_failure)
+/// so Goose knows which request is being updated.
 #[derive(Debug, Clone)]
 pub struct GooseRawRequest {
     /// The method being used (ie, GET, POST, etc).
@@ -471,11 +477,11 @@ pub struct GooseRawRequest {
     pub name: String,
     /// How many milliseconds the request took.
     pub response_time: u128,
-    /// The HTTP response code.
+    /// The HTTP response code (optional).
     pub status_code: Option<StatusCode>,
-    /// Whether or not request was successful.
+    /// Whether or not the request was successful.
     pub success: bool,
-    /// Whether or not we're updating a previous request.
+    /// Whether or not we're updating a previous request, modifies how the parent thread records it.
     pub update: bool,
 }
 impl GooseRawRequest {
@@ -817,6 +823,11 @@ impl GooseClient {
     /// object, you can instead call `goose_get` which returns a RequestBuilder, then
     /// call `goose_send` to invoke the request.)
     ///
+    /// Calls to `client.get` return a `GooseResponse` object which contains a copy of
+    /// the request you made
+    /// ([`response.request`](goose/*/goose/struct.GooseRawRequest)), and the response
+    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    ///
     /// # Example
     /// ```rust
     ///     use goose::prelude::*;
@@ -840,6 +851,11 @@ impl GooseClient {
     /// [`reqwest::RequestBuilder`](reqwest/*/reqwest/struct.RequestBuilder.html)
     /// object, you can instead call `goose_post` which returns a RequestBuilder, then
     /// call `goose_send` to invoke the request.)
+    ///
+    /// Calls to `client.post` return a `GooseResponse` object which contains a copy of
+    /// the request you made
+    /// ([`response.request`](goose/*/goose/struct.GooseRawRequest)), and the response
+    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -865,6 +881,11 @@ impl GooseClient {
     /// object, you can instead call `goose_head` which returns a RequestBuilder, then
     /// call `goose_send` to invoke the request.)
     ///
+    /// Calls to `client.head` return a `GooseResponse` object which contains a copy of
+    /// the request you made
+    /// ([`response.request`](goose/*/goose/struct.GooseRawRequest)), and the response
+    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    ///
     /// # Example
     /// ```rust
     ///     use goose::prelude::*;
@@ -888,6 +909,11 @@ impl GooseClient {
     /// [`reqwest::RequestBuilder`](reqwest/*/reqwest/struct.RequestBuilder.html)
     /// object, you can instead call `goose_delete` which returns a RequestBuilder,
     /// then call `goose_send` to invoke the request.)
+    ///
+    /// Calls to `client.delete` return a `GooseResponse` object which contains a copy of
+    /// the request you made
+    /// ([`response.request`](goose/*/goose/struct.GooseRawRequest)), and the response
+    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -1058,6 +1084,11 @@ impl GooseClient {
     /// Reqwest without using this helper function, but then Goose is unable to capture
     /// statistics.
     ///
+    /// Calls to `client.goose_send` return a `GooseResponse` object which contains a
+    /// copy of the request you made
+    /// ([`response.request`](goose/*/goose/struct.GooseRawRequest)), and the response
+    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    ///
     /// # Example
     /// ```rust
     ///     use goose::prelude::*;
@@ -1164,7 +1195,9 @@ impl GooseClient {
     /// Manually mark a request as a success.
     ///
     /// By default, Goose will consider any response with a 2xx status code as a success. It may be
-    /// valid in your test for a non-2xx HTTP status code to be returned.
+    /// valid in your test for a non-2xx HTTP status code to be returned. A copy of your original
+    /// request is returned with the response, and must be included when setting a request as a
+    /// success.
     ///
     /// # Example
     /// ```rust
@@ -1199,7 +1232,8 @@ impl GooseClient {
     /// Manually mark a request as a failure.
     ///
     /// By default, Goose will consider any response with a 2xx status code as a success. You may require
-    /// more advanced logic, in which a 2xx status code is actually a failure.
+    /// more advanced logic, in which a 2xx status code is actually a failure. A copy of your original
+    /// request is returned with the response, and must be included when setting a request as a failure.
     ///
     /// # Example
     /// ```rust

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -634,10 +634,7 @@ pub struct GooseResponse {
 }
 impl GooseResponse {
     pub fn new(request: GooseRawRequest, response: Result<Response, Error>) -> Self {
-        GooseResponse {
-            request,
-            response,
-        }
+        GooseResponse { request, response }
     }
 }
 
@@ -1182,17 +1179,17 @@ impl GooseClient {
     ///             Ok(r) => {
     ///                 // We expect a 404 here.
     ///                 if r.status() == 404 {
-    ///                     client.set_success(response);
+    ///                     client.set_success(&response.request);
     ///                 }
     ///             },
     ///             Err(_) => (),
     ///         }
     ///     }
     /// ````
-    pub fn set_success(&mut self, response: &GooseResponse) {
+    pub fn set_success(&mut self, request: &GooseRawRequest) {
         // Only send update if this was previously not a success.
-        if !response.request.success {
-            let mut update_request = response.request.clone();
+        if !request.success {
+            let mut update_request = request.clone();
             update_request.success = true;
             update_request.update = true;
             self.send_to_parent(&update_request);
@@ -1223,11 +1220,11 @@ impl GooseClient {
     ///                             // was a failure.
     ///                             if !text.contains("this string must exist") {
     ///                                 // As this is a named request, pass in the name not the URL
-    ///                                 client.set_failure(response);
+    ///                                 client.set_failure(&response.request);
     ///                             }
     ///                         }
     ///                         // Empty page, this is a failure.
-    ///                         Err(_) => client.set_failure(response),
+    ///                         Err(_) => client.set_failure(&response.request),
     ///                     }
     ///                 }
     ///             },
@@ -1236,10 +1233,10 @@ impl GooseClient {
     ///         }
     ///     }
     /// ````
-    pub fn set_failure(&mut self, response: &GooseResponse) {
+    pub fn set_failure(&mut self, request: &GooseRawRequest) {
         // Only send update if this was previously a success.
-        if response.request.success {
-            let mut update_request = response.request.clone();
+        if request.success {
+            let mut update_request = request.clone();
             update_request.success = false;
             update_request.update = true;
             self.send_to_parent(&update_request);


### PR DESCRIPTION
Requests made by Goose return a custom GooseResponse object which currently contains but the request made, and the response.

Subsequent calls to `set_success` and `set_failure` must include a mutable reference to the request that was made. For example:

```rust
    use goose::prelude::*;

    let mut task = task!(get_function);

    /// A simple task that makes a GET request.
    async fn get_function(client: &mut GooseClient) {
        let mut response = client.get("/404").await;
        match &response.response {
            Ok(r) => {
                // We expect a 404 here.
                if r.status() == 404 {
                    client.set_success(&mut response.request);
                }
            },
            Err(_) => (),
        }
    }
````