### PR TITLE
fix #66 track if we redirected

### DIFF
--- a/src/goose.rs
+++ b/src/goose.rs
@@ -254,8 +254,7 @@
 
 use http::method::Method;
 use http::StatusCode;
-use reqwest::{ClientBuilder, Error};
-use reqwest::{RequestBuilder, Response};
+use reqwest::{ClientBuilder, Error, RequestBuilder, Response};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
@@ -475,6 +474,10 @@ pub struct GooseRawRequest {
     pub name: String,
     /// The full URL that was requested.
     pub url: String,
+    /// The final full URL that was requested, after redirects.
+    pub final_url: String,
+    /// How many milliseconds the request took.
+    pub redirected: bool,
     /// How many milliseconds the request took.
     pub response_time: u128,
     /// The HTTP response code (optional).
@@ -490,10 +493,20 @@ impl GooseRawRequest {
             method,
             name: name.to_string(),
             url: url.to_string(),
+            final_url: "".to_string(),
+            redirected: false,
             response_time: 0,
             status_code: None,
             success: true,
             update: false,
+        }
+    }
+
+    // Record the final URL returned.
+    fn set_final_url(&mut self, final_url: &str) {
+        self.final_url = final_url.to_string();
+        if self.final_url != self.url {
+            self.redirected = true;
         }
     }
 
@@ -505,7 +518,6 @@ impl GooseRawRequest {
         self.status_code = status_code;
     }
 }
-
 /// Statistics collected about a path-method pair, (for example `/index`-`GET`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GooseRequest {
@@ -1209,6 +1221,7 @@ impl GooseClient {
                         raw_request.success = false;
                     }
                     raw_request.set_status_code(Some(status_code));
+                    raw_request.set_final_url(r.url().as_str());
                 }
                 Err(e) => {
                     // @TODO: what can we learn from a reqwest error?

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -1,0 +1,94 @@
+use httpmock::Method::GET;
+use httpmock::{mock, with_mock_server};
+
+mod common;
+
+use goose::prelude::*;
+
+const INDEX_PATH: &str = "/";
+const REDIRECT_PATH: &str = "/redirect";
+const REDIRECT2_PATH: &str = "/redirect2";
+const REDIRECT3_PATH: &str = "/redirect3";
+const ABOUT_PATH: &str = "/about.php";
+
+pub async fn get_index(client: &GooseClient) -> () {
+    let _response = client.get(INDEX_PATH).await;
+}
+
+pub async fn get_redirect(client: &GooseClient) -> () {
+    let mut response = client.get(REDIRECT_PATH).await;
+    match response.response {
+        Ok(r) => match r.text().await {
+            Ok(html) => {
+                // Confirm that we followed redirects and loaded the about page.
+                if !html.contains("about page") {
+                    eprintln!("about page body wrong");
+                    client.set_failure(&mut response.request);
+                }
+            }
+            Err(e) => {
+                eprintln!("unexpected error parsing about page: {}", e);
+                client.set_failure(&mut response.request);
+            }
+        },
+        // Goose will catch this error.
+        Err(_) => (),
+    }
+}
+
+#[test]
+#[with_mock_server]
+fn test_redirect() {
+    let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
+    let mock_redirect = mock(GET, REDIRECT_PATH)
+        // Moved Permanently
+        .return_status(301)
+        .return_header("Location", "/redirect2")
+        .create();
+    let mock_redirect2 = mock(GET, REDIRECT2_PATH)
+        // Found (Moved Temporarily)
+        .return_status(302)
+        .return_header("Location", "/redirect3")
+        .create();
+    let mock_redirect3 = mock(GET, REDIRECT3_PATH)
+        // See Other
+        .return_status(303)
+        .return_header("Location", "/about.php")
+        .create();
+    let mock_about = mock(GET, ABOUT_PATH)
+        .return_status(200)
+        .return_body("<HTML><BODY>about page</BODY></HTML>")
+        .create();
+
+    crate::GooseAttack::initialize_with_config(common::build_configuration())
+        .setup()
+        .register_taskset(
+            taskset!("LoadTest")
+                // Load index directly.
+                .register_task(task!(get_index))
+                // Load redirect path, redirect to redirect2 path, redirect to
+                // redirect3 path, redirect to about.
+                .register_task(task!(get_redirect)),
+        )
+        .execute();
+
+    let called_index = mock_index.times_called();
+    let called_redirect = mock_redirect.times_called();
+    let called_redirect2 = mock_redirect2.times_called();
+    let called_redirect3 = mock_redirect3.times_called();
+    let called_about = mock_about.times_called();
+
+    // Confirm that we loaded the mock endpoints; while we never load the about page
+    // directly, we should follow the redirects and load it.
+    assert_ne!(called_index, 0);
+    assert_ne!(called_redirect, 0);
+    assert_ne!(called_redirect2, 0);
+    assert_ne!(called_redirect3, 0);
+    assert_ne!(called_about, 0);
+
+    // We should have called all redirects the same number of times as we called the
+    // final about page.
+    assert!(called_redirect == called_redirect2);
+    assert!(called_redirect == called_redirect3);
+    assert!(called_redirect == called_about);
+}


### PR DESCRIPTION
This sets a boolean to `true` or `false` depending on if there was a redirect, and also stores the final `URL`.

I explored ways to track how many times the request was redirected, and the redirect header(s) used. A custom redirect policy can be defined when building the Reqwest client (https://docs.rs/reqwest/0.10.6/reqwest/redirect/index.html) but I didn't find any way to preserve the redirect information. I explored adding a redirections object within our global CLIENT lazy_static, but we don't have enough information when registering the callback, and the callback can't be async (which we require to unlock the CLIENT object).

Another idea to pursue is to completely disable Reqwests manual handling of redirects, and instead re-implement them in Goose. This may be worth the effort, as otherwise Goose has no way to collect statistics about which redirect headers it ran into, and how many times a given URL was redirected.