### PR TITLE
mock http server and automate test of actual load test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ nng = { version = "0.5", optional = true }
 
 [features]
 gaggle = ["nng"]
+
+[dev-dependencies]
+httpmock = "0.3"

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1233,7 +1233,7 @@ impl GooseClient {
                         std::process::exit(1);
                     }
                 }
-            },
+            }
             // No parent thread is defined when running test_start_task,
             // test_stop_task, and during testing.
             None => (),
@@ -1568,8 +1568,15 @@ mod tests {
         // Set up global client state.
         crate::GooseClientState::initialize(1).await;
         let configuration = GooseConfiguration::default();
-        let mut client =
-            GooseClient::new(0, Some("http://127.0.0.1:5000".to_string()), None, 0, 0, &configuration, 0);
+        let mut client = GooseClient::new(
+            0,
+            Some("http://127.0.0.1:5000".to_string()),
+            None,
+            0,
+            0,
+            &configuration,
+            0,
+        );
         client.weighted_clients_index = 0;
         client
     }
@@ -2118,9 +2125,7 @@ mod tests {
         let client = setup_client().await;
 
         // Set up a mock http server endpoint.
-        let mock_index = mock(GET, "/")
-            .return_status(200)
-            .create();
+        let mock_index = mock(GET, "/").return_status(200).create();
 
         // Make a GET request to the mock http server and confirm we get a 200 response.
         assert_eq!(mock_index.times_called(), 0);
@@ -2134,9 +2139,7 @@ mod tests {
         assert_eq!(response.request.update, false);
         assert_eq!(response.request.status_code, Some(http::StatusCode::OK));
 
-        let mock_404 = mock(GET, "/no/such/path")
-            .return_status(404)
-            .create();
+        let mock_404 = mock(GET, "/no/such/path").return_status(404).create();
 
         // Make an invalid GET request to the mock http server and confirm we get a 404 response.
         assert_eq!(mock_404.times_called(), 0);
@@ -2148,7 +2151,10 @@ mod tests {
         assert_eq!(response.request.name, "/no/such/path");
         assert_eq!(response.request.success, false);
         assert_eq!(response.request.update, false);
-        assert_eq!(response.request.status_code, Some(http::StatusCode::NOT_FOUND));
+        assert_eq!(
+            response.request.status_code,
+            Some(http::StatusCode::NOT_FOUND)
+        );
 
         // Set up a mock http server endpoint.
         let mock_comment = mock(POST, "/comment")
@@ -2208,9 +2214,7 @@ mod tests {
             manager_port: 5115,
         };
 
-        let mock_index = mock(GET, "/")
-            .return_status(200)
-            .create();
+        let mock_index = mock(GET, "/").return_status(200).create();
         let mock_about = mock(GET, "/about.html")
             .return_status(200)
             .return_body("<HTML><BODY>about page</BODY></HTML>")
@@ -2218,9 +2222,10 @@ mod tests {
 
         crate::GooseAttack::initialize_with_config(configuration)
             .setup()
-            .register_taskset(taskset!("LoadTest")
-                .register_task(task!(task_a).set_weight(9))
-                .register_task(task!(task_b).set_weight(3))
+            .register_taskset(
+                taskset!("LoadTest")
+                    .register_task(task!(task_a).set_weight(9))
+                    .register_task(task!(task_b).set_weight(3)),
             )
             .execute();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,7 +514,7 @@ impl GooseAttack {
         ]) {
             Ok(_) => (),
             Err(e) => {
-                error!("failed to initialize CombinedLogger: {}", e);
+                info!("failed to initialize CombinedLogger: {}", e);
             }
         }
         info!("Output verbosity level: {}", debug_level);
@@ -1164,7 +1164,7 @@ impl GooseAttack {
                             debug!("telling client {} to exit", index);
                         }
                         Err(e) => {
-                            warn!("failed to tell client {} to exit: {}", index, e);
+                            info!("failed to tell client {} to exit: {}", index, e);
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,7 @@ impl GooseAttack {
         }
     }
 
-    pub fn setup(mut self) -> Self {
+    pub fn initialize_logger(&self) {
         // Allow optionally controlling debug output level
         let debug_level;
         match self.configuration.verbose {
@@ -497,14 +497,13 @@ impl GooseAttack {
 
         let log_file = PathBuf::from(&self.configuration.log_file);
 
-        // @TODO: get rid of unwrap(), TermLogger fails if there's no terminal.
         match CombinedLogger::init(vec![
             match TermLogger::new(debug_level, Config::default(), TerminalMode::Mixed) {
                 Some(t) => t,
                 None => {
                     // Print this message, we don't have a logger yet.
                     eprintln!("failed to initialize TermLogger");
-                    std::process::exit(1);
+                    return;
                 }
             },
             WriteLogger::new(
@@ -521,6 +520,10 @@ impl GooseAttack {
         info!("Output verbosity level: {}", debug_level);
         info!("Logfile verbosity level: {}", log_level);
         info!("Writing to log file: {}", log_file.display());
+    }
+
+    pub fn setup(mut self) -> Self {
+        self.initialize_logger();
 
         // Don't allow overhead of collecting status codes unless we're printing statistics.
         if self.configuration.status_codes && self.configuration.no_stats {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1040,38 +1040,30 @@ impl GooseAttack {
             ) = mpsc::unbounded_channel();
             client_channels.push(parent_sender);
 
-            // We can only launch tasks if the task list is non-empty
-            if !thread_client.weighted_tasks.is_empty() {
-                // Copy the client-to-parent sender channel, used by all threads.
-                thread_client.parent = Some(all_threads_sender.clone());
+            // Copy the client-to-parent sender channel, used by all threads.
+            thread_client.parent = Some(all_threads_sender.clone());
 
-                // Copy the appropriate task_set into the thread.
-                let thread_task_set = self.task_sets[thread_client.task_sets_index].clone();
+            // Copy the appropriate task_set into the thread.
+            let thread_task_set = self.task_sets[thread_client.task_sets_index].clone();
 
-                // We number threads from 1 as they're human-visible (in the logs), whereas active_clients starts at 0.
-                let thread_number = self.active_clients + 1;
+            // We number threads from 1 as they're human-visible (in the logs), whereas active_clients starts at 0.
+            let thread_number = self.active_clients + 1;
 
-                let is_worker = self.configuration.worker;
+            let is_worker = self.configuration.worker;
 
-                // Launch a new client.
-                let client = tokio::spawn(client::client_main(
-                    thread_number,
-                    thread_task_set,
-                    thread_client,
-                    thread_receiver,
-                    is_worker,
-                ));
+            // Launch a new client.
+            let client = tokio::spawn(client::client_main(
+                thread_number,
+                thread_task_set,
+                thread_client,
+                thread_receiver,
+                is_worker,
+            ));
 
-                clients.push(client);
-                self.active_clients += 1;
-                debug!("sleeping {:?} milliseconds...", sleep_duration);
-                tokio::time::delay_for(sleep_duration).await;
-            } else {
-                warn!(
-                    "no tasks for thread {} to run",
-                    self.task_sets[thread_client.task_sets_index].name
-                );
-            }
+            clients.push(client);
+            self.active_clients += 1;
+            debug!("sleeping {:?} milliseconds...", sleep_duration);
+            tokio::time::delay_for(sleep_duration).await;
         }
         // Restart the timer now that all threads are launched.
         started = time::Instant::now();
@@ -1445,8 +1437,10 @@ fn weight_tasks(task_set: &GooseTaskSet) -> (Vec<Vec<usize>>, Vec<Vec<usize>>, V
         let mut tasks = vec![task.tasks_index; weight];
         weighted_unsequenced_tasks.append(&mut tasks);
     }
-    // Unsequenced tasks come lost.
-    weighted_tasks.push(weighted_unsequenced_tasks);
+    // Unsequenced tasks come last.
+    if !weighted_unsequenced_tasks.is_empty() {
+        weighted_tasks.push(weighted_unsequenced_tasks);
+    }
 
     // Apply weight to on_start sequenced tasks.
     let mut weighted_on_start_tasks: Vec<Vec<usize>> = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,7 +502,8 @@ impl GooseAttack {
             match TermLogger::new(debug_level, Config::default(), TerminalMode::Mixed) {
                 Some(t) => t,
                 None => {
-                    error!("failed to initialize TermLogger");
+                    // Print this message, we don't have a logger yet.
+                    eprintln!("failed to initialize TermLogger");
                     std::process::exit(1);
                 }
             },

--- a/src/util.rs
+++ b/src/util.rs
@@ -118,7 +118,7 @@ pub fn setup_ctrlc_handler(canceled: &Arc<AtomicBool>) {
     }) {
         Ok(_) => (),
         Err(e) => {
-            warn!("failed to set ctrl-c handler: {}", e);
+            info!("failed to set ctrl-c handler: {}", e);
         }
     }
 }


### PR DESCRIPTION
I started with https://docs.rs/wiremock/ but didn't find a way to control which port it listens on: I like the idea of auto-selecting a port, but I didn't have a way to then pass this into the load test functions.

I then switched to https://docs.rs/httptest/ which is simple and has worked great.

Tests are working locally, debugging why they're failing here.