### PR TITLE
cleanup and bug fixing

### DIFF
--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1225,19 +1225,20 @@ impl GooseClient {
     }
 
     fn send_to_parent(&self, raw_request: &GooseRawRequest) {
-        let parent = match self.parent.clone() {
-            Some(p) => p,
-            None => {
-                error!("unable to communicate with parent thread, exiting");
-                std::process::exit(1);
+        match self.parent.clone() {
+            Some(p) => {
+                let parent = p;
+                match parent.send(raw_request.clone()) {
+                    Ok(_) => (),
+                    Err(e) => {
+                        info!("unable to communicate with parent thread, exiting: {}", e);
+                        std::process::exit(1);
+                    }
+                }
             }
-        };
-        match parent.send(raw_request.clone()) {
-            Ok(_) => (),
-            Err(e) => {
-                error!("unable to communicate with parent thread, exiting: {}", e);
-                std::process::exit(1);
-            }
+            // Parent is not defined when running test_start_task, test_stop_task,
+            // and during testing.
+            None => (),
         }
     }
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1200,15 +1200,12 @@ impl GooseClient {
             match &response {
                 Ok(r) => {
                     let status_code = r.status();
-                    // Only increment status_code_counts if we're displaying the results
-                    if self.config.status_codes {
-                        raw_request.set_status_code(Some(status_code));
-                    }
                     debug!("{:?}: status_code {}", &path, status_code);
                     // @TODO: match/handle all is_foo() https://docs.rs/http/0.2.1/http/status/struct.StatusCode.html
                     if !status_code.is_success() {
                         raw_request.success = false;
                     }
+                    raw_request.set_status_code(Some(status_code));
                 }
                 Err(e) => {
                     // @TODO: what can we learn from a reqwest error?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1167,7 +1167,7 @@ impl GooseAttack {
                             debug!("telling client {} to exit", index);
                         }
                         Err(e) => {
-                            warn!("failed to tell client {} to exit: {}", index, e);
+                            info!("failed to tell client {} to exit: {}", index, e);
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,7 @@ impl GooseAttack {
         }
     }
 
-    pub fn setup(mut self) -> Self {
+    pub fn initialize_logger(&self) {
         // Allow optionally controlling debug output level
         let debug_level;
         match self.configuration.verbose {
@@ -497,13 +497,12 @@ impl GooseAttack {
 
         let log_file = PathBuf::from(&self.configuration.log_file);
 
-        // @TODO: get rid of unwrap(), TermLogger fails if there's no terminal.
         match CombinedLogger::init(vec![
             match TermLogger::new(debug_level, Config::default(), TerminalMode::Mixed) {
                 Some(t) => t,
                 None => {
-                    error!("failed to initialize TermLogger");
-                    std::process::exit(1);
+                    eprintln!("failed to initialize TermLogger");
+                    return;
                 }
             },
             WriteLogger::new(
@@ -514,12 +513,16 @@ impl GooseAttack {
         ]) {
             Ok(_) => (),
             Err(e) => {
-                error!("failed to initialize CombinedLogger: {}", e);
+                info!("failed to initialize CombinedLogger: {}", e);
             }
         }
         info!("Output verbosity level: {}", debug_level);
         info!("Logfile verbosity level: {}", log_level);
         info!("Writing to log file: {}", log_file.display());
+    }
+
+    pub fn setup(mut self) -> Self {
+        self.initialize_logger();
 
         // Don't allow overhead of collecting status codes unless we're printing statistics.
         if self.configuration.status_codes && self.configuration.no_stats {

--- a/src/util.rs
+++ b/src/util.rs
@@ -118,7 +118,7 @@ pub fn setup_ctrlc_handler(canceled: &Arc<AtomicBool>) {
     }) {
         Ok(_) => (),
         Err(e) => {
-            warn!("failed to set ctrl-c handler: {}", e);
+            info!("failed to set ctrl-c handler: {}", e);
         }
     }
 }


### PR DESCRIPTION
 - [bugfix] send_to_parent can only send messages if there is a parent
 - [bugfix] always store status_code in raw-request
 - [cleanup] a task set can have on_start or on_exit tasks, so don't exist if the task list is empty, the client can handle
 - [cleanup] reduce severity of non-critical issues
 - [bugfix] don't exit if we fail to setup logger (this can happen in testing environments)