### PR TITLE
fix #45 run optional test_start_task and test_stop_task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3-dev
  - move client out of GooseClient into global GooseClientState
+ - introduce `test_start_task` and `test_stop_task` allowing global setup and teardown
 
 ## 0.7.2 June 1, 2020
  - don't shuffle order of weighted task sets when launching clients


### PR DESCRIPTION
Required for a client load test, adds ability to define an optional `test_start_task` and/or an optional `test_stop_task`. These tasks are only run one time. If running in a Gaggle, the tasks are run by the Manager process.

### Example
```rust
use goose::prelude::*;

fn main() {
    GooseAttack::initialize()
        .test_start(task!(setup))
        .register_taskset(taskset!("FooTasks")
            .register_task(task!(foo_task))
        )
        .test_stop(task!(teardown))
        .execute();
}

async fn setup(client: &GooseClient) {
    // do stuff to set up the load test ...
}

async fn teardown(client: &GooseClient) {
    // do stuff to tear down the load test ...
}

async fn foo_task(client: &GooseClient) {
    // this is a normal load test task ...
    client.get("/foo");
}
```