### PR TITLE
properly initialize global state so gaggles work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.7.4-dev
- -
+ - fix gaggles to not panic
 
 ## 0.7.3 June 5, 2020
  - move client out of GooseClient into global GooseClientState

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1003,9 +1003,10 @@ impl GooseAttack {
                 // No test_start_task defined, nothing to do.
                 None => (),
             }
-
-            GooseClientState::initialize(self.weighted_clients.len()).await;
         }
+
+        // Initial globa client state.
+        GooseClientState::initialize(self.weighted_clients.len()).await;
 
         // Collect client threads in a vector for when we want to stop them later.
         let mut clients = vec![];


### PR DESCRIPTION
 - always initialize global state (otherwise gaggles panic)
 - don't exit worker process if manager process goes away during shutdown

These fixes are required for #56 