### PR TITLE
fix #44 dont panic if there are no normal tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.3-dev
  - move client out of GooseClient into global GooseClientState
  - introduce `test_start_task` and `test_stop_task` allowing global setup and teardown
+ - don't panic if a load test doesn't define any normal tasks
 
 ## 0.7.2 June 1, 2020
  - don't shuffle order of weighted task sets when launching clients

--- a/src/client.rs
+++ b/src/client.rs
@@ -60,6 +60,10 @@ pub async fn client_main(
     let mut weighted_bucket_position = CLIENT.read().await[thread_client.weighted_clients_index]
         .weighted_bucket_position
         .load(Ordering::SeqCst);
+    if thread_client.weighted_tasks.is_empty() {
+        // Handle the edge case where a load test doesn't define any normal tasks.
+        thread_continue = false;
+    }
     while thread_continue {
         // Weighted_tasks is divided into buckets of tasks sorted by sequence, and then all non-sequenced tasks.
         if thread_client.weighted_tasks[weighted_bucket].len() <= weighted_bucket_position {


### PR DESCRIPTION
 - allow a load-test to be just `on_start` and/or `on_exit` tasks