### PR TITLE
release 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 0.7.4-dev
- - fix gaggles to not panic
+## 0.7.4 June 5, 2020
+ - fix gaggles to not panic, add test
+ - fix test_start and test_stop to not panic, add tests
+ - optimize NNG usage, write directly to Message instead of first to buffer
+ - fix documentation links
 
 ## 0.7.3 June 5, 2020
  - move client out of GooseClient into global GooseClientState

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.7.4-dev"
+version = "0.7.4"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ resulting binary only displays "Hello, world!":
 ```
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.7.3
+  Downloaded goose v0.7.4
       ...
-   Compiling goose v0.7.3
+   Compiling goose v0.7.4
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`
@@ -165,7 +165,7 @@ load tests. For example, pass the `-h` flag to the `simple` example,
 `cargo run --example simple -- -h`:
 
 ```
-client 0.7.3
+client 0.7.4
 CLI options available when launching a Goose loadtest
 
 USAGE:


### PR DESCRIPTION
0.7.3 had some panics, rolling 0.7.4 quickly to fix

## 0.7.4 June 5, 2020
 - fix gaggles to not panic, add test
 - fix test_start and test_stop to not panic, add tests
 - optimize NNG usage, write directly to Message instead of first to buffer
 - fix documentation links
