### PR TITLE
[EXPERIMENTAL] removing locks with unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.3-dev
+ - move client out of GooseClient into global GooseClientState
+
 ## 0.7.2 June 1, 2020
  - don't shuffle order of weighted task sets when launching clients
  - remove GooseClientMode as it serves no useful purpose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 simplelog = "0.7"
 structopt = "0.3"
-tokio = { version = "0.2.20", features = ["rt-core", "time", "sync"] }
+tokio = { version = "0.2.20", features = ["macros", "rt-core", "time", "sync"] }
 url = "2.1"
 
 # optional dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.7.2"
+version = "0.7.3-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -82,20 +82,26 @@ fn main() {
 
 /// View the front page.
 async fn drupal_loadtest_front_page(client: &GooseClient) {
-    let mut response = client.get("/").await;
+    let mut response = client.get("/", None).await;
 
     // Grab some static assets from the front page.
     match response.response {
         Ok(r) => match r.text().await {
             Ok(t) => {
                 let re = Regex::new(r#"src="(.*?)""#).unwrap();
+                // Collect copy of URLs to run them async
+                let mut urls = Vec::new();
+                let mut futures = Vec::new();
                 for url in re.captures_iter(&t) {
                     if url[1].contains("/misc") || url[1].contains("/themes") {
-                        // @TODO: implement `set_request_name` without mutable client
-                        //let _response = client.set_request_name("static asset").get(&url[1]);
-                        let _response = client.get(&url[1]);
+                        urls.push(url[1].to_string());
                     }
                 }
+                for index in 0..urls.len() {
+                    futures.push(client.get(&urls[index], Some("static asset")));
+                }
+                // Asynchronously load all static assets together.
+                futures::future::join_all(futures).await;
             }
             Err(e) => {
                 eprintln!("failed to parse front page: {}", e);
@@ -112,18 +118,18 @@ async fn drupal_loadtest_front_page(client: &GooseClient) {
 /// View a node from 1 to 10,000, created by preptest.sh.
 async fn drupal_loadtest_node_page(client: &GooseClient) {
     let nid = rand::thread_rng().gen_range(1, 10_000);
-    let _response = client.get(format!("/node/{}", &nid).as_str()).await;
+    let _response = client.get(format!("/node/{}", &nid).as_str(), None).await;
 }
 
 /// View a profile from 2 to 5,001, created by preptest.sh.
 async fn drupal_loadtest_profile_page(client: &GooseClient) {
     let uid = rand::thread_rng().gen_range(2, 5_001);
-    let _response = client.get(format!("/user/{}", &uid).as_str()).await;
+    let _response = client.get(format!("/user/{}", &uid).as_str(), None).await;
 }
 
 /// Log in.
 async fn drupal_loadtest_login(client: &GooseClient) {
-    let mut response = client.get("/user").await;
+    let mut response = client.get("/user", None).await;
     match response.response {
         Ok(r) => {
             match r.text().await {
@@ -149,7 +155,7 @@ async fn drupal_loadtest_login(client: &GooseClient) {
                         ("op", "Log+in"),
                     ];
                     let request_builder = client.goose_post("/user").await;
-                    let _response = client.goose_send(request_builder.form(&params)).await;
+                    let _response = client.goose_send(request_builder.form(&params), None).await;
                     // @TODO: verify that we actually logged in.
                 }
                 Err(e) => {
@@ -168,7 +174,7 @@ async fn drupal_loadtest_post_comment(client: &GooseClient) {
     let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);
-    let mut response = client.get(&node_path).await;
+    let mut response = client.get(&node_path, None).await;
     match response.response {
         Ok(r) => {
             match r.text().await {
@@ -216,7 +222,7 @@ async fn drupal_loadtest_post_comment(client: &GooseClient) {
                         ("op", "Save"),
                     ];
                     let request_builder = client.goose_post(&comment_path).await;
-                    let mut response = client.goose_send(request_builder.form(&params)).await;
+                    let mut response = client.goose_send(request_builder.form(&params), None).await;
                     match response.response {
                         Ok(r) => match r.text().await {
                             Ok(html) => {

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -146,7 +146,7 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
                         ("form_id", "user_login"),
                         ("op", "Log+in"),
                     ];
-                    let request_builder = client.goose_post("/user");
+                    let request_builder = client.goose_post("/user").await;
                     let _response = client.goose_send(request_builder.form(&params)).await;
                     // @TODO: verify that we actually logged in.
                 }
@@ -213,7 +213,7 @@ async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
                         ("form_id", &form_id[1]),
                         ("op", "Save"),
                     ];
-                    let request_builder = client.goose_post(&comment_path);
+                    let request_builder = client.goose_post(&comment_path).await;
                     let mut response = client.goose_send(request_builder.form(&params)).await;
                     match response.response {
                         Ok(r) => match r.text().await {

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -82,7 +82,7 @@ fn main() {
 
 /// View the front page.
 async fn drupal_loadtest_front_page(client: &GooseClient) {
-    let mut response = client.get("/", None).await;
+    let mut response = client.get("/").await;
 
     // Grab some static assets from the front page.
     match response.response {
@@ -97,7 +97,7 @@ async fn drupal_loadtest_front_page(client: &GooseClient) {
                     }
                 }
                 for index in 0..urls.len() {
-                    client.get(&urls[index], Some("static asset")).await;
+                    client.get_named(&urls[index], "static asset").await;
                 }
             }
             Err(e) => {
@@ -115,18 +115,18 @@ async fn drupal_loadtest_front_page(client: &GooseClient) {
 /// View a node from 1 to 10,000, created by preptest.sh.
 async fn drupal_loadtest_node_page(client: &GooseClient) {
     let nid = rand::thread_rng().gen_range(1, 10_000);
-    let _response = client.get(format!("/node/{}", &nid).as_str(), None).await;
+    let _response = client.get(format!("/node/{}", &nid).as_str()).await;
 }
 
 /// View a profile from 2 to 5,001, created by preptest.sh.
 async fn drupal_loadtest_profile_page(client: &GooseClient) {
     let uid = rand::thread_rng().gen_range(2, 5_001);
-    let _response = client.get(format!("/user/{}", &uid).as_str(), None).await;
+    let _response = client.get(format!("/user/{}", &uid).as_str()).await;
 }
 
 /// Log in.
 async fn drupal_loadtest_login(client: &GooseClient) {
-    let mut response = client.get("/user", None).await;
+    let mut response = client.get("/user").await;
     match response.response {
         Ok(r) => {
             match r.text().await {
@@ -171,7 +171,7 @@ async fn drupal_loadtest_post_comment(client: &GooseClient) {
     let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);
-    let mut response = client.get(&node_path, None).await;
+    let mut response = client.get(&node_path).await;
     match response.response {
         Ok(r) => {
             match r.text().await {

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -81,7 +81,7 @@ fn main() {
 }
 
 /// View the front page.
-async fn drupal_loadtest_front_page(client: &mut GooseClient) {
+async fn drupal_loadtest_front_page(client: &GooseClient) {
     let mut response = client.get("/").await;
 
     // Grab some static assets from the front page.
@@ -91,7 +91,9 @@ async fn drupal_loadtest_front_page(client: &mut GooseClient) {
                 let re = Regex::new(r#"src="(.*?)""#).unwrap();
                 for url in re.captures_iter(&t) {
                     if url[1].contains("/misc") || url[1].contains("/themes") {
-                        let _response = client.set_request_name("static asset").get(&url[1]);
+                        // @TODO: implement `set_request_name` without mutable client
+                        //let _response = client.set_request_name("static asset").get(&url[1]);
+                        let _response = client.get(&url[1]);
                     }
                 }
             }
@@ -108,19 +110,19 @@ async fn drupal_loadtest_front_page(client: &mut GooseClient) {
 }
 
 /// View a node from 1 to 10,000, created by preptest.sh.
-async fn drupal_loadtest_node_page(client: &mut GooseClient) {
+async fn drupal_loadtest_node_page(client: &GooseClient) {
     let nid = rand::thread_rng().gen_range(1, 10_000);
     let _response = client.get(format!("/node/{}", &nid).as_str()).await;
 }
 
 /// View a profile from 2 to 5,001, created by preptest.sh.
-async fn drupal_loadtest_profile_page(client: &mut GooseClient) {
+async fn drupal_loadtest_profile_page(client: &GooseClient) {
     let uid = rand::thread_rng().gen_range(2, 5_001);
     let _response = client.get(format!("/user/{}", &uid).as_str()).await;
 }
 
 /// Log in.
-async fn drupal_loadtest_login(client: &mut GooseClient) {
+async fn drupal_loadtest_login(client: &GooseClient) {
     let mut response = client.get("/user").await;
     match response.response {
         Ok(r) => {
@@ -162,7 +164,7 @@ async fn drupal_loadtest_login(client: &mut GooseClient) {
 }
 
 /// Post a comment.
-async fn drupal_loadtest_post_comment(client: &mut GooseClient) {
+async fn drupal_loadtest_post_comment(client: &GooseClient) {
     let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -91,17 +91,14 @@ async fn drupal_loadtest_front_page(client: &GooseClient) {
                 let re = Regex::new(r#"src="(.*?)""#).unwrap();
                 // Collect copy of URLs to run them async
                 let mut urls = Vec::new();
-                let mut futures = Vec::new();
                 for url in re.captures_iter(&t) {
                     if url[1].contains("/misc") || url[1].contains("/themes") {
                         urls.push(url[1].to_string());
                     }
                 }
                 for index in 0..urls.len() {
-                    futures.push(client.get(&urls[index], Some("static asset")));
+                    client.get(&urls[index], Some("static asset")).await;
                 }
-                // Asynchronously load all static assets together.
-                futures::future::join_all(futures).await;
             }
             Err(e) => {
                 eprintln!("failed to parse front page: {}", e);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -47,10 +47,10 @@ async fn website_login(client: &GooseClient) {
 
 /// A very simple task that simply loads the front page.
 async fn website_index(client: &GooseClient) {
-    let _response = client.get("/", None).await;
+    let _response = client.get("/").await;
 }
 
 /// A very simple task that simply loads the about page.
 async fn website_about(client: &GooseClient) {
-    let _response = client.get("/about/", None).await;
+    let _response = client.get("/about/").await;
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -42,15 +42,15 @@ async fn website_login(client: &GooseClient) {
     let request_builder = client.goose_post("/login").await;
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
-    let _response = client.goose_send(request_builder.form(&params)).await;
+    let _response = client.goose_send(request_builder.form(&params), None).await;
 }
 
 /// A very simple task that simply loads the front page.
 async fn website_index(client: &GooseClient) {
-    let _response = client.get("/").await;
+    let _response = client.get("/", None).await;
 }
 
 /// A very simple task that simply loads the about page.
 async fn website_about(client: &GooseClient) {
-    let _response = client.get("/about/").await;
+    let _response = client.get("/about/", None).await;
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -39,7 +39,7 @@ fn main() {
 /// on_start task when registering it above. This means it only runs one time
 /// per client, when the client thread first starts.
 async fn website_login(client: &mut GooseClient) {
-    let request_builder = client.goose_post("/login");
+    let request_builder = client.goose_post("/login").await;
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
     let _response = client.goose_send(request_builder.form(&params)).await;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -38,7 +38,7 @@ fn main() {
 /// Demonstrates how to log in when a client starts. We flag this task as an
 /// on_start task when registering it above. This means it only runs one time
 /// per client, when the client thread first starts.
-async fn website_login(client: &mut GooseClient) {
+async fn website_login(client: &GooseClient) {
     let request_builder = client.goose_post("/login").await;
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
@@ -46,11 +46,11 @@ async fn website_login(client: &mut GooseClient) {
 }
 
 /// A very simple task that simply loads the front page.
-async fn website_index(client: &mut GooseClient) {
+async fn website_index(client: &GooseClient) {
     let _response = client.get("/").await;
 }
 
 /// A very simple task that simply loads the about page.
-async fn website_about(client: &mut GooseClient) {
+async fn website_about(client: &GooseClient) {
     let _response = client.get("/about/").await;
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -59,7 +59,7 @@ pub async fn client_main(
         .load(Ordering::SeqCst);
     let mut weighted_bucket_position = CLIENT.read().await[thread_client.weighted_clients_index]
         .weighted_bucket_position
-        .fetch_add(1, Ordering::SeqCst);
+        .load(Ordering::SeqCst);
     while thread_continue {
         // Weighted_tasks is divided into buckets of tasks sorted by sequence, and then all non-sequenced tasks.
         if thread_client.weighted_tasks[weighted_bucket].len() <= weighted_bucket_position {

--- a/src/client.rs
+++ b/src/client.rs
@@ -47,7 +47,7 @@ pub async fn client_main(
                     thread_client.task_request_name = Some(thread_task_name.to_string());
                 }
                 // Invoke the task function.
-                function(&mut thread_client).await;
+                function(&thread_client).await;
             }
         }
     }
@@ -92,7 +92,7 @@ pub async fn client_main(
             thread_client.task_request_name = Some(thread_task_name.to_string());
         }
         // Invoke the task function.
-        function(&mut thread_client).await;
+        function(&thread_client).await;
 
         // Prepare to sleep for a random value from min_wait to max_wait.
         let wait_time = if thread_client.max_wait > 0 {
@@ -159,7 +159,7 @@ pub async fn client_main(
                     thread_client.task_request_name = Some(thread_task_name.to_string());
                 }
                 // Invoke the task function.
-                function(&mut thread_client).await;
+                function(&thread_client).await;
             }
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -56,10 +56,9 @@ pub async fn client_main(
     let mut weighted_bucket: usize;
     let mut weighted_bucket_position: usize;
     unsafe {
-        weighted_bucket = CLIENT[thread_client.weighted_clients_index]
-            .weighted_bucket;
-        weighted_bucket_position = CLIENT[thread_client.weighted_clients_index]
-            .weighted_bucket_position;
+        weighted_bucket = CLIENT[thread_client.weighted_clients_index].weighted_bucket;
+        weighted_bucket_position =
+            CLIENT[thread_client.weighted_clients_index].weighted_bucket_position;
     }
     while thread_continue {
         // Weighted_tasks is divided into buckets of tasks sorted by sequence, and then all non-sequenced tasks.
@@ -67,8 +66,8 @@ pub async fn client_main(
             // This bucket is exhausted, move on to position 0 of the next bucket.
             weighted_bucket_position = 0;
             unsafe {
-                CLIENT[thread_client.weighted_clients_index]
-                    .weighted_bucket_position = weighted_bucket_position;
+                CLIENT[thread_client.weighted_clients_index].weighted_bucket_position =
+                    weighted_bucket_position;
             }
 
             weighted_bucket += 1;
@@ -76,8 +75,7 @@ pub async fn client_main(
                 weighted_bucket = 0;
             }
             unsafe {
-                CLIENT[thread_client.weighted_clients_index]
-                    .weighted_bucket = weighted_bucket;
+                CLIENT[thread_client.weighted_clients_index].weighted_bucket = weighted_bucket;
             }
             // Shuffle new bucket before we walk through the tasks.
             thread_client.weighted_tasks[weighted_bucket].shuffle(&mut thread_rng());
@@ -148,8 +146,8 @@ pub async fn client_main(
         // Move to the next task in thread_client.weighted_tasks.
         weighted_bucket_position += 1;
         unsafe {
-            CLIENT[thread_client.weighted_clients_index]
-                .weighted_bucket_position = weighted_bucket_position;
+            CLIENT[thread_client.weighted_clients_index].weighted_bucket_position =
+                weighted_bucket_position;
         }
     }
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -73,7 +73,7 @@
 //!
 //!     /// A very simple task that simply loads the front page.
 //!     async fn task_function(client: &GooseClient) {
-//!       let _response = client.get("/");
+//!       let _response = client.get("/", None);
 //!     }
 //! ```
 //!
@@ -89,7 +89,7 @@
 //!
 //!     /// A very simple task that simply loads the front page.
 //!     async fn task_function(client: &GooseClient) {
-//!       let _response = client.get("/");
+//!       let _response = client.get("/", None);
 //!     }
 //! ```
 //!
@@ -107,12 +107,12 @@
 //!
 //!     /// A very simple task that simply loads the "a" page.
 //!     async fn a_task_function(client: &GooseClient) {
-//!       let _response = client.get("/a/");
+//!       let _response = client.get("/a/", None);
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
 //!     async fn b_task_function(client: &GooseClient) {
-//!       let _response = client.get("/b/");
+//!       let _response = client.get("/b/", None);
 //!     }
 //! ```
 //!
@@ -135,17 +135,17 @@
 //!
 //!     /// A very simple task that simply loads the "a" page.
 //!     async fn a_task_function(client: &GooseClient) {
-//!       let _response = client.get("/a/");
+//!       let _response = client.get("/a/", None);
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
 //!     async fn b_task_function(client: &GooseClient) {
-//!       let _response = client.get("/b/");
+//!       let _response = client.get("/b/", None);
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "c" page.
 //!     async fn c_task_function(client: &GooseClient) {
-//!       let _response = client.get("/c/");
+//!       let _response = client.get("/c/", None);
 //!     }
 //! ```
 //!
@@ -164,7 +164,7 @@
 //!
 //!     /// A very simple task that simply loads the "a" page.
 //!     async fn a_task_function(client: &GooseClient) {
-//!       let _response = client.get("/a/");
+//!       let _response = client.get("/a/", None);
 //!     }
 //! ```
 //!
@@ -183,7 +183,7 @@
 //!
 //!     /// Another very simple task that simply loads the "b" page.
 //!     async fn b_task_function(client: &GooseClient) {
-//!       let _response = client.get("/b/");
+//!       let _response = client.get("/b/", None);
 //!     }
 //! ```
 //!
@@ -211,7 +211,7 @@
 //!
 //!     /// A very simple task that makes a GET request.
 //!     async  fn get_function(client: &GooseClient) {
-//!       let _response = client.get("/path/to/foo/");
+//!       let _response = client.get("/path/to/foo/", None);
 //!     }
 //! ```
 //!
@@ -232,7 +232,7 @@
 //!
 //!     /// A very simple task that makes a POST request.
 //!     async fn post_function(client: &GooseClient) {
-//!       let _response = client.post("/path/to/foo/", "string value to post".to_string());
+//!       let _response = client.post("/path/to/foo/", None, "string value to post");
 //!     }
 //! ```
 //!
@@ -343,7 +343,7 @@ impl GooseTaskSet {
     ///
     ///     /// A very simple task that simply loads the "a" page.
     ///     async fn a_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/a/");
+    ///       let _response = client.get("/a/", None);
     ///     }
     /// ```
     pub fn register_task(mut self, mut task: GooseTask) -> Self {
@@ -705,51 +705,6 @@ impl GooseClient {
         }
     }
 
-    /*
-     * @TODO: fixme
-    /// Sets a name for the next request made.
-    ///
-    /// One example use case of this is to group together requests to different URLs in the
-    /// statistics that don't need to be split out, perhaps because they're all the same type
-    /// of page.
-    ///
-    /// # Examples
-    ///
-    /// In this example, the request will show up as "GET foo":
-    /// ```rust
-    ///     use goose::prelude::*;
-    ///
-    ///     let mut task = task!(get_function);
-    ///
-    ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(client: &GooseClient) {
-    ///       let _response = client.set_request_name("foo").get("/path/to/foo");
-    ///     }
-    /// ```
-    ///
-    /// In this example, the first request will show up in the statistics as "GET foo", and the
-    /// second request will show up as "GET /path/to/foo".
-    /// ```rust
-    ///     use goose::prelude::*;
-    ///
-    ///     let mut task = task!(get_function);
-    ///
-    ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(client: &GooseClient) {
-    ///       let _response = client.set_request_name("foo").get("/path/to/foo").await;
-    ///       let _response = client.get("/path/to/foo").await;
-    ///     }
-    /// ```
-    pub fn set_request_name(&mut self, name: &str) -> &mut Self {
-        if name != "" {
-            self.request_name = Some(name.to_string());
-        } else {
-            self.request_name = None;
-        }
-        self
-    }
-    */
-
     /// A helper that pre-pends a hostname to the path. For example, if you pass in `/foo`
     /// and `--host` is set to `http://127.0.0.1` it will return `http://127.0.0.1/foo`.
     /// Respects per-`GooseTaskSet` `host` configuration, global `GooseAttack` `host`
@@ -814,12 +769,12 @@ impl GooseClient {
     ///
     ///     /// A very simple task that makes a GET request.
     ///     async fn get_function(client: &GooseClient) {
-    ///       let _response = client.get("/path/to/foo/");
+    ///       let _response = client.get("/path/to/foo/", None);
     ///     }
     /// ```
-    pub async fn get(&self, path: &str) -> GooseResponse {
+    pub async fn get(&self, path: &str, request_name: Option<&str>) -> GooseResponse {
         let request_builder = self.goose_get(path).await;
-        self.goose_send(request_builder).await
+        self.goose_send(request_builder, request_name).await
     }
 
     /// A helper to make a `POST` request of a path and collect relevant statistics.
@@ -843,12 +798,12 @@ impl GooseClient {
     ///
     ///     /// A very simple task that makes a POST request.
     ///     async fn post_function(client: &GooseClient) {
-    ///       let _response = client.post("/path/to/foo/", "BODY BEING POSTED".to_string());
+    ///       let _response = client.post("/path/to/foo/", None, "BODY BEING POSTED");
     ///     }
     /// ```
-    pub async fn post(&self, path: &str, body: String) -> GooseResponse {
-        let request_builder = self.goose_post(path).await.body(body);
-        self.goose_send(request_builder).await
+    pub async fn post(&self, path: &str, request_name: Option<&str>, body: &str) -> GooseResponse {
+        let request_builder = self.goose_post(path).await.body(body.to_string());
+        self.goose_send(request_builder, request_name).await
     }
 
     /// A helper to make a `HEAD` request of a path and collect relevant statistics.
@@ -872,12 +827,12 @@ impl GooseClient {
     ///
     ///     /// A very simple task that makes a HEAD request.
     ///     async fn head_function(client: &GooseClient) {
-    ///       let _response = client.head("/path/to/foo/");
+    ///       let _response = client.head("/path/to/foo/", None);
     ///     }
     /// ```
-    pub async fn head(&self, path: &str) -> GooseResponse {
+    pub async fn head(&self, path: &str, request_name: Option<&str>) -> GooseResponse {
         let request_builder = self.goose_head(path).await;
-        self.goose_send(request_builder).await
+        self.goose_send(request_builder, request_name).await
     }
 
     /// A helper to make a `DELETE` request of a path and collect relevant statistics.
@@ -901,12 +856,12 @@ impl GooseClient {
     ///
     ///     /// A very simple task that makes a DELETE request.
     ///     async fn delete_function(client: &GooseClient) {
-    ///       let _response = client.delete("/path/to/foo/");
+    ///       let _response = client.delete("/path/to/foo/", None);
     ///     }
     /// ```
-    pub async fn delete(&self, path: &str) -> GooseResponse {
+    pub async fn delete(&self, path: &str, request_name: Option<&str>) -> GooseResponse {
         let request_builder = self.goose_delete(path).await;
-        self.goose_send(request_builder).await
+        self.goose_send(request_builder, request_name).await
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -925,7 +880,7 @@ impl GooseClient {
     ///     /// request builder.
     ///     async fn get_function(client: &GooseClient) {
     ///       let request_builder = client.goose_get("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder).await;
+    ///       let response = client.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_get(&self, path: &str) -> RequestBuilder {
@@ -953,7 +908,7 @@ impl GooseClient {
     ///     /// request builder.
     ///     async fn post_function(client: &GooseClient) {
     ///       let request_builder = client.goose_post("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder).await;
+    ///       let response = client.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_post(&self, path: &str) -> RequestBuilder {
@@ -981,7 +936,7 @@ impl GooseClient {
     ///     /// request builder.
     ///     async fn head_function(client: &GooseClient) {
     ///       let request_builder = client.goose_head("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder).await;
+    ///       let response = client.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_head(&self, path: &str) -> RequestBuilder {
@@ -1009,7 +964,7 @@ impl GooseClient {
     ///     /// request builder.
     ///     async fn put_function(client: &GooseClient) {
     ///       let request_builder = client.goose_put("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder).await;
+    ///       let response = client.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_put(&self, path: &str) -> RequestBuilder {
@@ -1037,7 +992,7 @@ impl GooseClient {
     ///     /// request builder.
     ///     async fn patch_function(client: &GooseClient) {
     ///       let request_builder = client.goose_patch("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder).await;
+    ///       let response = client.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_patch(&self, path: &str) -> RequestBuilder {
@@ -1065,7 +1020,7 @@ impl GooseClient {
     ///     /// request builder.
     ///     async fn delete_function(client: &GooseClient) {
     ///       let request_builder = client.goose_delete("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder).await;
+    ///       let response = client.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_delete(&self, path: &str) -> RequestBuilder {
@@ -1101,10 +1056,10 @@ impl GooseClient {
     ///     /// request builder.
     ///     async fn get_function(client: &GooseClient) {
     ///       let request_builder = client.goose_get("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder).await;
+    ///       let response = client.goose_send(request_builder, None).await;
     ///     }
     /// ```
-    pub async fn goose_send(&self, request_builder: RequestBuilder) -> GooseResponse {
+    pub async fn goose_send(&self, request_builder: RequestBuilder, request_name: Option<&str>) -> GooseResponse {
         let started = Instant::now();
         let request = match request_builder.build() {
             Ok(r) => r,
@@ -1123,7 +1078,7 @@ impl GooseClient {
             }
         };
         let method = goose_method_from_method(request.method().clone());
-        let request_name = self.get_request_name(&path);
+        let request_name = self.get_request_name(&path, request_name);
         let mut raw_request = GooseRawRequest::new(method, &request_name);
 
         // Make the actual request.
@@ -1162,13 +1117,6 @@ impl GooseClient {
             self.send_to_parent(&raw_request);
         }
 
-        // Consume request_name if set.
-        /*
-        if self.request_name != None {
-            self.request_name = None;
-        }
-        */
-
         GooseResponse::new(raw_request, response)
     }
 
@@ -1189,10 +1137,10 @@ impl GooseClient {
         }
     }
 
-    /// If individual `request_name` is set, use this. Otherwise, if `task_request_name`
+    /// If `request_name` is set, unwrap and use this. Otherwise, if `task_request_name`
     /// is set, use this. Otherwise, use path.
-    fn get_request_name(&self, path: &str) -> String {
-        match &self.request_name {
+    fn get_request_name(&self, path: &str, request_name: Option<&str>) -> String {
+        match request_name {
             Some(rn) => rn.to_string(),
             None => match &self.task_request_name {
                 Some(trn) => trn.to_string(),
@@ -1216,7 +1164,7 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a GET request.
     ///     async fn get_function(client: &GooseClient) {
-    ///         let mut response = client.get("/404").await;
+    ///         let mut response = client.get("/404", None).await;
     ///         match &response.response {
     ///             Ok(r) => {
     ///                 // We expect a 404 here.
@@ -1251,8 +1199,7 @@ impl GooseClient {
     ///     let mut task = task!(loadtest_index_page);
     ///
     ///     async fn loadtest_index_page(client: &GooseClient) {
-    ///         //let mut response = client.set_request_name("index").get("/").await;
-    ///         let mut response = client.get("/").await;
+    ///         let mut response = client.get("/", Some("index")).await;
     ///         // Extract the response Result.
     ///         match response.response {
     ///             Ok(r) => {
@@ -1324,6 +1271,7 @@ impl GooseTask {
     /// Set an optional name for the task, used when displaying statistics about
     /// requests made by the task.
     ///
+    /// @TODO: rewrite:
     /// Individual requests can also be named withing your load test. See the
     /// documentation for `GooseClient`.[`set_request_name()`](./struct.GooseClient.html#method.set_request_name)
     ///
@@ -1334,7 +1282,7 @@ impl GooseTask {
     ///     task!(my_task_function).set_name("foo");
     ///
     ///     async fn my_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/");
+    ///       let _response = client.get("/", None);
     ///     }
     /// ```
     pub fn set_name(mut self, name: &str) -> Self {
@@ -1360,7 +1308,7 @@ impl GooseTask {
     ///     task!(my_on_start_function).set_on_start();
     ///
     ///     async fn my_on_start_function(client: &GooseClient) {
-    ///       let _response = client.get("/");
+    ///       let _response = client.get("/", None);
     ///     }
     /// ```
     pub fn set_on_start(mut self) -> Self {
@@ -1386,7 +1334,7 @@ impl GooseTask {
     ///     task!(my_on_stop_function).set_on_stop();
     ///
     ///     async fn my_on_stop_function(client: &GooseClient) {
-    ///       let _response = client.get("/");
+    ///       let _response = client.get("/", None);
     ///     }
     /// ```
     pub fn set_on_stop(mut self) -> Self {
@@ -1406,7 +1354,7 @@ impl GooseTask {
     ///     task!(task_function).set_weight(3);
     ///
     ///     async fn task_function(client: &GooseClient) {
-    ///       let _response = client.get("/");
+    ///       let _response = client.get("/", None);
     ///     }
     /// ```
     pub fn set_weight(mut self, weight: usize) -> Self {
@@ -1443,15 +1391,15 @@ impl GooseTask {
     ///     let runs_last = task!(third_task_function);
     ///
     ///     async fn first_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/1");
+    ///       let _response = client.get("/1", None);
     ///     }
     ///
     ///     async fn second_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/2");
+    ///       let _response = client.get("/2", None);
     ///     }
     ///
     ///     async fn third_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/3");
+    ///       let _response = client.get("/3", None);
     ///     }
     /// ```
     ///
@@ -1467,15 +1415,15 @@ impl GooseTask {
     ///     let also_runs_second = task!(second_task_function_b).set_sequence(2).set_weight(2);
     ///
     ///     async fn first_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/1");
+    ///       let _response = client.get("/1", None);
     ///     }
     ///
     ///     async fn second_task_function_a(client: &GooseClient) {
-    ///       let _response = client.get("/2a");
+    ///       let _response = client.get("/2a", None);
     ///     }
     ///
     ///     async fn second_task_function_b(client: &GooseClient) {
-    ///       let _response = client.get("/2b");
+    ///       let _response = client.get("/2b", None);
     ///     }
     /// ```
     pub fn set_sequence(mut self, sequence: usize) -> Self {
@@ -1514,11 +1462,11 @@ mod tests {
     fn goose_task_set() {
         // Simplistic test task functions.
         async fn test_function_a(client: &GooseClient) -> () {
-            let _response = client.get("/a/").await;
+            let _response = client.get("/a/", None).await;
         }
 
         async fn test_function_b(client: &GooseClient) -> () {
-            let _response = client.get("/b/").await;
+            let _response = client.get("/b/", None).await;
         }
 
         let mut task_set = taskset!("foo");
@@ -1611,7 +1559,7 @@ mod tests {
     fn goose_task() {
         // Simplistic test task functions.
         async fn test_function_a(client: &GooseClient) -> () {
-            let _response = client.get("/a/");
+            let _response = client.get("/a/", None);
         }
 
         // Initialize task set.
@@ -1922,7 +1870,6 @@ mod tests {
 
     #[tokio::test]
     async fn goose_client() {
-        //crate::GooseClientState::initialize(1).await;
         let configuration = GooseConfiguration::default();
         let client = GooseClient::new(
             0,
@@ -1944,26 +1891,6 @@ mod tests {
         assert_eq!(client.weighted_on_stop_tasks.len(), 0);
         assert_eq!(client.task_request_name, None);
         assert_eq!(client.request_name, None);
-
-        // Setting request name doesn't affect anything else.
-        // @TODO: fixme
-        //client.set_request_name("foo");
-        //assert_eq!(client.request_name, Some("foo".to_string()));
-        assert_eq!(client.task_sets_index, 0);
-        assert_eq!(client.default_host, Some("http://example.com/".to_string()));
-        assert_eq!(client.task_set_host, None);
-        assert_eq!(client.min_wait, 0);
-        assert_eq!(client.max_wait, 0);
-        assert_eq!(client.weighted_clients_index, usize::max_value());
-        assert_eq!(client.weighted_on_start_tasks.len(), 0);
-        assert_eq!(client.weighted_tasks.len(), 0);
-        assert_eq!(client.weighted_on_stop_tasks.len(), 0);
-        assert_eq!(client.task_request_name, None);
-
-        // Can set request name multiple times.
-        // @OTOD: fixme
-        //client.set_request_name("bar");
-        //assert_eq!(client.request_name, Some("bar".to_string()));
 
         // Confirm the URLs are correctly built using the default_host.
         let url = client.build_url("/foo");

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1059,7 +1059,11 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder, None).await;
     ///     }
     /// ```
-    pub async fn goose_send(&self, request_builder: RequestBuilder, request_name: Option<&str>) -> GooseResponse {
+    pub async fn goose_send(
+        &self,
+        request_builder: RequestBuilder,
+        request_name: Option<&str>,
+    ) -> GooseResponse {
         let started = Instant::now();
         let request = match request_builder.build() {
             Ok(r) => r,

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -985,11 +985,7 @@ impl GooseClient {
     /// ```
     pub async fn goose_get(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        unsafe {
-            CLIENT[self.weighted_clients_index]
-                .client
-                .get(&url)
-        }
+        unsafe { CLIENT[self.weighted_clients_index].client.get(&url) }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1013,11 +1009,7 @@ impl GooseClient {
     /// ```
     pub async fn goose_post(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        unsafe {
-            CLIENT[self.weighted_clients_index]
-                .client
-                .post(&url)
-        }
+        unsafe { CLIENT[self.weighted_clients_index].client.post(&url) }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1041,11 +1033,7 @@ impl GooseClient {
     /// ```
     pub async fn goose_head(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        unsafe {
-            CLIENT[self.weighted_clients_index]
-                .client
-                .head(&url)
-        }
+        unsafe { CLIENT[self.weighted_clients_index].client.head(&url) }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1069,11 +1057,7 @@ impl GooseClient {
     /// ```
     pub async fn goose_put(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        unsafe {
-            CLIENT[self.weighted_clients_index]
-                .client
-                .put(&url)
-        }
+        unsafe { CLIENT[self.weighted_clients_index].client.put(&url) }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1097,11 +1081,7 @@ impl GooseClient {
     /// ```
     pub async fn goose_patch(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        unsafe {
-            CLIENT[self.weighted_clients_index]
-                .client
-                .patch(&url)
-        }
+        unsafe { CLIENT[self.weighted_clients_index].client.patch(&url) }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1125,11 +1105,7 @@ impl GooseClient {
     /// ```
     pub async fn goose_delete(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        unsafe {
-            CLIENT[self.weighted_clients_index]
-                .client
-                .delete(&url)
-        }
+        unsafe { CLIENT[self.weighted_clients_index].client.delete(&url) }
     }
 
     /// Builds the provided

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -260,9 +260,8 @@ use reqwest::{Client, RequestBuilder, Response};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
-use std::sync::Mutex;
 use std::{future::Future, pin::Pin, time::Instant};
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc};
 use url::Url;
 
 use crate::GooseConfiguration;
@@ -846,7 +845,7 @@ impl GooseClient {
     ///     }
     /// ```
     pub async fn get(&mut self, path: &str) -> GooseResponse {
-        let request_builder = self.goose_get(path);
+        let request_builder = self.goose_get(path).await;
         self.goose_send(request_builder).await
     }
 
@@ -875,7 +874,7 @@ impl GooseClient {
     ///     }
     /// ```
     pub async fn post(&mut self, path: &str, body: String) -> GooseResponse {
-        let request_builder = self.goose_post(path).body(body);
+        let request_builder = self.goose_post(path).await.body(body);
         self.goose_send(request_builder).await
     }
 
@@ -904,7 +903,7 @@ impl GooseClient {
     ///     }
     /// ```
     pub async fn head(&mut self, path: &str) -> GooseResponse {
-        let request_builder = self.goose_head(path);
+        let request_builder = self.goose_head(path).await;
         self.goose_send(request_builder).await
     }
 
@@ -933,7 +932,7 @@ impl GooseClient {
     ///     }
     /// ```
     pub async fn delete(&mut self, path: &str) -> GooseResponse {
-        let request_builder = self.goose_delete(path);
+        let request_builder = self.goose_delete(path).await;
         self.goose_send(request_builder).await
     }
 
@@ -952,13 +951,13 @@ impl GooseClient {
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
     ///     async fn get_function(client: &mut GooseClient) {
-    ///       let request_builder = client.goose_get("/path/to/foo");
+    ///       let request_builder = client.goose_get("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub fn goose_get(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_get(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.lock().unwrap().get(&url)
+        CLIENT.lock().await.get(&url)
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -976,13 +975,13 @@ impl GooseClient {
     ///     /// A simple task that makes a POST request, exposing the Reqwest
     ///     /// request builder.
     ///     async fn post_function(client: &mut GooseClient) {
-    ///       let request_builder = client.goose_post("/path/to/foo");
+    ///       let request_builder = client.goose_post("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub fn goose_post(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_post(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.lock().unwrap().post(&url)
+        CLIENT.lock().await.post(&url)
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1000,13 +999,13 @@ impl GooseClient {
     ///     /// A simple task that makes a HEAD request, exposing the Reqwest
     ///     /// request builder.
     ///     async fn head_function(client: &mut GooseClient) {
-    ///       let request_builder = client.goose_head("/path/to/foo");
+    ///       let request_builder = client.goose_head("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub fn goose_head(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_head(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.lock().unwrap().head(&url)
+        CLIENT.lock().await.head(&url)
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1024,13 +1023,13 @@ impl GooseClient {
     ///     /// A simple task that makes a PUT request, exposing the Reqwest
     ///     /// request builder.
     ///     async fn put_function(client: &mut GooseClient) {
-    ///       let request_builder = client.goose_put("/path/to/foo");
+    ///       let request_builder = client.goose_put("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub fn goose_put(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_put(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.lock().unwrap().put(&url)
+        CLIENT.lock().await.put(&url)
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1052,9 +1051,9 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub fn goose_patch(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_patch(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.lock().unwrap().patch(&url)
+        CLIENT.lock().await.patch(&url)
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1076,9 +1075,9 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub fn goose_delete(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_delete(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.lock().unwrap().delete(&url)
+        CLIENT.lock().await.delete(&url)
     }
 
     /// Builds the provided
@@ -1104,7 +1103,7 @@ impl GooseClient {
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
     ///     async fn get_function(client: &mut GooseClient) {
-    ///       let request_builder = client.goose_get("/path/to/foo");
+    ///       let request_builder = client.goose_get("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
@@ -1131,7 +1130,7 @@ impl GooseClient {
         let mut raw_request = GooseRawRequest::new(method, &request_name);
 
         // Make the actual request.
-        let response = CLIENT.lock().unwrap().execute(request).await;
+        let response = CLIENT.lock().await.execute(request).await;
         let elapsed = started.elapsed();
 
         // Create a raw request object if we're tracking statistics.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -988,8 +988,6 @@ impl GooseClient {
         unsafe {
             CLIENT[self.weighted_clients_index]
                 .client
-                .lock()
-                .await
                 .get(&url)
         }
     }
@@ -1018,8 +1016,6 @@ impl GooseClient {
         unsafe {
             CLIENT[self.weighted_clients_index]
                 .client
-                .lock()
-                .await
                 .post(&url)
         }
     }
@@ -1048,8 +1044,6 @@ impl GooseClient {
         unsafe {
             CLIENT[self.weighted_clients_index]
                 .client
-                .lock()
-                .await
                 .head(&url)
         }
     }
@@ -1078,8 +1072,6 @@ impl GooseClient {
         unsafe {
             CLIENT[self.weighted_clients_index]
                 .client
-                .lock()
-                .await
                 .put(&url)
         }
     }
@@ -1108,8 +1100,6 @@ impl GooseClient {
         unsafe {
             CLIENT[self.weighted_clients_index]
                 .client
-                .lock()
-                .await
                 .patch(&url)
         }
     }
@@ -1138,8 +1128,6 @@ impl GooseClient {
         unsafe {
             CLIENT[self.weighted_clients_index]
                 .client
-                .lock()
-                .await
                 .delete(&url)
         }
     }
@@ -1202,8 +1190,6 @@ impl GooseClient {
         unsafe {
             response = CLIENT[self.weighted_clients_index]
                 .client
-                .lock()
-                .await
                 .execute(request)
                 .await;
         }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -985,11 +985,13 @@ impl GooseClient {
     /// ```
     pub async fn goose_get(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.read().await[self.weighted_clients_index]
-            .client
-            .lock()
-            .await
-            .get(&url)
+        unsafe {
+            CLIENT[self.weighted_clients_index]
+                .client
+                .lock()
+                .await
+                .get(&url)
+        }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1013,11 +1015,13 @@ impl GooseClient {
     /// ```
     pub async fn goose_post(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.read().await[self.weighted_clients_index]
-            .client
-            .lock()
-            .await
-            .post(&url)
+        unsafe {
+            CLIENT[self.weighted_clients_index]
+                .client
+                .lock()
+                .await
+                .post(&url)
+        }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1041,11 +1045,13 @@ impl GooseClient {
     /// ```
     pub async fn goose_head(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.read().await[self.weighted_clients_index]
-            .client
-            .lock()
-            .await
-            .head(&url)
+        unsafe {
+            CLIENT[self.weighted_clients_index]
+                .client
+                .lock()
+                .await
+                .head(&url)
+        }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1069,11 +1075,13 @@ impl GooseClient {
     /// ```
     pub async fn goose_put(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.read().await[self.weighted_clients_index]
-            .client
-            .lock()
-            .await
-            .put(&url)
+        unsafe {
+            CLIENT[self.weighted_clients_index]
+                .client
+                .lock()
+                .await
+                .put(&url)
+        }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1097,11 +1105,13 @@ impl GooseClient {
     /// ```
     pub async fn goose_patch(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.read().await[self.weighted_clients_index]
-            .client
-            .lock()
-            .await
-            .patch(&url)
+        unsafe {
+            CLIENT[self.weighted_clients_index]
+                .client
+                .lock()
+                .await
+                .patch(&url)
+        }
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1125,11 +1135,13 @@ impl GooseClient {
     /// ```
     pub async fn goose_delete(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
-        CLIENT.read().await[self.weighted_clients_index]
-            .client
-            .lock()
-            .await
-            .delete(&url)
+        unsafe {
+            CLIENT[self.weighted_clients_index]
+                .client
+                .lock()
+                .await
+                .delete(&url)
+        }
     }
 
     /// Builds the provided
@@ -1186,12 +1198,15 @@ impl GooseClient {
         let mut raw_request = GooseRawRequest::new(method, &request_name);
 
         // Make the actual request.
-        let response = CLIENT.read().await[self.weighted_clients_index]
-            .client
-            .lock()
-            .await
-            .execute(request)
-            .await;
+        let response;
+        unsafe {
+            response = CLIENT[self.weighted_clients_index]
+                .client
+                .lock()
+                .await
+                .execute(request)
+                .await;
+        }
         let elapsed = started.elapsed();
 
         // Create a raw request object if we're tracking statistics.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -759,7 +759,7 @@ impl GooseClient {
     ///  - Otherwise, if `--host` is defined, use this
     ///  - Otherwise, if `GooseTaskSet.host` is defined, use this
     ///  - Otherwise, use global `GooseAttack.host`.
-    pub fn build_url(&mut self, path: &str) -> String {
+    pub fn build_url(&self, path: &str) -> String {
         // If URL includes a host, use it.
         if let Ok(parsed_path) = Url::parse(path) {
             if let Some(_uri) = parsed_path.host() {
@@ -814,7 +814,7 @@ impl GooseClient {
     ///       let _response = client.get("/path/to/foo/");
     ///     }
     /// ```
-    pub async fn get(&mut self, path: &str) -> GooseResponse {
+    pub async fn get(&self, path: &str) -> GooseResponse {
         let request_builder = self.goose_get(path).await;
         self.goose_send(request_builder).await
     }
@@ -843,7 +843,7 @@ impl GooseClient {
     ///       let _response = client.post("/path/to/foo/", "BODY BEING POSTED".to_string());
     ///     }
     /// ```
-    pub async fn post(&mut self, path: &str, body: String) -> GooseResponse {
+    pub async fn post(&self, path: &str, body: String) -> GooseResponse {
         let request_builder = self.goose_post(path).await.body(body);
         self.goose_send(request_builder).await
     }
@@ -872,7 +872,7 @@ impl GooseClient {
     ///       let _response = client.head("/path/to/foo/");
     ///     }
     /// ```
-    pub async fn head(&mut self, path: &str) -> GooseResponse {
+    pub async fn head(&self, path: &str) -> GooseResponse {
         let request_builder = self.goose_head(path).await;
         self.goose_send(request_builder).await
     }
@@ -901,7 +901,7 @@ impl GooseClient {
     ///       let _response = client.delete("/path/to/foo/");
     ///     }
     /// ```
-    pub async fn delete(&mut self, path: &str) -> GooseResponse {
+    pub async fn delete(&self, path: &str) -> GooseResponse {
         let request_builder = self.goose_delete(path).await;
         self.goose_send(request_builder).await
     }
@@ -925,7 +925,7 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub async fn goose_get(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_get(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
             .client
@@ -953,7 +953,7 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub async fn goose_post(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_post(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
             .client
@@ -981,7 +981,7 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub async fn goose_head(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_head(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
             .client
@@ -1009,7 +1009,7 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub async fn goose_put(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_put(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
             .client
@@ -1037,7 +1037,7 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub async fn goose_patch(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_patch(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
             .client
@@ -1065,7 +1065,7 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub async fn goose_delete(&mut self, path: &str) -> RequestBuilder {
+    pub async fn goose_delete(&self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
             .client
@@ -1101,7 +1101,7 @@ impl GooseClient {
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
-    pub async fn goose_send(&mut self, request_builder: RequestBuilder) -> GooseResponse {
+    pub async fn goose_send(&self, request_builder: RequestBuilder) -> GooseResponse {
         let started = Instant::now();
         let request = match request_builder.build() {
             Ok(r) => r,
@@ -1160,14 +1160,16 @@ impl GooseClient {
         }
 
         // Consume request_name if set.
+        /*
         if self.request_name != None {
             self.request_name = None;
         }
+        */
 
         GooseResponse::new(raw_request, response)
     }
 
-    fn send_to_parent(&mut self, raw_request: &GooseRawRequest) {
+    fn send_to_parent(&self, raw_request: &GooseRawRequest) {
         let parent = match self.parent.clone() {
             Some(p) => p,
             None => {
@@ -1186,7 +1188,7 @@ impl GooseClient {
 
     /// If individual `request_name` is set, use this. Otherwise, if `task_request_name`
     /// is set, use this. Otherwise, use path.
-    fn get_request_name(&mut self, path: &str) -> String {
+    fn get_request_name(&self, path: &str) -> String {
         match &self.request_name {
             Some(rn) => rn.to_string(),
             None => match &self.task_request_name {
@@ -1223,7 +1225,7 @@ impl GooseClient {
     ///         }
     ///     }
     /// ````
-    pub fn set_success(&mut self, request: &mut GooseRawRequest) {
+    pub fn set_success(&self, request: &mut GooseRawRequest) {
         // Only send update if this was previously not a success.
         if !request.success {
             request.success = true;
@@ -1271,7 +1273,7 @@ impl GooseClient {
     ///         }
     ///     }
     /// ````
-    pub fn set_failure(&mut self, request: &mut GooseRawRequest) {
+    pub fn set_failure(&self, request: &mut GooseRawRequest) {
         // Only send update if this was previously a success.
         if request.success {
             request.success = false;
@@ -1297,11 +1299,11 @@ pub struct GooseTask {
     /// A flag indicating that this task runs when the client stops.
     pub on_stop: bool,
     /// A required function that is executed each time this task runs.
-    pub function: for<'r> fn(&'r mut GooseClient) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
+    pub function: for<'r> fn(&'r GooseClient) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
 }
 impl GooseTask {
     pub fn new(
-        function: for<'r> fn(&'r mut GooseClient) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
+        function: for<'r> fn(&'r GooseClient) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
     ) -> Self {
         trace!("new task");
         GooseTask {

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -665,10 +665,6 @@ pub struct GooseClient {
     pub weighted_on_start_tasks: Vec<Vec<usize>>,
     /// A weighted list of all tasks that this client runs once started.
     pub weighted_tasks: Vec<Vec<usize>>,
-    /// A pointer into which sequenced bucket the client is currently running tasks from.
-    pub weighted_bucket: usize,
-    /// A pointer of which task within the current sequenced bucket is currently running.
-    pub weighted_bucket_position: usize,
     /// A weighted list of all tasks that run when the client stops.
     pub weighted_on_stop_tasks: Vec<Vec<usize>>,
     /// Optional name of all requests made within the current task.
@@ -702,8 +698,6 @@ impl GooseClient {
             weighted_clients_index: usize::max_value(),
             weighted_on_start_tasks: Vec::new(),
             weighted_tasks: Vec::new(),
-            weighted_bucket: 0,
-            weighted_bucket_position: 0,
             weighted_on_stop_tasks: Vec::new(),
             task_request_name: None,
             request_name: None,
@@ -934,6 +928,7 @@ impl GooseClient {
     pub async fn goose_get(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
+            .client
             .lock()
             .await
             .get(&url)
@@ -961,6 +956,7 @@ impl GooseClient {
     pub async fn goose_post(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
+            .client
             .lock()
             .await
             .post(&url)
@@ -988,6 +984,7 @@ impl GooseClient {
     pub async fn goose_head(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
+            .client
             .lock()
             .await
             .head(&url)
@@ -1015,6 +1012,7 @@ impl GooseClient {
     pub async fn goose_put(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
+            .client
             .lock()
             .await
             .put(&url)
@@ -1042,6 +1040,7 @@ impl GooseClient {
     pub async fn goose_patch(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
+            .client
             .lock()
             .await
             .patch(&url)
@@ -1069,6 +1068,7 @@ impl GooseClient {
     pub async fn goose_delete(&mut self, path: &str) -> RequestBuilder {
         let url = self.build_url(path);
         CLIENT.read().await[self.weighted_clients_index]
+            .client
             .lock()
             .await
             .delete(&url)
@@ -1125,6 +1125,7 @@ impl GooseClient {
 
         // Make the actual request.
         let response = CLIENT.read().await[self.weighted_clients_index]
+            .client
             .lock()
             .await
             .execute(request)

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -72,7 +72,7 @@
 //!     let mut a_task = task!(task_function);
 //!
 //!     /// A very simple task that simply loads the front page.
-//!     async fn task_function(client: &mut GooseClient) {
+//!     async fn task_function(client: &GooseClient) {
 //!       let _response = client.get("/");
 //!     }
 //! ```
@@ -88,7 +88,7 @@
 //!     let mut a_task = task!(task_function).set_name("a");
 //!
 //!     /// A very simple task that simply loads the front page.
-//!     async fn task_function(client: &mut GooseClient) {
+//!     async fn task_function(client: &GooseClient) {
 //!       let _response = client.get("/");
 //!     }
 //! ```
@@ -106,12 +106,12 @@
 //!     let mut b_task = task!(b_task_function).set_weight(3);
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(client: &mut GooseClient) {
+//!     async fn a_task_function(client: &GooseClient) {
 //!       let _response = client.get("/a/");
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(client: &mut GooseClient) {
+//!     async fn b_task_function(client: &GooseClient) {
 //!       let _response = client.get("/b/");
 //!     }
 //! ```
@@ -134,17 +134,17 @@
 //!     let mut c_task = task!(c_task_function);
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(client: &mut GooseClient) {
+//!     async fn a_task_function(client: &GooseClient) {
 //!       let _response = client.get("/a/");
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(client: &mut GooseClient) {
+//!     async fn b_task_function(client: &GooseClient) {
 //!       let _response = client.get("/b/");
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "c" page.
-//!     async fn c_task_function(client: &mut GooseClient) {
+//!     async fn c_task_function(client: &GooseClient) {
 //!       let _response = client.get("/c/");
 //!     }
 //! ```
@@ -163,7 +163,7 @@
 //!     let mut a_task = task!(a_task_function).set_sequence(1).set_on_start();
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(client: &mut GooseClient) {
+//!     async fn a_task_function(client: &GooseClient) {
 //!       let _response = client.get("/a/");
 //!     }
 //! ```
@@ -182,7 +182,7 @@
 //!     let mut b_task = task!(b_task_function).set_sequence(2).set_on_stop();
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(client: &mut GooseClient) {
+//!     async fn b_task_function(client: &GooseClient) {
 //!       let _response = client.get("/b/");
 //!     }
 //! ```
@@ -210,7 +210,7 @@
 //!     let mut task = task!(get_function);
 //!
 //!     /// A very simple task that makes a GET request.
-//!     async  fn get_function(client: &mut GooseClient) {
+//!     async  fn get_function(client: &GooseClient) {
 //!       let _response = client.get("/path/to/foo/");
 //!     }
 //! ```
@@ -231,7 +231,7 @@
 //!     let mut task = task!(post_function);
 //!
 //!     /// A very simple task that makes a POST request.
-//!     async fn post_function(client: &mut GooseClient) {
+//!     async fn post_function(client: &GooseClient) {
 //!       let _response = client.post("/path/to/foo/", "string value to post".to_string());
 //!     }
 //! ```
@@ -342,7 +342,7 @@ impl GooseTaskSet {
     ///     example_tasks.register_task(task!(a_task_function));
     ///
     ///     /// A very simple task that simply loads the "a" page.
-    ///     async fn a_task_function(client: &mut GooseClient) {
+    ///     async fn a_task_function(client: &GooseClient) {
     ///       let _response = client.get("/a/");
     ///     }
     /// ```
@@ -705,6 +705,8 @@ impl GooseClient {
         }
     }
 
+    /*
+     * @TODO: fixme
     /// Sets a name for the next request made.
     ///
     /// One example use case of this is to group together requests to different URLs in the
@@ -720,7 +722,7 @@ impl GooseClient {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(client: &mut GooseClient) {
+    ///     async fn get_function(client: &GooseClient) {
     ///       let _response = client.set_request_name("foo").get("/path/to/foo");
     ///     }
     /// ```
@@ -733,7 +735,7 @@ impl GooseClient {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(client: &mut GooseClient) {
+    ///     async fn get_function(client: &GooseClient) {
     ///       let _response = client.set_request_name("foo").get("/path/to/foo").await;
     ///       let _response = client.get("/path/to/foo").await;
     ///     }
@@ -746,6 +748,7 @@ impl GooseClient {
         }
         self
     }
+    */
 
     /// A helper that pre-pends a hostname to the path. For example, if you pass in `/foo`
     /// and `--host` is set to `http://127.0.0.1` it will return `http://127.0.0.1/foo`.
@@ -810,7 +813,7 @@ impl GooseClient {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(client: &mut GooseClient) {
+    ///     async fn get_function(client: &GooseClient) {
     ///       let _response = client.get("/path/to/foo/");
     ///     }
     /// ```
@@ -839,7 +842,7 @@ impl GooseClient {
     ///     let mut task = task!(post_function);
     ///
     ///     /// A very simple task that makes a POST request.
-    ///     async fn post_function(client: &mut GooseClient) {
+    ///     async fn post_function(client: &GooseClient) {
     ///       let _response = client.post("/path/to/foo/", "BODY BEING POSTED".to_string());
     ///     }
     /// ```
@@ -868,7 +871,7 @@ impl GooseClient {
     ///     let mut task = task!(head_function);
     ///
     ///     /// A very simple task that makes a HEAD request.
-    ///     async fn head_function(client: &mut GooseClient) {
+    ///     async fn head_function(client: &GooseClient) {
     ///       let _response = client.head("/path/to/foo/");
     ///     }
     /// ```
@@ -897,7 +900,7 @@ impl GooseClient {
     ///     let mut task = task!(delete_function);
     ///
     ///     /// A very simple task that makes a DELETE request.
-    ///     async fn delete_function(client: &mut GooseClient) {
+    ///     async fn delete_function(client: &GooseClient) {
     ///       let _response = client.delete("/path/to/foo/");
     ///     }
     /// ```
@@ -920,7 +923,7 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn get_function(client: &mut GooseClient) {
+    ///     async fn get_function(client: &GooseClient) {
     ///       let request_builder = client.goose_get("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
@@ -948,7 +951,7 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a POST request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn post_function(client: &mut GooseClient) {
+    ///     async fn post_function(client: &GooseClient) {
     ///       let request_builder = client.goose_post("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
@@ -976,7 +979,7 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a HEAD request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn head_function(client: &mut GooseClient) {
+    ///     async fn head_function(client: &GooseClient) {
     ///       let request_builder = client.goose_head("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
@@ -1004,7 +1007,7 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a PUT request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn put_function(client: &mut GooseClient) {
+    ///     async fn put_function(client: &GooseClient) {
     ///       let request_builder = client.goose_put("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
@@ -1032,8 +1035,8 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a PUT request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn patch_function(client: &mut GooseClient) {
-    ///       let request_builder = client.goose_patch("/path/to/foo");
+    ///     async fn patch_function(client: &GooseClient) {
+    ///       let request_builder = client.goose_patch("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
@@ -1060,8 +1063,8 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a DELETE request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn delete_function(client: &mut GooseClient) {
-    ///       let request_builder = client.goose_delete("/path/to/foo");
+    ///     async fn delete_function(client: &GooseClient) {
+    ///       let request_builder = client.goose_delete("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
     /// ```
@@ -1096,7 +1099,7 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn get_function(client: &mut GooseClient) {
+    ///     async fn get_function(client: &GooseClient) {
     ///       let request_builder = client.goose_get("/path/to/foo").await;
     ///       let response = client.goose_send(request_builder).await;
     ///     }
@@ -1212,7 +1215,7 @@ impl GooseClient {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A simple task that makes a GET request.
-    ///     async fn get_function(client: &mut GooseClient) {
+    ///     async fn get_function(client: &GooseClient) {
     ///         let mut response = client.get("/404").await;
     ///         match &response.response {
     ///             Ok(r) => {
@@ -1247,8 +1250,9 @@ impl GooseClient {
     ///
     ///     let mut task = task!(loadtest_index_page);
     ///
-    ///     async fn loadtest_index_page(client: &mut GooseClient) {
-    ///         let mut response = client.set_request_name("index").get("/").await;
+    ///     async fn loadtest_index_page(client: &GooseClient) {
+    ///         //let mut response = client.set_request_name("index").get("/").await;
+    ///         let mut response = client.get("/").await;
     ///         // Extract the response Result.
     ///         match response.response {
     ///             Ok(r) => {
@@ -1329,7 +1333,7 @@ impl GooseTask {
     ///
     ///     task!(my_task_function).set_name("foo");
     ///
-    ///     async fn my_task_function(client: &mut GooseClient) {
+    ///     async fn my_task_function(client: &GooseClient) {
     ///       let _response = client.get("/");
     ///     }
     /// ```
@@ -1355,7 +1359,7 @@ impl GooseTask {
     ///
     ///     task!(my_on_start_function).set_on_start();
     ///
-    ///     async fn my_on_start_function(client: &mut GooseClient) {
+    ///     async fn my_on_start_function(client: &GooseClient) {
     ///       let _response = client.get("/");
     ///     }
     /// ```
@@ -1381,7 +1385,7 @@ impl GooseTask {
     ///
     ///     task!(my_on_stop_function).set_on_stop();
     ///
-    ///     async fn my_on_stop_function(client: &mut GooseClient) {
+    ///     async fn my_on_stop_function(client: &GooseClient) {
     ///       let _response = client.get("/");
     ///     }
     /// ```
@@ -1401,7 +1405,7 @@ impl GooseTask {
     ///
     ///     task!(task_function).set_weight(3);
     ///
-    ///     async fn task_function(client: &mut GooseClient) {
+    ///     async fn task_function(client: &GooseClient) {
     ///       let _response = client.get("/");
     ///     }
     /// ```
@@ -1438,15 +1442,15 @@ impl GooseTask {
     ///     let runs_second = task!(second_task_function).set_sequence(5835);
     ///     let runs_last = task!(third_task_function);
     ///
-    ///     async fn first_task_function(client: &mut GooseClient) {
+    ///     async fn first_task_function(client: &GooseClient) {
     ///       let _response = client.get("/1");
     ///     }
     ///
-    ///     async fn second_task_function(client: &mut GooseClient) {
+    ///     async fn second_task_function(client: &GooseClient) {
     ///       let _response = client.get("/2");
     ///     }
     ///
-    ///     async fn third_task_function(client: &mut GooseClient) {
+    ///     async fn third_task_function(client: &GooseClient) {
     ///       let _response = client.get("/3");
     ///     }
     /// ```
@@ -1462,15 +1466,15 @@ impl GooseTask {
     ///     let runs_second = task!(second_task_function_a).set_sequence(2);
     ///     let also_runs_second = task!(second_task_function_b).set_sequence(2).set_weight(2);
     ///
-    ///     async fn first_task_function(client: &mut GooseClient) {
+    ///     async fn first_task_function(client: &GooseClient) {
     ///       let _response = client.get("/1");
     ///     }
     ///
-    ///     async fn second_task_function_a(client: &mut GooseClient) {
+    ///     async fn second_task_function_a(client: &GooseClient) {
     ///       let _response = client.get("/2a");
     ///     }
     ///
-    ///     async fn second_task_function_b(client: &mut GooseClient) {
+    ///     async fn second_task_function_b(client: &GooseClient) {
     ///       let _response = client.get("/2b");
     ///     }
     /// ```
@@ -1509,11 +1513,11 @@ mod tests {
     #[test]
     fn goose_task_set() {
         // Simplistic test task functions.
-        async fn test_function_a(client: &mut GooseClient) -> () {
+        async fn test_function_a(client: &GooseClient) -> () {
             let _response = client.get("/a/").await;
         }
 
-        async fn test_function_b(client: &mut GooseClient) -> () {
+        async fn test_function_b(client: &GooseClient) -> () {
             let _response = client.get("/b/").await;
         }
 
@@ -1606,7 +1610,7 @@ mod tests {
     #[test]
     fn goose_task() {
         // Simplistic test task functions.
-        async fn test_function_a(client: &mut GooseClient) -> () {
+        async fn test_function_a(client: &GooseClient) -> () {
             let _response = client.get("/a/");
         }
 
@@ -1916,11 +1920,11 @@ mod tests {
         assert_eq!(request.response_time_counter, 8);
     }
 
-    #[test]
-    fn goose_client() {
+    #[tokio::test]
+    async fn goose_client() {
+        //crate::GooseClientState::initialize(1).await;
         let configuration = GooseConfiguration::default();
-        let mut client = GooseClient::new(
-            0,
+        let client = GooseClient::new(
             0,
             Some("http://example.com/".to_string()),
             None,
@@ -1937,15 +1941,14 @@ mod tests {
         assert_eq!(client.weighted_clients_index, usize::max_value());
         assert_eq!(client.weighted_on_start_tasks.len(), 0);
         assert_eq!(client.weighted_tasks.len(), 0);
-        assert_eq!(client.weighted_bucket, 0);
-        assert_eq!(client.weighted_bucket_position, 0);
         assert_eq!(client.weighted_on_stop_tasks.len(), 0);
         assert_eq!(client.task_request_name, None);
         assert_eq!(client.request_name, None);
 
         // Setting request name doesn't affect anything else.
-        client.set_request_name("foo");
-        assert_eq!(client.request_name, Some("foo".to_string()));
+        // @TODO: fixme
+        //client.set_request_name("foo");
+        //assert_eq!(client.request_name, Some("foo".to_string()));
         assert_eq!(client.task_sets_index, 0);
         assert_eq!(client.default_host, Some("http://example.com/".to_string()));
         assert_eq!(client.task_set_host, None);
@@ -1954,14 +1957,13 @@ mod tests {
         assert_eq!(client.weighted_clients_index, usize::max_value());
         assert_eq!(client.weighted_on_start_tasks.len(), 0);
         assert_eq!(client.weighted_tasks.len(), 0);
-        assert_eq!(client.weighted_bucket, 0);
-        assert_eq!(client.weighted_bucket_position, 0);
         assert_eq!(client.weighted_on_stop_tasks.len(), 0);
         assert_eq!(client.task_request_name, None);
 
         // Can set request name multiple times.
-        client.set_request_name("bar");
-        assert_eq!(client.request_name, Some("bar".to_string()));
+        // @OTOD: fixme
+        //client.set_request_name("bar");
+        //assert_eq!(client.request_name, Some("bar".to_string()));
 
         // Confirm the URLs are correctly built using the default_host.
         let url = client.build_url("/foo");
@@ -1978,8 +1980,7 @@ mod tests {
         assert_eq!(url, "https://www.example.com/path/to/resource");
 
         // Create a second client, this time setting a task_set_host.
-        let mut client2 = GooseClient::new(
-            0,
+        let client2 = GooseClient::new(
             0,
             Some("http://www.example.com/".to_string()),
             Some("http://www2.example.com/".to_string()),
@@ -2007,15 +2008,17 @@ mod tests {
         let url = client.build_url("https://example.com/foo");
         assert_eq!(url, "https://example.com/foo");
 
+        /*
+         * @TODO: fixme
         // Create a GET request.
-        let mut goose_request = client.goose_get("/foo");
+        let mut goose_request = client.goose_get("/foo").await;
         let mut built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::GET);
         assert_eq!(built_request.url().as_str(), "http://example.com/foo");
         assert_eq!(built_request.timeout(), None);
 
         // Create a POST request.
-        goose_request = client.goose_post("/path/to/post");
+        goose_request = client.goose_post("/path/to/post").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::POST);
         assert_eq!(
@@ -2025,7 +2028,7 @@ mod tests {
         assert_eq!(built_request.timeout(), None);
 
         // Create a PUT request.
-        goose_request = client.goose_put("/path/to/put");
+        goose_request = client.goose_put("/path/to/put").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::PUT);
         assert_eq!(
@@ -2035,7 +2038,7 @@ mod tests {
         assert_eq!(built_request.timeout(), None);
 
         // Create a PATCH request.
-        goose_request = client.goose_patch("/path/to/patch");
+        goose_request = client.goose_patch("/path/to/patch").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::PATCH);
         assert_eq!(
@@ -2045,7 +2048,7 @@ mod tests {
         assert_eq!(built_request.timeout(), None);
 
         // Create a DELETE request.
-        goose_request = client.goose_delete("/path/to/delete");
+        goose_request = client.goose_delete("/path/to/delete").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::DELETE);
         assert_eq!(
@@ -2055,7 +2058,7 @@ mod tests {
         assert_eq!(built_request.timeout(), None);
 
         // Create a HEAD request.
-        goose_request = client.goose_head("/path/to/head");
+        goose_request = client.goose_head("/path/to/head").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::HEAD);
         assert_eq!(
@@ -2063,5 +2066,6 @@ mod tests {
             "http://example.com/path/to/head"
         );
         assert_eq!(built_request.timeout(), None);
+        */
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! use goose::prelude::*;
 //!
 //! async fn loadtest_foo(client: &GooseClient) {
-//!   let _response = client.get("/path/to/foo");
+//!   let _response = client.get("/path/to/foo", None);
 //! }   
 //! ```
 //!
@@ -70,7 +70,7 @@
 //!
 //! async fn loadtest_bar(client: &GooseClient) {
 //!   let request_builder = client.goose_get("/path/to/bar").await;
-//!   let _response = client.goose_send(request_builder.timeout(time::Duration::from_secs(3))).await;
+//!   let _response = client.goose_send(request_builder.timeout(time::Duration::from_secs(3)), None).await;
 //! }   
 //! ```
 //!
@@ -100,11 +100,11 @@
 //!     .execute();
 //!
 //! async fn loadtest_foo(client: &GooseClient) {
-//!   let _response = client.get("/path/to/foo");
+//!   let _response = client.get("/path/to/foo", None);
 //! }   
 //!
 //! async fn loadtest_bar(client: &GooseClient) {
-//!   let _response = client.get("/path/to/bar");
+//!   let _response = client.get("/path/to/bar", None);
 //! }   
 //! ```
 //!
@@ -589,11 +589,11 @@ impl GooseAttack {
     ///         );
     ///
     ///     async fn example_task(client: &GooseClient) {
-    ///       let _response = client.get("/foo");
+    ///       let _response = client.get("/foo", None);
     ///     }
     ///
     ///     async fn other_task(client: &GooseClient) {
-    ///       let _response = client.get("/bar");
+    ///       let _response = client.get("/bar", None);
     ///     }
     /// ```
     pub fn register_taskset(mut self, mut taskset: GooseTaskSet) -> Self {
@@ -700,11 +700,11 @@ impl GooseAttack {
     ///         .execute();
     ///
     ///     async fn example_task(client: &GooseClient) {
-    ///       let _response = client.get("/foo");
+    ///       let _response = client.get("/foo", None);
     ///     }
     ///
     ///     async fn another_example_task(client: &GooseClient) {
-    ///       let _response = client.get("/bar");
+    ///       let _response = client.get("/bar", None);
     ///     }
     /// ```
     pub fn execute(mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! use goose::prelude::*;
 //!
 //! async fn loadtest_foo(client: &GooseClient) {
-//!   let _response = client.get("/path/to/foo", None);
+//!   let _response = client.get("/path/to/foo");
 //! }   
 //! ```
 //!
@@ -100,11 +100,11 @@
 //!     .execute();
 //!
 //! async fn loadtest_foo(client: &GooseClient) {
-//!   let _response = client.get("/path/to/foo", None);
+//!   let _response = client.get("/path/to/foo");
 //! }   
 //!
 //! async fn loadtest_bar(client: &GooseClient) {
-//!   let _response = client.get("/path/to/bar", None);
+//!   let _response = client.get("/path/to/bar");
 //! }   
 //! ```
 //!
@@ -589,11 +589,11 @@ impl GooseAttack {
     ///         );
     ///
     ///     async fn example_task(client: &GooseClient) {
-    ///       let _response = client.get("/foo", None);
+    ///       let _response = client.get("/foo");
     ///     }
     ///
     ///     async fn other_task(client: &GooseClient) {
-    ///       let _response = client.get("/bar", None);
+    ///       let _response = client.get("/bar");
     ///     }
     /// ```
     pub fn register_taskset(mut self, mut taskset: GooseTaskSet) -> Self {
@@ -700,11 +700,11 @@ impl GooseAttack {
     ///         .execute();
     ///
     ///     async fn example_task(client: &GooseClient) {
-    ///       let _response = client.get("/foo", None);
+    ///       let _response = client.get("/foo");
     ///     }
     ///
     ///     async fn another_example_task(client: &GooseClient) {
-    ///       let _response = client.get("/bar", None);
+    ///       let _response = client.get("/bar");
     ///     }
     /// ```
     pub fn execute(mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use simplelog::*;
 use structopt::StructOpt;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::mpsc;
 use url::Url;
 
 use crate::goose::{
@@ -339,9 +339,8 @@ static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_P
 static mut CLIENT: Vec<GooseClientState> = Vec::new();
 
 struct GooseClientState {
-    /// A Reqwest client, wrapped in a Mutex as a read-write copy is always needed to
-    /// manage things like sessions and cookies.
-    client: Mutex<Client>,
+    /// A Reqwest client used to manage things like sessions and cookies.
+    client: Client,
     /// Integer value indicating which sequenced bucket the client is currently running
     /// tasks from.
     weighted_bucket: AtomicUsize,
@@ -360,7 +359,7 @@ impl GooseClientState {
                     .user_agent(APP_USER_AGENT)
                     .cookie_store(true);
                 let client = match builder.build() {
-                    Ok(c) => Mutex::new(c),
+                    Ok(c) => c,
                     Err(e) => {
                         error!("failed to build client: {}", e);
                         std::process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,10 +343,10 @@ struct GooseClientState {
     client: Client,
     /// Integer value indicating which sequenced bucket the client is currently running
     /// tasks from.
-    weighted_bucket: AtomicUsize,
+    weighted_bucket: usize,
     /// Integer value indicating which task within the current sequenced bucket is currently
     /// running.
-    weighted_bucket_position: AtomicUsize,
+    weighted_bucket_position: usize,
 }
 impl GooseClientState {
     // Initialize one client per thread.
@@ -368,8 +368,8 @@ impl GooseClientState {
                 // Push the new client into the global client vector.
                 CLIENT.push(GooseClientState {
                     client,
-                    weighted_bucket: AtomicUsize::new(0),
-                    weighted_bucket_position: AtomicUsize::new(0),
+                    weighted_bucket: 0,
+                    weighted_bucket_position: 0,
                 });
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! ```rust
 //! use goose::prelude::*;
 //!
-//! async fn loadtest_foo(client: &mut GooseClient) {
+//! async fn loadtest_foo(client: &GooseClient) {
 //!   let _response = client.get("/path/to/foo");
 //! }   
 //! ```
@@ -68,8 +68,8 @@
 //!
 //! use goose::prelude::*;
 //!
-//! async fn loadtest_bar(client: &mut GooseClient) {
-//!   let request_builder = client.goose_get("/path/to/bar");
+//! async fn loadtest_bar(client: &GooseClient) {
+//!   let request_builder = client.goose_get("/path/to/bar").await;
 //!   let _response = client.goose_send(request_builder.timeout(time::Duration::from_secs(3))).await;
 //! }   
 //! ```
@@ -99,11 +99,11 @@
 //!     //.set_host("http://dev.local/")
 //!     .execute();
 //!
-//! async fn loadtest_foo(client: &mut GooseClient) {
+//! async fn loadtest_foo(client: &GooseClient) {
 //!   let _response = client.get("/path/to/foo");
 //! }   
 //!
-//! async fn loadtest_bar(client: &mut GooseClient) {
+//! async fn loadtest_bar(client: &GooseClient) {
 //!   let _response = client.get("/path/to/bar");
 //! }   
 //! ```
@@ -588,11 +588,11 @@ impl GooseAttack {
     ///             .register_task(task!(other_task))
     ///         );
     ///
-    ///     async fn example_task(client: &mut GooseClient) {
+    ///     async fn example_task(client: &GooseClient) {
     ///       let _response = client.get("/foo");
     ///     }
     ///
-    ///     async fn other_task(client: &mut GooseClient) {
+    ///     async fn other_task(client: &GooseClient) {
     ///       let _response = client.get("/bar");
     ///     }
     /// ```
@@ -699,11 +699,11 @@ impl GooseAttack {
     ///         )
     ///         .execute();
     ///
-    ///     async fn example_task(client: &mut GooseClient) {
+    ///     async fn example_task(client: &GooseClient) {
     ///       let _response = client.get("/foo");
     ///     }
     ///
-    ///     async fn another_example_task(client: &mut GooseClient) {
+    ///     async fn another_example_task(client: &GooseClient) {
     ///       let _response = client.get("/bar");
     ///     }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -623,7 +623,6 @@ impl GooseAttack {
             for task_sets_index in &weighted_task_sets {
                 let task_set_host = self.task_sets[*task_sets_index].host.clone();
                 weighted_clients.push(GooseClient::new(
-                    client_count,
                     self.task_sets[*task_sets_index].task_sets_index,
                     self.host.clone(),
                     task_set_host,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -127,7 +127,6 @@ pub fn worker_main(goose_attack: &GooseAttack) {
                 worker_id = initializer.worker_id;
             }
             weighted_clients.push(GooseClient::new(
-                weighted_clients.len(),
                 initializer.task_sets_index,
                 initializer.default_host.clone(),
                 initializer.task_set_host.clone(),


### PR DESCRIPTION
Rust makes us wrap the global client object in locks to ensure we're using it safely, but in reality our code enforces that each client only modifies its own GooseClientState, so we don't _need_ the locks. This is an experimental branch to see how much overhead the locks actually have.

 - the first commit removed the RWLock
 - the second commit removed the Mutex around the Reqwest Client
 - the third commit removed the Atomics
 - performance tests were run after each commit: there was no measurable performance improvement (if anything, there was a small performance penalty: perhaps the Rust compiler is less-able to optimize when we use unsafe?)
 - raw statistics are on the right side of this tab in this document: https://docs.google.com/spreadsheets/d/18qW_ZTWeY5apSSIeGhT298DzVA0IIs2kHxq9wAbkgGE/edit#gid=2009779167