### PR TITLE
fix #67 allow load test to build custom client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.7.5-dev
- -
+ - add `set_client_builder`, allow load test to build a Reqwest client with custom options
 
 ## 0.7.4 June 5, 2020
  - fix gaggles to not panic, add test


### PR DESCRIPTION
Allow load test to build a custom Reqwest header, fixing #67 