### PR TITLE
fix #74 optionally make redirects of base_url sticky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.6-dev
  - properly subtract previous statistic when handling `set_failure()` and `set_success()`
  - detect and track redirects in `GooseRawRequest`
- - redirect of test base_url are sticky and affect subsequent requests
+ - redirect of GooseClient base_url is sticky and affects subsequent requests
 
 ## 0.7.5 June 10, 2020
  - store actual URL requested in GooseRawRequest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.6-dev
  - properly subtract previous statistic when handling `set_failure()` and `set_success()`
  - detect and track redirects in `GooseRawRequest`
+ - redirect of test base_url are sticky and affect subsequent requests
 
 ## 0.7.5 June 10, 2020
  - store actual URL requested in GooseRawRequest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.6-dev
  - properly subtract previous statistic when handling `set_failure()` and `set_success()`
  - detect and track redirects in `GooseRawRequest`
- - redirect of GooseClient base_url is sticky and affects subsequent requests
+ - redirect of GooseClient base_url is sticky and affects subsequent requests (disable with `--no-sticky-follow`)
 
 ## 0.7.5 June 10, 2020
  - store actual URL requested in GooseRawRequest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.6-dev
  - properly subtract previous statistic when handling `set_failure()` and `set_success()`
  - detect and track redirects in `GooseRawRequest`
- - redirect of GooseClient base_url is sticky and affects subsequent requests (disable with `--no-sticky-follow`)
+ - `--sticky-follow` makes redirect of GooseClient base_url sticky, affecting subsequent requests
 
 ## 0.7.5 June 10, 2020
  - store actual URL requested in GooseRawRequest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ gaggle = ["nng"]
 
 [dev-dependencies]
 httpmock = "0.3"
+mockito = "0.25"

--- a/README.md
+++ b/README.md
@@ -166,25 +166,25 @@ load tests. For example, pass the `-h` flag to the `simple` example,
 
 ```
 client 0.7.5
-CLI options available when launching a Goose loadtest
+CLI options available when launching a Goose load test
 
 USAGE:
     simple [FLAGS] [OPTIONS]
 
 FLAGS:
-    -h, --help                Prints help information
-    -l, --list                Shows list of all possible Goose tasks and exits
-    -g, --log-level           Log level (-g, -gg, -ggg, etc.)
-        --manager             Enables manager mode
-        --no-hash-check       Ignore worker load test checksum
-        --no-stats            Don't print stats in the console
-        --no-sticky-follow    Prevent load test client from following redirect of base_url with subsequent requests
-        --only-summary        Only prints summary stats
-        --reset-stats         Resets statistics once hatching has been completed
-        --status-codes        Includes status code counts in console stats
-    -V, --version             Prints version information
-    -v, --verbose             Debug level (-v, -vv, -vvv, etc.)
-        --worker              Enables worker mode
+    -h, --help             Prints help information
+    -l, --list             Shows list of all possible Goose tasks and exits
+    -g, --log-level        Log level (-g, -gg, -ggg, etc.)
+        --manager          Enables manager mode
+        --no-hash-check    Ignore worker load test checksum
+        --no-stats         Don't print stats in the console
+        --only-summary     Only prints summary stats
+        --reset-stats      Resets statistics once hatching has been completed
+        --status-codes     Includes status code counts in console stats
+        --sticky-follow    Client follows redirect of base_url with subsequent requests
+    -V, --version          Prints version information
+    -v, --verbose          Debug level (-v, -vv, -vvv, etc.)
+        --worker           Enables worker mode
 
 OPTIONS:
     -c, --clients <clients>                        Number of concurrent Goose users (defaults to available CPUs)

--- a/README.md
+++ b/README.md
@@ -172,18 +172,19 @@ USAGE:
     simple [FLAGS] [OPTIONS]
 
 FLAGS:
-    -h, --help             Prints help information
-    -l, --list             Shows list of all possible Goose tasks and exits
-    -g, --log-level        Log level (-g, -gg, -ggg, etc.)
-        --manager          Enables manager mode
-        --no-hash-check    Ignore worker load test checksum
-        --no-stats         Don't print stats in the console
-        --only-summary     Only prints summary stats
-        --reset-stats      Resets statistics once hatching has been completed
-        --status-codes     Includes status code counts in console stats
-    -V, --version          Prints version information
-    -v, --verbose          Debug level (-v, -vv, -vvv, etc.)
-        --worker           Enables worker mode
+    -h, --help                Prints help information
+    -l, --list                Shows list of all possible Goose tasks and exits
+    -g, --log-level           Log level (-g, -gg, -ggg, etc.)
+        --manager             Enables manager mode
+        --no-hash-check       Ignore worker load test checksum
+        --no-stats            Don't print stats in the console
+        --no-sticky-follow    Prevent load test client from following redirect of base_url with subsequent requests
+        --only-summary        Only prints summary stats
+        --reset-stats         Resets statistics once hatching has been completed
+        --status-codes        Includes status code counts in console stats
+    -V, --version             Prints version information
+    -v, --verbose             Debug level (-v, -vv, -vvv, etc.)
+        --worker              Enables worker mode
 
 OPTIONS:
     -c, --clients <clients>                        Number of concurrent Goose users (defaults to available CPUs)

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1524,7 +1524,7 @@ impl GooseClient {
     /// Determine if the load test has been redirected, and if so return the redirected
     /// host against which all relative URLs should be loaded.
     pub async fn get_redirected_host(&self) -> Option<String> {
-        let redirected_host = self.redirected_host.write().await;
+        let redirected_host = self.redirected_host.read().await;
         if redirected_host.is_empty() {
             None
         } else {

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1206,7 +1206,7 @@ impl GooseClient {
                     raw_request.set_final_url(r.url().as_str());
 
                     // Load test client was redirected.
-                    if raw_request.url != raw_request.final_url {
+                    if !self.config.no_sticky_follow && raw_request.url != raw_request.final_url {
                         let base_url = self.base_url.read().await.to_string();
                         // Check if the URL redirected started with the load test base_url.
                         if !raw_request.final_url.starts_with(&base_url) {
@@ -1220,7 +1220,9 @@ impl GooseClient {
                             };
                             info!(
                                 "base_url for client {} redirected from {} to {}",
-                                self.weighted_clients_index + 1, &base_url, &redirected_base_url
+                                self.weighted_clients_index + 1,
+                                &base_url,
+                                &redirected_base_url
                             );
                             self.set_base_url(&redirected_base_url).await;
                         }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1206,7 +1206,7 @@ impl GooseClient {
                     raw_request.set_final_url(r.url().as_str());
 
                     // Load test client was redirected.
-                    if !self.config.no_sticky_follow && raw_request.url != raw_request.final_url {
+                    if self.config.sticky_follow && raw_request.url != raw_request.final_url {
                         let base_url = self.base_url.read().await.to_string();
                         // Check if the URL redirected started with the load test base_url.
                         if !raw_request.final_url.starts_with(&base_url) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1343,6 +1343,10 @@ pub struct GooseConfiguration {
     #[structopt(long, default_value = "goose.log")]
     pub log_file: String,
 
+    /// Prevent load test client from following redirect of base_url with subsequent requests
+    #[structopt(long)]
+    pub no_sticky_follow: bool,
+
     /// Enables manager mode
     #[structopt(long)]
     pub manager: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1343,9 +1343,9 @@ pub struct GooseConfiguration {
     #[structopt(long, default_value = "goose.log")]
     pub log_file: String,
 
-    /// Prevent load test client from following redirect of base_url with subsequent requests
+    /// Client follows redirect of base_url with subsequent requests
     #[structopt(long)]
-    pub no_sticky_follow: bool,
+    pub sticky_follow: bool,
 
     /// Enables manager mode
     #[structopt(long)]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -16,6 +16,7 @@ pub fn build_configuration() -> GooseConfiguration {
         verbose: 0,
         log_level: 0,
         log_file: "goose.log".to_string(),
+        no_sticky_follow: false,
         manager: false,
         no_hash_check: false,
         expect_workers: 0,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -16,7 +16,7 @@ pub fn build_configuration() -> GooseConfiguration {
         verbose: 0,
         log_level: 0,
         log_file: "goose.log".to_string(),
-        no_sticky_follow: false,
+        sticky_follow: false,
         manager: false,
         no_hash_check: false,
         expect_workers: 0,


### PR DESCRIPTION
This functionality is required for a client load test ported from Locust.