### PR TITLE
Rename GooseClient to GooseUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 0.7.6-dev
+## 0.8.0-dev
  - properly subtract previous statistic when handling `set_failure()` and `set_success()`
  - detect and track redirects in `GooseRawRequest`
  - `--sticky-follow` makes redirect of GooseClient base_url sticky, affecting subsequent requests
+ - changed `GooseClient` to `GooseUser`
 
 ## 0.7.5 June 10, 2020
  - store actual URL requested in GooseRawRequest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.7.6-dev"
+version = "0.8.0-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ use goose::prelude::*;
 
 Then create a new load testing function. For our example we're simply going
 to load the front page of the website we're load-testing. Goose passes all
-load testing functions a mutable pointer to a GooseClient object, which is used
+load testing functions a mutable pointer to a GooseUser object, which is used
 to track statistics and make web requests. Thanks to the Reqwest library, the
 Goose client manages things like cookies, headers, and sessions for you. Load
 testing functions must be declared async.
@@ -75,8 +75,8 @@ the host at run time, so you can easily run your load test against different
 environments without recompiling:
 
 ```rust
-async fn loadtest_index(client: &GooseClient) {
-    let _response = client.get("/").await;
+async fn loadtest_index(user: &GooseUser) {
+    let _response = user.get("/").await;
 }
 ```
 
@@ -165,11 +165,11 @@ load tests. For example, pass the `-h` flag to the `simple` example,
 `cargo run --example simple -- -h`:
 
 ```
-client 0.8.0
+Goose 0.8.0
 CLI options available when launching a Goose load test
 
 USAGE:
-8   simple [FLAGS] [OPTIONS]
+    simple [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help             Prints help information
@@ -181,13 +181,12 @@ FLAGS:
         --only-summary     Only prints summary stats
         --reset-stats      Resets statistics once hatching has been completed
         --status-codes     Includes status code counts in console stats
-        --sticky-follow    Client follows redirect of base_url with subsequent requests
+        --sticky-follow    User follows redirect of base_url with subsequent requests
     -V, --version          Prints version information
     -v, --verbose          Debug level (-v, -vv, -vvv, etc.)
         --worker           Enables worker mode
 
 OPTIONS:
-    -c, --clients <clients>                        Number of concurrent Goose users (defaults to available CPUs)
         --expect-workers <expect-workers>
             Required when in manager mode, how many workers to expect [default: 0]
 
@@ -200,11 +199,13 @@ OPTIONS:
         --manager-port <manager-port>              Port manager is listening on [default: 5115]
     -t, --run-time <run-time>
             Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.) [default: ]
+
+    -u, --users <users>                            Number of concurrent Goose users (defaults to available CPUs)
 ```
 
-The `examples/simple.rs` example copies the simple load test documented on the locust.io web page, rewritten in Rust for Goose. It uses minimal advanced functionality, but demonstrates how to GET and POST pages. It defines a single Task Set which has the client log in and then load a couple of pages.
+The `examples/simple.rs` example copies the simple load test documented on the locust.io web page, rewritten in Rust for Goose. It uses minimal advanced functionality, but demonstrates how to GET and POST pages. It defines a single Task Set which has the user log in and then load a couple of pages.
 
-Goose can make use of all available CPU cores. By default, it will launch 1 client per core, and it can be configured to launch many more. The following was configured instead to launch 1,024 clients. Each client randomly pauses 5 to 15 seconds after each task is loaded, so it's possible to spin up a large number of clients. Here is a snapshot of `top` when running this example on an 8-core VM with 10G of available RAM -- there were ample resources to launch considerably more "clients", though `ulimit` had to be resized:
+Goose can make use of all available CPU cores. By default, it will launch 1 user per core, and it can be configured to launch many more. The following was configured instead to launch 1,024 users. Each user randomly pauses 5 to 15 seconds after each task is loaded, so it's possible to spin up a large number of users. Here is a snapshot of `top` when running this example on an 8-core VM with 10G of available RAM -- there were ample resources to launch considerably more "users", though `ulimit` had to be resized:
 
 ```
 top - 11:14:57 up 16 days,  4:40,  2 users,  load average: 0.00, 0.04, 0.01
@@ -217,7 +218,7 @@ MiB Swap:  10237.0 total,  10234.7 free,      2.3 used.   8401.5 avail Mem
 19776 goose     20   0    9.8g 874688   8252 S   6.3   8.5   0:42.90 simple                                                    
 ```
 
-Here's the output of running the loadtest. The `-v` flag sends `INFO` and more critical messages to stdout (in addition to the log file). The `-c1024` tells Goose to spin up 1,024 clients. The `-r32` option tells Goose to spin up 32 clients per second. The `-t 10m` option tells Goose to run the load test for 10 minutes, or 600 seconds. The `--print-stats` flag tells Goose to collect statistics during the load test, and the `--status-codes` flag tells it to include statistics about HTTP Status codes returned by the server. Finally, the `--only-summary` flag tells Goose to only display the statistics when the load test finishes, otherwise it would display running statistics every 15 seconds for the duration of the test.
+Here's the output of running the loadtest. The `-v` flag sends `INFO` and more critical messages to stdout (in addition to the log file). The `-u1024` tells Goose to spin up 1,024 users. The `-r32` option tells Goose to spin up 32 users per second. The `-t 10m` option tells Goose to run the load test for 10 minutes, or 600 seconds. The `--print-stats` flag tells Goose to collect statistics during the load test, and the `--status-codes` flag tells it to include statistics about HTTP Status codes returned by the server. Finally, the `--only-summary` flag tells Goose to only display the statistics when the load test finishes, otherwise it would display running statistics every 15 seconds for the duration of the test.
 
 ```
 $ cargo run --release --example simple -- --host http://apache.fosciana -v -c1024 -r32 -t 10m --print-stats --status-codes --only-summary
@@ -228,24 +229,24 @@ $ cargo run --release --example simple -- --host http://apache.fosciana -v -c102
 18:42:48 [ INFO] Writing to log file: goose.log
 18:42:48 [ INFO] run_time = 600
 18:42:48 [ INFO] global host configured: http://apache.fosciana
-18:42:53 [ INFO] launching client 1 from WebsiteUser...
-18:42:53 [ INFO] launching client 2 from WebsiteUser...
-18:42:53 [ INFO] launching client 3 from WebsiteUser...
-18:42:53 [ INFO] launching client 4 from WebsiteUser...
-18:42:53 [ INFO] launching client 5 from WebsiteUser...
-18:42:53 [ INFO] launching client 6 from WebsiteUser...
-18:42:53 [ INFO] launching client 7 from WebsiteUser...
-18:42:53 [ INFO] launching client 8 from WebsiteUser...
+18:42:53 [ INFO] launching user 1 from WebsiteUser...
+18:42:53 [ INFO] launching user 2 from WebsiteUser...
+18:42:53 [ INFO] launching user 3 from WebsiteUser...
+18:42:53 [ INFO] launching user 4 from WebsiteUser...
+18:42:53 [ INFO] launching user 5 from WebsiteUser...
+18:42:53 [ INFO] launching user 6 from WebsiteUser...
+18:42:53 [ INFO] launching user 7 from WebsiteUser...
+18:42:53 [ INFO] launching user 8 from WebsiteUser...
 
 ```
 ...
 ```
-18:43:25 [ INFO] launching client 1022 from WebsiteUser...
-18:43:25 [ INFO] launching client 1023 from WebsiteUser...
-18:43:25 [ INFO] launching client 1024 from WebsiteUser...
-18:43:25 [ INFO] launched 1024 clients...
+18:43:25 [ INFO] launching user 1022 from WebsiteUser...
+18:43:25 [ INFO] launching user 1023 from WebsiteUser...
+18:43:25 [ INFO] launching user 1024 from WebsiteUser...
+18:43:25 [ INFO] launched 1024 users...
 18:53:26 [ INFO] stopping after 600 seconds...
-18:53:26 [ INFO] waiting for clients to exit
+18:53:26 [ INFO] waiting for users to exit
 ------------------------------------------------------------------------------ 
  Name                    | # reqs         | # fails        | req/s  | fail/s
  ----------------------------------------------------------------------------- 
@@ -362,7 +363,7 @@ The `--no-stats`, `--only-summary`, `--reset-stats`, `--status-codes`, and `--no
 * `--manager-host <manager-host>`: configures the host that the worker will talk to the manager on. By default, a Goose worker will connect to the localhost, or `127.0.0.1`. In a distributed load test, this must be set to the IP of the Goose manager.
 * `--manager-port <manager-port>`: configures the port that a worker will talk to the manager on. By default, a Goose worker will connect to port `5115`.
 
-The `--clients`, `--hatch-rate`, `--host`, and `--run-time` options must be set on the manager. Workers inheret these options from the manager.
+The `--users`, `--hatch-rate`, `--host`, and `--run-time` options must be set on the manager. Workers inheret these options from the manager.
 
 ### Technical Details
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ heading:
 
 ```toml
 [dependencies]
-goose = "^0.7"
+goose = "^0.8"
 ```
 
 At this point it's possible to compile all dependencies, though the
@@ -47,9 +47,9 @@ resulting binary only displays "Hello, world!":
 ```
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.7.5
+  Downloaded goose v0.8.0
       ...
-   Compiling goose v0.7.5
+   Compiling goose v0.8.0
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`
@@ -165,11 +165,11 @@ load tests. For example, pass the `-h` flag to the `simple` example,
 `cargo run --example simple -- -h`:
 
 ```
-client 0.7.5
+client 0.8.0
 CLI options available when launching a Goose load test
 
 USAGE:
-    simple [FLAGS] [OPTIONS]
+8   simple [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help             Prints help information
@@ -305,7 +305,7 @@ feature in the `dependencies` section of your `Cargo.toml`, for example:
 
 ```toml
 [dependencies]
-goose = { version = "^0.7", features = ["gaggle"] }
+goose = { version = "^0.8", features = ["gaggle"] }
 ```
 
 ### Goose Manager

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -26,7 +26,7 @@ fn main() {
             taskset!("WebsiteUser")
                 // After each task runs, sleep randomly from 5 to 15 seconds.
                 .set_wait_time(5, 15)
-                // This task only runs one time when the client first starts.
+                // This task only runs one time when the user first starts.
                 .register_task(task!(website_login).set_on_start())
                 // These next two tasks run repeatedly as long as the load test is running.
                 .register_task(task!(website_index))
@@ -35,22 +35,22 @@ fn main() {
         .execute();
 }
 
-/// Demonstrates how to log in when a client starts. We flag this task as an
+/// Demonstrates how to log in when a user starts. We flag this task as an
 /// on_start task when registering it above. This means it only runs one time
-/// per client, when the client thread first starts.
-async fn website_login(client: &GooseClient) {
-    let request_builder = client.goose_post("/login").await;
+/// per user, when the user thread first starts.
+async fn website_login(user: &GooseUser) {
+    let request_builder = user.goose_post("/login").await;
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
-    let _response = client.goose_send(request_builder.form(&params), None).await;
+    let _response = user.goose_send(request_builder.form(&params), None).await;
 }
 
 /// A very simple task that simply loads the front page.
-async fn website_index(client: &GooseClient) {
-    let _response = client.get("/").await;
+async fn website_index(user: &GooseUser) {
+    let _response = user.get("/").await;
 }
 
 /// A very simple task that simply loads the about page.
-async fn website_about(client: &GooseClient) {
-    let _response = client.get("/about/").await;
+async fn website_about(user: &GooseUser) {
+    let _response = user.get("/about/").await;
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -2,9 +2,9 @@
 //!
 //! Goose manages load tests with a series of objects:
 //!
-//! - [`GooseTaskSet`](./struct.GooseTaskSet.html) each client is assigned a task set, which is a collection of tasks.
+//! - [`GooseTaskSet`](./struct.GooseTaskSet.html) each user is assigned a task set, which is a collection of tasks.
 //! - [`GooseTask`](./struct.GooseTask.html) tasks define one or more web requests and are assigned to task sets.
-//! - [`GooseClient`](./struct.GooseClient.html) a client state responsible for repeatedly running all tasks in the assigned task set.
+//! - [`GooseUser`](./struct.GooseUser.html) a user state responsible for repeatedly running all tasks in the assigned task set.
 //! - [`GooseRequest`](./struct.GooseRequest.html) optional statistics collected for each URL/method pair.
 //!
 //! ## Creating Task Sets
@@ -19,9 +19,9 @@
 //!
 //! ### Task Set Weight
 //!
-//! A weight can be assigned to a task set, controlling how often it is assigned to client
-//! threads. The larger the value of weight, the more it will be assigned to clients. In the
-//! following example, `FooTasks` will be assigned to clients twice as often as `Bar` tasks.
+//! A weight can be assigned to a task set, controlling how often it is assigned to user
+//! threads. The larger the value of weight, the more it will be assigned to users. In the
+//! following example, `FooTasks` will be assigned to users twice as often as `Bar` tasks.
 //! We could have just added a weight of `2` to `FooTasks` and left the default weight of `1`
 //! assigned to `BarTasks` for the same weighting:
 //!
@@ -50,9 +50,9 @@
 //! ### Task Set Wait Time
 //!
 //! Wait time is specified as a low-high integer range. Each time a task completes in
-//! the task set, the client will pause for a random number of seconds inclusively between
-//! the low and high wait times. In the following example, Clients loading `foo` tasks will
-//! sleep 0 to 3 seconds after each task completes, and Clients loading `bar` tasks will
+//! the task set, the user will pause for a random number of seconds inclusively between
+//! the low and high wait times. In the following example, users loading `foo` tasks will
+//! sleep 0 to 3 seconds after each task completes, and users loading `bar` tasks will
 //! sleep 5 to 10 seconds after each task completes.
 //!
 //! ```rust
@@ -72,8 +72,8 @@
 //!     let mut a_task = task!(task_function);
 //!
 //!     /// A very simple task that simply loads the front page.
-//!     async fn task_function(client: &GooseClient) {
-//!       let _response = client.get("/");
+//!     async fn task_function(user: &GooseUser) {
+//!       let _response = user.get("/");
 //!     }
 //! ```
 //!
@@ -88,8 +88,8 @@
 //!     let mut a_task = task!(task_function).set_name("a");
 //!
 //!     /// A very simple task that simply loads the front page.
-//!     async fn task_function(client: &GooseClient) {
-//!       let _response = client.get("/");
+//!     async fn task_function(user: &GooseUser) {
+//!       let _response = user.get("/");
 //!     }
 //! ```
 //!
@@ -106,13 +106,13 @@
 //!     let mut b_task = task!(b_task_function).set_weight(3);
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(client: &GooseClient) {
-//!       let _response = client.get("/a/");
+//!     async fn a_task_function(user: &GooseUser) {
+//!       let _response = user.get("/a/");
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(client: &GooseClient) {
-//!       let _response = client.get("/b/");
+//!     async fn b_task_function(user: &GooseUser) {
+//!       let _response = user.get("/b/");
 //!     }
 //! ```
 //!
@@ -134,24 +134,24 @@
 //!     let mut c_task = task!(c_task_function);
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(client: &GooseClient) {
-//!       let _response = client.get("/a/");
+//!     async fn a_task_function(user: &GooseUser) {
+//!       let _response = user.get("/a/");
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(client: &GooseClient) {
-//!       let _response = client.get("/b/");
+//!     async fn b_task_function(user: &GooseUser) {
+//!       let _response = user.get("/b/");
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "c" page.
-//!     async fn c_task_function(client: &GooseClient) {
-//!       let _response = client.get("/c/");
+//!     async fn c_task_function(user: &GooseUser) {
+//!       let _response = user.get("/c/");
 //!     }
 //! ```
 //!
 //! ### Task On Start
 //!
-//! Tasks can be flagged to only run when a client first starts. This can be useful if you'd
+//! Tasks can be flagged to only run when a user first starts. This can be useful if you'd
 //! like your load test to use a logged-in user. It is possible to assign sequences and weights
 //! to `on_start` functions if you want to have multiple tasks run in a specific order at start
 //! time, and/or the tasks to run multiple times. A task can be flagged to run both on start
@@ -163,14 +163,14 @@
 //!     let mut a_task = task!(a_task_function).set_sequence(1).set_on_start();
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(client: &GooseClient) {
-//!       let _response = client.get("/a/");
+//!     async fn a_task_function(user: &GooseUser) {
+//!       let _response = user.get("/a/");
 //!     }
 //! ```
 //!
 //! ### Task On Stop
 //!
-//! Tasks can be flagged to only run when a client stops. This can be useful if you'd like your
+//! Tasks can be flagged to only run when a user stops. This can be useful if you'd like your
 //! load test to simluate a user logging out when it finishes. It is possible to assign sequences
 //! and weights to `on_stop` functions if you want to have multiple tasks run in a specific order
 //! at stop time, and/or the tasks to run multiple times. A task can be flagged to run both on
@@ -182,22 +182,22 @@
 //!     let mut b_task = task!(b_task_function).set_sequence(2).set_on_stop();
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(client: &GooseClient) {
-//!       let _response = client.get("/b/");
+//!     async fn b_task_function(user: &GooseUser) {
+//!       let _response = user.get("/b/");
 //!     }
 //! ```
 //!
-//! ## Controlling Clients
+//! ## Controlling User
 //!
-//! When Goose starts, it creates one or more [`GooseClient`](./struct.GooseClient.html)s,
-//! assigning a single [`GooseTaskSet`](./struct.GooseTaskSet.html) to each. This client is
+//! When Goose starts, it creates one or more [`GooseUser`](./struct.GooseUser.html)s,
+//! assigning a single [`GooseTaskSet`](./struct.GooseTaskSet.html) to each. This user is
 //! then used to generate load. Behind the scenes, Goose is leveraging the
-//! [`reqwest::blocking::client`](https://docs.rs/reqwest/*/reqwest/blocking/struct.Client.html)
+//! [`reqwest::client`](https://docs.rs/reqwest/*/reqwest/struct.Client.html)
 //! to load web pages, and Goose can therefor do anything Reqwest can do.
 //!
-//! The most common request types are [`GET`](./struct.GooseClient.html#method.get) and
-//! [`POST`](./struct.GooseClient.html#method.post), but [`HEAD`](./struct.GooseClient.html#method.head),
-//! PUT, PATCH and [`DELETE`](./struct.GooseClient.html#method.delete) are also supported.
+//! The most common request types are [`GET`](./struct.GooseUser.html#method.get) and
+//! [`POST`](./struct.GooseUser.html#method.post), but [`HEAD`](./struct.GooseUser.html#method.head),
+//! PUT, PATCH and [`DELETE`](./struct.GooseUser.html#method.delete) are also supported.
 //!
 //! ### GET
 //!
@@ -210,8 +210,8 @@
 //!     let mut task = task!(get_function);
 //!
 //!     /// A very simple task that makes a GET request.
-//!     async  fn get_function(client: &GooseClient) {
-//!       let _response = client.get("/path/to/foo/");
+//!     async  fn get_function(user: &GooseUser) {
+//!       let _response = user.get("/path/to/foo/");
 //!     }
 //! ```
 //!
@@ -231,8 +231,8 @@
 //!     let mut task = task!(post_function);
 //!
 //!     /// A very simple task that makes a POST request.
-//!     async fn post_function(client: &GooseClient) {
-//!       let _response = client.post("/path/to/foo/", "string value to post");
+//!     async fn post_function(user: &GooseUser) {
+//!       let _response = user.post("/path/to/foo/", "string value to post");
 //!     }
 //! ```
 //!
@@ -291,19 +291,19 @@ pub struct GooseTaskSet {
     pub name: String,
     /// An integer reflecting where this task set lives in the internal `GooseTest.task_sets` vector.
     pub task_sets_index: usize,
-    /// An integer value that controls the frequency that this task set will be assigned to a client.
+    /// An integer value that controls the frequency that this task set will be assigned to a user.
     pub weight: usize,
-    /// An integer value indicating the minimum number of seconds a client will sleep after running a task.
+    /// An integer value indicating the minimum number of seconds a user will sleep after running a task.
     pub min_wait: usize,
-    /// An integer value indicating the maximum number of seconds a client will sleep after running a task.
+    /// An integer value indicating the maximum number of seconds a user will sleep after running a task.
     pub max_wait: usize,
-    /// A vector containing one copy of each GooseTask that will run by clients running this task set.
+    /// A vector containing one copy of each GooseTask that will run by users running this task set.
     pub tasks: Vec<GooseTask>,
     /// A vector of vectors of integers, controlling the sequence and order GooseTasks are run.
     pub weighted_tasks: Vec<Vec<usize>>,
-    /// A vector of vectors of integers, controlling the sequence and order on_start GooseTasks are run when the client first starts.
+    /// A vector of vectors of integers, controlling the sequence and order on_start GooseTasks are run when the user first starts.
     pub weighted_on_start_tasks: Vec<Vec<usize>>,
-    /// A vector of vectors of integers, controlling the sequence and order on_stop GooseTasks are run when a client stops.
+    /// A vector of vectors of integers, controlling the sequence and order on_stop GooseTasks are run when the user stops.
     pub weighted_on_stop_tasks: Vec<Vec<usize>>,
     /// An optional default host to run this TaskSet against.
     pub host: Option<String>,
@@ -345,8 +345,8 @@ impl GooseTaskSet {
     ///     example_tasks.register_task(task!(a_task_function));
     ///
     ///     /// A very simple task that simply loads the "a" page.
-    ///     async fn a_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/a/");
+    ///     async fn a_task_function(user: &GooseUser) {
+    ///       let _response = user.get("/a/");
     ///     }
     /// ```
     pub fn register_task(mut self, mut task: GooseTask) -> Self {
@@ -357,8 +357,8 @@ impl GooseTaskSet {
     }
 
     /// Sets a weight on a task set. The larger the value of weight, the more often the task set will
-    /// be assigned to clients. For example, if you have task set foo with a weight of 3, and task set
-    /// bar with a weight of 1, and you spin up a load test with 8 clients, 6 of them will be running
+    /// be assigned to users. For example, if you have task set foo with a weight of 3, and task set
+    /// bar with a weight of 1, and you spin up a load test with 8 users, 6 of them will be running
     /// the foo task set, and 2 will be running the bar task set.
     ///
     /// # Example
@@ -398,7 +398,7 @@ impl GooseTaskSet {
 
     /// Configure a task_set to to pause after running each task. The length of the pause will be randomly
     /// selected from `min_weight` to `max_wait` inclusively.  For example, if `min_wait` is `0` and
-    /// `max_weight` is `2`, the client will randomly sleep for 0, 1 or 2 seconds after each task completes.
+    /// `max_weight` is `2`, the user will randomly sleep for 0, 1 or 2 seconds after each task completes.
     ///
     /// # Example
     /// ```rust
@@ -426,15 +426,15 @@ impl GooseTaskSet {
     }
 }
 
-/// Commands sent between the parent and client threads, and between manager and
+/// Commands sent between the parent and user threads, and between manager and
 /// worker processes.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum GooseClientCommand {
+pub enum GooseUserCommand {
     /// Tell worker process to pause load test.
     WAIT,
     /// Tell worker process to start load test.
     RUN,
-    /// Tell client thread to exit.
+    /// Tell user thread to exit.
     EXIT,
 }
 
@@ -464,11 +464,11 @@ fn goose_method_from_method(method: Method) -> GooseMethod {
     }
 }
 
-/// The request that Goose is making. Client threads send this data to the parent thread
+/// The request that Goose is making. User threads send this data to the parent thread
 /// when statistics are enabled. This request object must be provided to calls to
-/// [`set_success`](https://docs.rs/goose/*/goose/goose/struct.GooseClient.html#method.set_success)
+/// [`set_success`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_success)
 /// or
-/// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseClient.html#method.set_failure)
+/// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_failure)
 /// so Goose knows which request is being updated.
 #[derive(Debug, Clone)]
 pub struct GooseRawRequest {
@@ -660,16 +660,16 @@ impl GooseResponse {
     }
 }
 
-/// An individual client state, repeatedly running all GooseTasks in a specific GooseTaskSet.
+/// An individual user state, repeatedly running all GooseTasks in a specific GooseTaskSet.
 #[derive(Debug, Clone)]
-pub struct GooseClient {
+pub struct GooseUser {
     /// An index into the internal `GooseTest.task_sets` vector, indicating which GooseTaskSet is running.
     pub task_sets_index: usize,
     /// Client used to make requests, managing sessions and cookies.
     pub client: Arc<Mutex<Client>>,
-    /// Integer value tracking the sequenced bucket client is running tasks from.
+    /// Integer value tracking the sequenced bucket user is running tasks from.
     pub weighted_bucket: Arc<AtomicUsize>,
-    /// Integer value tracking the current task client is running.
+    /// Integer value tracking the current task user is running.
     pub weighted_bucket_position: Arc<AtomicUsize>,
     /// The base URL to prepend to all relative paths.
     pub base_url: Arc<RwLock<Url>>,
@@ -681,13 +681,13 @@ pub struct GooseClient {
     pub config: GooseConfiguration,
     /// Channel
     pub parent: Option<mpsc::UnboundedSender<GooseRawRequest>>,
-    /// An index into the internal `GooseTest.weighted_clients, indicating which weighted GooseTaskSet is running.
-    pub weighted_clients_index: usize,
-    /// A weighted list of all tasks that run when the client first starts.
+    /// An index into the internal `GooseTest.weighted_users, indicating which weighted GooseTaskSet is running.
+    pub weighted_users_index: usize,
+    /// A weighted list of all tasks that run when the user first starts.
     pub weighted_on_start_tasks: Vec<Vec<usize>>,
-    /// A weighted list of all tasks that this client runs once started.
+    /// A weighted list of all tasks that this user runs once started.
     pub weighted_tasks: Vec<Vec<usize>>,
-    /// A weighted list of all tasks that run when the client stops.
+    /// A weighted list of all tasks that run when the user stops.
     pub weighted_on_stop_tasks: Vec<Vec<usize>>,
     /// Optional name of all requests made within the current task.
     pub task_request_name: Option<String>,
@@ -696,8 +696,8 @@ pub struct GooseClient {
     /// Load test hash.
     pub load_test_hash: u64,
 }
-impl GooseClient {
-    /// Create a new client state.
+impl GooseUser {
+    /// Create a new user state.
     pub fn new(
         task_sets_index: usize,
         base_url: Url,
@@ -706,14 +706,14 @@ impl GooseClient {
         configuration: &GooseConfiguration,
         load_test_hash: u64,
     ) -> Self {
-        trace!("new client");
+        trace!("new user");
         match Client::builder()
             .user_agent(APP_USER_AGENT)
             .cookie_store(true)
             .build()
         {
             Ok(c) => {
-                GooseClient {
+                GooseUser {
                     task_sets_index,
                     client: Arc::new(Mutex::new(c)),
                     weighted_bucket: Arc::new(AtomicUsize::new(0)),
@@ -723,8 +723,8 @@ impl GooseClient {
                     max_wait,
                     config: configuration.clone(),
                     parent: None,
-                    // A value of max_value() indicates this client isn't fully initialized yet.
-                    weighted_clients_index: usize::max_value(),
+                    // A value of max_value() indicates this user isn't fully initialized yet.
+                    weighted_users_index: usize::max_value(),
                     weighted_on_start_tasks: Vec::new(),
                     weighted_tasks: Vec::new(),
                     weighted_on_stop_tasks: Vec::new(),
@@ -734,22 +734,22 @@ impl GooseClient {
                 }
             }
             Err(e) => {
-                error!("failed to create client: {}", e);
+                error!("failed to create web client: {}", e);
                 std::process::exit(1);
             }
         }
     }
 
-    /// Create a new single-use client.
+    /// Create a new single-use user.
     pub fn single(base_url: Url, configuration: &GooseConfiguration) -> Self {
-        let mut single_client = GooseClient::new(0, base_url, 0, 0, configuration, 0);
-        single_client.weighted_clients_index = 0;
-        single_client
+        let mut single_user = GooseUser::new(0, base_url, 0, 0, configuration, 0);
+        single_user.weighted_users_index = 0;
+        single_user
     }
 
     /// A helper that prepends a base_url to all relative paths.
     ///
-    /// A base_url is determined per Goose Client thread, using the following order
+    /// A base_url is determined per user thread, using the following order
     /// of precedence:
     ///  1. `--host` (host specified on the command line when running load test)
     ///  2. `GooseTaskSet.host` (default host defined for the current task set)
@@ -783,7 +783,7 @@ impl GooseClient {
     /// object, you can instead call `goose_get` which returns a RequestBuilder, then
     /// call `goose_send` to invoke the request.)
     ///
-    /// Calls to `client.get` return a `GooseResponse` object which contains a copy of
+    /// Calls to `user.get` return a `GooseResponse` object which contains a copy of
     /// the request you made
     /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
     /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
@@ -795,8 +795,8 @@ impl GooseClient {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(client: &GooseClient) {
-    ///       let _response = client.get("/path/to/foo/");
+    ///     async fn get_function(user: &GooseUser) {
+    ///       let _response = user.get("/path/to/foo/");
     ///     }
     /// ```
     pub async fn get(&self, path: &str) -> GooseResponse {
@@ -808,7 +808,7 @@ impl GooseClient {
     /// Automatically prepends the correct host. Naming a request only affects collected
     /// statistics.
     ///
-    /// Calls to `client.get_named` return a `GooseResponse` object which contains a copy of
+    /// Calls to `user.get_named` return a `GooseResponse` object which contains a copy of
     /// the request you made
     /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
     /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
@@ -820,8 +820,8 @@ impl GooseClient {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(client: &GooseClient) {
-    ///       let _response = client.get_named("/path/to/foo/", "foo");
+    ///     async fn get_function(user: &GooseUser) {
+    ///       let _response = user.get_named("/path/to/foo/", "foo");
     ///     }
     /// ```
     pub async fn get_named(&self, path: &str, request_name: &str) -> GooseResponse {
@@ -837,7 +837,7 @@ impl GooseClient {
     /// object, you can instead call `goose_post` which returns a RequestBuilder, then
     /// call `goose_send` to invoke the request.)
     ///
-    /// Calls to `client.post` return a `GooseResponse` object which contains a copy of
+    /// Calls to `user.post` return a `GooseResponse` object which contains a copy of
     /// the request you made
     /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
     /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
@@ -849,8 +849,8 @@ impl GooseClient {
     ///     let mut task = task!(post_function);
     ///
     ///     /// A very simple task that makes a POST request.
-    ///     async fn post_function(client: &GooseClient) {
-    ///       let _response = client.post("/path/to/foo/", "BODY BEING POSTED");
+    ///     async fn post_function(user: &GooseUser) {
+    ///       let _response = user.post("/path/to/foo/", "BODY BEING POSTED");
     ///     }
     /// ```
     pub async fn post(&self, path: &str, body: &str) -> GooseResponse {
@@ -862,7 +862,7 @@ impl GooseClient {
     /// Automatically prepends the correct host. Naming a request only affects collected
     /// statistics.
     ///
-    /// Calls to `client.post` return a `GooseResponse` object which contains a copy of
+    /// Calls to `user.post` return a `GooseResponse` object which contains a copy of
     /// the request you made
     /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
     /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
@@ -874,8 +874,8 @@ impl GooseClient {
     ///     let mut task = task!(post_function);
     ///
     ///     /// A very simple task that makes a POST request.
-    ///     async fn post_function(client: &GooseClient) {
-    ///       let _response = client.post_named("/path/to/foo/", "foo", "BODY BEING POSTED");
+    ///     async fn post_function(user: &GooseUser) {
+    ///       let _response = user.post_named("/path/to/foo/", "foo", "BODY BEING POSTED");
     ///     }
     /// ```
     pub async fn post_named(&self, path: &str, request_name: &str, body: &str) -> GooseResponse {
@@ -891,7 +891,7 @@ impl GooseClient {
     /// object, you can instead call `goose_head` which returns a RequestBuilder, then
     /// call `goose_send` to invoke the request.)
     ///
-    /// Calls to `client.head` return a `GooseResponse` object which contains a copy of
+    /// Calls to `user.head` return a `GooseResponse` object which contains a copy of
     /// the request you made
     /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
     /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
@@ -903,8 +903,8 @@ impl GooseClient {
     ///     let mut task = task!(head_function);
     ///
     ///     /// A very simple task that makes a HEAD request.
-    ///     async fn head_function(client: &GooseClient) {
-    ///       let _response = client.head("/path/to/foo/");
+    ///     async fn head_function(user: &GooseUser) {
+    ///       let _response = user.head("/path/to/foo/");
     ///     }
     /// ```
     pub async fn head(&self, path: &str) -> GooseResponse {
@@ -916,7 +916,7 @@ impl GooseClient {
     /// Automatically prepends the correct host. Naming a request only affects collected
     /// statistics.
     ///
-    /// Calls to `client.head` return a `GooseResponse` object which contains a copy of
+    /// Calls to `user.head` return a `GooseResponse` object which contains a copy of
     /// the request you made
     /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
     /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
@@ -928,8 +928,8 @@ impl GooseClient {
     ///     let mut task = task!(head_function);
     ///
     ///     /// A very simple task that makes a HEAD request.
-    ///     async fn head_function(client: &GooseClient) {
-    ///       let _response = client.head_named("/path/to/foo/", "foo");
+    ///     async fn head_function(user: &GooseUser) {
+    ///       let _response = user.head_named("/path/to/foo/", "foo");
     ///     }
     /// ```
     pub async fn head_named(&self, path: &str, request_name: &str) -> GooseResponse {
@@ -945,7 +945,7 @@ impl GooseClient {
     /// object, you can instead call `goose_delete` which returns a RequestBuilder,
     /// then call `goose_send` to invoke the request.)
     ///
-    /// Calls to `client.delete` return a `GooseResponse` object which contains a copy of
+    /// Calls to `user.delete` return a `GooseResponse` object which contains a copy of
     /// the request you made
     /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
     /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
@@ -957,8 +957,8 @@ impl GooseClient {
     ///     let mut task = task!(delete_function);
     ///
     ///     /// A very simple task that makes a DELETE request.
-    ///     async fn delete_function(client: &GooseClient) {
-    ///       let _response = client.delete("/path/to/foo/");
+    ///     async fn delete_function(user: &GooseUser) {
+    ///       let _response = user.delete("/path/to/foo/");
     ///     }
     /// ```
     pub async fn delete(&self, path: &str) -> GooseResponse {
@@ -970,7 +970,7 @@ impl GooseClient {
     /// Automatically prepends the correct host. Naming a request only affects collected
     /// statistics.
     ///
-    /// Calls to `client.delete` return a `GooseResponse` object which contains a copy of
+    /// Calls to `user.delete` return a `GooseResponse` object which contains a copy of
     /// the request you made
     /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
     /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
@@ -982,8 +982,8 @@ impl GooseClient {
     ///     let mut task = task!(delete_function);
     ///
     ///     /// A very simple task that makes a DELETE request.
-    ///     async fn delete_function(client: &GooseClient) {
-    ///       let _response = client.delete_named("/path/to/foo/", "foo");
+    ///     async fn delete_function(user: &GooseUser) {
+    ///       let _response = user.delete_named("/path/to/foo/", "foo");
     ///     }
     /// ```
     pub async fn delete_named(&self, path: &str, request_name: &str) -> GooseResponse {
@@ -1005,9 +1005,9 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn get_function(client: &GooseClient) {
-    ///       let request_builder = client.goose_get("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder, None).await;
+    ///     async fn get_function(user: &GooseUser) {
+    ///       let request_builder = user.goose_get("/path/to/foo").await;
+    ///       let response = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_get(&self, path: &str) -> RequestBuilder {
@@ -1029,9 +1029,9 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a POST request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn post_function(client: &GooseClient) {
-    ///       let request_builder = client.goose_post("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder, None).await;
+    ///     async fn post_function(user: &GooseUser) {
+    ///       let request_builder = user.goose_post("/path/to/foo").await;
+    ///       let response = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_post(&self, path: &str) -> RequestBuilder {
@@ -1053,9 +1053,9 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a HEAD request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn head_function(client: &GooseClient) {
-    ///       let request_builder = client.goose_head("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder, None).await;
+    ///     async fn head_function(user: &GooseUser) {
+    ///       let request_builder = user.goose_head("/path/to/foo").await;
+    ///       let response = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_head(&self, path: &str) -> RequestBuilder {
@@ -1077,9 +1077,9 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a PUT request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn put_function(client: &GooseClient) {
-    ///       let request_builder = client.goose_put("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder, None).await;
+    ///     async fn put_function(user: &GooseUser) {
+    ///       let request_builder = user.goose_put("/path/to/foo").await;
+    ///       let response = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_put(&self, path: &str) -> RequestBuilder {
@@ -1101,9 +1101,9 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a PUT request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn patch_function(client: &GooseClient) {
-    ///       let request_builder = client.goose_patch("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder, None).await;
+    ///     async fn patch_function(user: &GooseUser) {
+    ///       let request_builder = user.goose_patch("/path/to/foo").await;
+    ///       let response = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_patch(&self, path: &str) -> RequestBuilder {
@@ -1125,9 +1125,9 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a DELETE request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn delete_function(client: &GooseClient) {
-    ///       let request_builder = client.goose_delete("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder, None).await;
+    ///     async fn delete_function(user: &GooseUser) {
+    ///       let request_builder = user.goose_delete("/path/to/foo").await;
+    ///       let response = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_delete(&self, path: &str) -> RequestBuilder {
@@ -1144,7 +1144,7 @@ impl GooseClient {
     /// Reqwest without using this helper function, but then Goose is unable to capture
     /// statistics.
     ///
-    /// Calls to `client.goose_send` return a `GooseResponse` object which contains a
+    /// Calls to `user.goose_send` return a `GooseResponse` object which contains a
     /// copy of the request you made
     /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
     /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
@@ -1157,9 +1157,9 @@ impl GooseClient {
     ///
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn get_function(client: &GooseClient) {
-    ///       let request_builder = client.goose_get("/path/to/foo").await;
-    ///       let response = client.goose_send(request_builder, None).await;
+    ///     async fn get_function(user: &GooseUser) {
+    ///       let request_builder = user.goose_get("/path/to/foo").await;
+    ///       let response = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_send(
@@ -1204,7 +1204,7 @@ impl GooseClient {
                 raw_request.set_status_code(Some(status_code));
                 raw_request.set_final_url(r.url().as_str());
 
-                // Load test client was redirected.
+                // Load test user was redirected.
                 if self.config.sticky_follow && raw_request.url != raw_request.final_url {
                     let base_url = self.base_url.read().await.to_string();
                     // Check if the URL redirected started with the load test base_url.
@@ -1218,8 +1218,8 @@ impl GooseClient {
                             }
                         };
                         info!(
-                            "base_url for client {} redirected from {} to {}",
-                            self.weighted_clients_index + 1,
+                            "base_url for user {} redirected from {} to {}",
+                            self.weighted_users_index + 1,
                             &base_url,
                             &redirected_base_url
                         );
@@ -1287,13 +1287,13 @@ impl GooseClient {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A simple task that makes a GET request.
-    ///     async fn get_function(client: &GooseClient) {
-    ///         let mut response = client.get("/404").await;
+    ///     async fn get_function(user: &GooseUser) {
+    ///         let mut response = user.get("/404").await;
     ///         match &response.response {
     ///             Ok(r) => {
     ///                 // We expect a 404 here.
     ///                 if r.status() == 404 {
-    ///                     client.set_success(&mut response.request);
+    ///                     user.set_success(&mut response.request);
     ///                 }
     ///             },
     ///             Err(_) => (),
@@ -1322,8 +1322,8 @@ impl GooseClient {
     ///
     ///     let mut task = task!(loadtest_index_page);
     ///
-    ///     async fn loadtest_index_page(client: &GooseClient) {
-    ///         let mut response = client.get_named("/", "index").await;
+    ///     async fn loadtest_index_page(user: &GooseUser) {
+    ///         let mut response = user.get_named("/", "index").await;
     ///         // Extract the response Result.
     ///         match response.response {
     ///             Ok(r) => {
@@ -1335,11 +1335,11 @@ impl GooseClient {
     ///                             // was a failure.
     ///                             if !text.contains("this string must exist") {
     ///                                 // As this is a named request, pass in the name not the URL
-    ///                                 client.set_failure(&mut response.request);
+    ///                                 user.set_failure(&mut response.request);
     ///                             }
     ///                         }
     ///                         // Empty page, this is a failure.
-    ///                         Err(_) => client.set_failure(&mut response.request),
+    ///                         Err(_) => user.set_failure(&mut response.request),
     ///                     }
     ///                 }
     ///             },
@@ -1387,7 +1387,7 @@ impl GooseClient {
     ///  - Manually building a client in `test_stop` will only affect requests made during
     ///    test teardown;
     ///  - A manually built client is specific to a single Goose thread -- if you are
-    ///    generating a large load test with many clients, each will need to manually build their
+    ///    generating a large load test with many users, each will need to manually build their
     ///    own client (typically you'd do this in a Task that is registered with `set_on_start()`
     ///    in each Task Set requiring a custom client;
     ///  - Manually building a client will completely replace the automatically built client
@@ -1406,7 +1406,7 @@ impl GooseClient {
     ///
     /// task!(setup_custom_client).set_on_start();
     ///
-    /// async fn setup_custom_client(client: &GooseClient) {
+    /// async fn setup_custom_client(user: &GooseUser) {
     ///   use reqwest::{Client, header};
     ///
     ///   // Build a custom HeaderMap to include with all requests made by this client.
@@ -1418,14 +1418,14 @@ impl GooseClient {
     ///     .user_agent("custom user agent")
     ///     .cookie_store(true);
     ///
-    ///   client.set_client_builder(builder);
+    ///   user.set_client_builder(builder);
     /// }
     /// ```
     pub async fn set_client_builder(&self, builder: ClientBuilder) {
         match builder.build() {
             Ok(c) => *self.client.lock().await = c,
             Err(e) => {
-                error!("failed to build client: {}", e);
+                error!("failed to build web client: {}", e);
                 std::process::exit(1);
             }
         };
@@ -1438,9 +1438,9 @@ impl GooseClient {
     /// For example, if the base_url (ie --host) is set to foo.example.com and the
     /// load test requests /login, thereby loading http://foo.example.com/login and
     /// this request gets redirected by the server to http://foo-secure.example.com/,
-    /// subsequent requests made by this client need to be against the new
+    /// subsequent requests made by this user need to be against the new
     /// foo-secure.example.com domain. (Further, if the base_url is again redirected,
-    /// such as when loading http://foo-secure.example.com/logout, the client should
+    /// such as when loading http://foo-secure.example.com/logout, the user should
     /// again follow for subsequent requests, perhaps in this case back to
     /// foo.example.com.)
     ///
@@ -1467,16 +1467,16 @@ impl GooseClient {
     ///     )
     ///     .execute();
     ///
-    ///     async fn task_foo(client: &GooseClient) {
-    ///       let _response = client.get("/");
+    ///     async fn task_foo(user: &GooseUser) {
+    ///       let _response = user.get("/");
     ///     }
     ///
-    ///     async fn task_bar(client: &GooseClient) {
+    ///     async fn task_bar(user: &GooseUser) {
     ///       // Before this task runs, all requests are being made against
     ///       // http://foo.example.com, after this task runs all subsequent
     ///       // requests are made against http://bar.example.com/.
-    ///       client.set_base_url("http://bar.example.com/");
-    ///       let _response = client.get("/");
+    ///       user.set_base_url("http://bar.example.com/");
+    ///       let _response = user.get("/");
     ///     }
     /// ```
     pub async fn set_base_url(&self, host: &str) {
@@ -1527,16 +1527,16 @@ pub struct GooseTask {
     pub weight: usize,
     /// An integer value that controls when this task runs compared to other tasks in the same GooseTaskSet.
     pub sequence: usize,
-    /// A flag indicating that this task runs when the client starts.
+    /// A flag indicating that this task runs when the user starts.
     pub on_start: bool,
-    /// A flag indicating that this task runs when the client stops.
+    /// A flag indicating that this task runs when the user stops.
     pub on_stop: bool,
     /// A required function that is executed each time this task runs.
-    pub function: for<'r> fn(&'r GooseClient) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
+    pub function: for<'r> fn(&'r GooseUser) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
 }
 impl GooseTask {
     pub fn new(
-        function: for<'r> fn(&'r GooseClient) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
+        function: for<'r> fn(&'r GooseUser) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
     ) -> Self {
         trace!("new task");
         GooseTask {
@@ -1553,9 +1553,9 @@ impl GooseTask {
     /// Set an optional name for the task, used when displaying statistics about
     /// requests made by the task.
     ///
-    /// @TODO: rewrite:
     /// Individual requests can also be named withing your load test. See the
-    /// documentation for `GooseClient`.[`set_request_name()`](./struct.GooseClient.html#method.set_request_name)
+    /// documentation for `GooseUser`.
+    /// [`set_request_name()`](./struct.GooseUser.html#method.set_request_name)
     ///
     /// # Example
     /// ```rust
@@ -1563,8 +1563,8 @@ impl GooseTask {
     ///
     ///     task!(my_task_function).set_name("foo");
     ///
-    ///     async fn my_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/");
+    ///     async fn my_task_function(user: &GooseUser) {
+    ///       let _response = user.get("/");
     ///     }
     /// ```
     pub fn set_name(mut self, name: &str) -> Self {
@@ -1574,14 +1574,14 @@ impl GooseTask {
     }
 
     /// Set an optional flag indicating that this task should be run when
-    /// a client first starts. This could be used to log the user in, and
+    /// a user first starts. This could be used to log the user in, and
     /// so all subsequent tasks are done as a logged in user. A task with
     /// this flag set will only run at start time (and optionally at stop
     /// time as well, if that flag is also set).
     ///
     /// On-start tasks can be sequenced and weighted. Sequences allow
     /// multiple on-start tasks to run in a controlled order. Weights allow
-    /// on-start tasks to run multiple times when a client starts.
+    /// on-start tasks to run multiple times when a user starts.
     ///
     /// # Example
     /// ```rust
@@ -1589,8 +1589,8 @@ impl GooseTask {
     ///
     ///     task!(my_on_start_function).set_on_start();
     ///
-    ///     async fn my_on_start_function(client: &GooseClient) {
-    ///       let _response = client.get("/");
+    ///     async fn my_on_start_function(user: &GooseUser) {
+    ///       let _response = user.get("/");
     ///     }
     /// ```
     pub fn set_on_start(mut self) -> Self {
@@ -1600,14 +1600,14 @@ impl GooseTask {
     }
 
     /// Set an optional flag indicating that this task should be run when
-    /// a client stops. This could be used to log a user out when the client
+    /// a user stops. This could be used to log a user out when the user
     /// finishes its load test. A task with this flag set will only run at
     /// stop time (and optionally at start time as well, if that flag is
     /// also set).
     ///
     /// On-stop tasks can be sequenced and weighted. Sequences allow
     /// multiple on-stop tasks to run in a controlled order. Weights allow
-    /// on-stop tasks to run multiple times when a client stops.
+    /// on-stop tasks to run multiple times when a user stops.
     ///
     /// # Example
     /// ```rust
@@ -1615,8 +1615,8 @@ impl GooseTask {
     ///
     ///     task!(my_on_stop_function).set_on_stop();
     ///
-    ///     async fn my_on_stop_function(client: &GooseClient) {
-    ///       let _response = client.get("/");
+    ///     async fn my_on_stop_function(user: &GooseUser) {
+    ///       let _response = user.get("/");
     ///     }
     /// ```
     pub fn set_on_stop(mut self) -> Self {
@@ -1635,8 +1635,8 @@ impl GooseTask {
     ///
     ///     task!(task_function).set_weight(3);
     ///
-    ///     async fn task_function(client: &GooseClient) {
-    ///       let _response = client.get("/");
+    ///     async fn task_function(user: &GooseUser) {
+    ///       let _response = user.get("/");
     ///     }
     /// ```
     pub fn set_weight(mut self, weight: usize) -> Self {
@@ -1672,21 +1672,21 @@ impl GooseTask {
     ///     let runs_second = task!(second_task_function).set_sequence(5835);
     ///     let runs_last = task!(third_task_function);
     ///
-    ///     async fn first_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/1");
+    ///     async fn first_task_function(user: &GooseUser) {
+    ///       let _response = user.get("/1");
     ///     }
     ///
-    ///     async fn second_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/2");
+    ///     async fn second_task_function(user: &GooseUser) {
+    ///       let _response = user.get("/2");
     ///     }
     ///
-    ///     async fn third_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/3");
+    ///     async fn third_task_function(user: &GooseUser) {
+    ///       let _response = user.get("/3");
     ///     }
     /// ```
     ///
     /// In the following example, the `runs_first` task runs two times, then one instance of `runs_second`
-    /// and two instances of `also_runs_second` are all three run. The client will do this over and over
+    /// and two instances of `also_runs_second` are all three run. The user will do this over and over
     /// the entire time it runs, with `runs_first` always running first, then the other tasks being
     /// run in a random and weighted order:
     /// ```rust
@@ -1696,16 +1696,16 @@ impl GooseTask {
     ///     let runs_second = task!(second_task_function_a).set_sequence(2);
     ///     let also_runs_second = task!(second_task_function_b).set_sequence(2).set_weight(2);
     ///
-    ///     async fn first_task_function(client: &GooseClient) {
-    ///       let _response = client.get("/1");
+    ///     async fn first_task_function(user: &GooseUser) {
+    ///       let _response = user.get("/1");
     ///     }
     ///
-    ///     async fn second_task_function_a(client: &GooseClient) {
-    ///       let _response = client.get("/2a");
+    ///     async fn second_task_function_a(user: &GooseUser) {
+    ///       let _response = user.get("/2a");
     ///     }
     ///
-    ///     async fn second_task_function_b(client: &GooseClient) {
-    ///       let _response = client.get("/2b");
+    ///     async fn second_task_function_b(user: &GooseUser) {
+    ///       let _response = user.get("/2b");
     ///     }
     /// ```
     pub fn set_sequence(mut self, sequence: usize) -> Self {
@@ -1743,22 +1743,21 @@ mod tests {
     use httpmock::Method::{GET, POST};
     use httpmock::{mock, with_mock_server};
 
-    async fn setup_client() -> GooseClient {
-        // Set up global client state.
+    async fn setup_user() -> GooseUser {
         let configuration = GooseConfiguration::default();
         let base_url = get_base_url(Some("http://127.0.0.1:5000".to_string()), None, None);
-        GooseClient::single(base_url, &configuration)
+        GooseUser::single(base_url, &configuration)
     }
 
     #[test]
     fn goose_task_set() {
         // Simplistic test task functions.
-        async fn test_function_a(client: &GooseClient) -> () {
-            let _response = client.get("/a/").await;
+        async fn test_function_a(user: &GooseUser) -> () {
+            let _response = user.get("/a/").await;
         }
 
-        async fn test_function_b(client: &GooseClient) -> () {
-            let _response = client.get("/b/").await;
+        async fn test_function_b(user: &GooseUser) -> () {
+            let _response = user.get("/b/").await;
         }
 
         let mut task_set = taskset!("foo");
@@ -1850,8 +1849,8 @@ mod tests {
     #[test]
     fn goose_task() {
         // Simplistic test task functions.
-        async fn test_function_a(client: &GooseClient) -> () {
-            let _response = client.get("/a/");
+        async fn test_function_a(user: &GooseUser) -> () {
+            let _response = user.get("/a/");
         }
 
         // Initialize task set.
@@ -2165,69 +2164,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn goose_client() {
+    async fn goose_user() {
         const HOST: &str = "http://example.com/";
         let configuration = GooseConfiguration::default();
         let base_url = get_base_url(Some(HOST.to_string()), None, None);
-        let client = GooseClient::new(0, base_url, 0, 0, &configuration, 0);
-        assert_eq!(client.task_sets_index, 0);
-        assert_eq!(client.min_wait, 0);
-        assert_eq!(client.max_wait, 0);
-        assert_eq!(client.weighted_clients_index, usize::max_value());
-        assert_eq!(client.weighted_on_start_tasks.len(), 0);
-        assert_eq!(client.weighted_tasks.len(), 0);
-        assert_eq!(client.weighted_on_stop_tasks.len(), 0);
-        assert_eq!(client.task_request_name, None);
-        assert_eq!(client.request_name, None);
+        let user = GooseUser::new(0, base_url, 0, 0, &configuration, 0);
+        assert_eq!(user.task_sets_index, 0);
+        assert_eq!(user.min_wait, 0);
+        assert_eq!(user.max_wait, 0);
+        assert_eq!(user.weighted_users_index, usize::max_value());
+        assert_eq!(user.weighted_on_start_tasks.len(), 0);
+        assert_eq!(user.weighted_tasks.len(), 0);
+        assert_eq!(user.weighted_on_stop_tasks.len(), 0);
+        assert_eq!(user.task_request_name, None);
+        assert_eq!(user.request_name, None);
 
         // Confirm the URLs are correctly built using the default_host.
-        let url = client.build_url("/foo").await;
+        let url = user.build_url("/foo").await;
         eprintln!("url: {}", url);
         assert_eq!(&url, &[HOST, "foo"].concat());
-        let url = client.build_url("bar/").await;
+        let url = user.build_url("bar/").await;
         assert_eq!(&url, &[HOST, "bar/"].concat());
-        let url = client.build_url("/foo/bar").await;
+        let url = user.build_url("/foo/bar").await;
         assert_eq!(&url, &[HOST, "foo/bar"].concat());
 
         // Confirm the URLs are built with their own specified host.
-        let url = client.build_url("https://example.com/foo").await;
+        let url = user.build_url("https://example.com/foo").await;
         assert_eq!(url, "https://example.com/foo");
-        let url = client
+        let url = user
             .build_url("https://www.example.com/path/to/resource")
             .await;
         assert_eq!(url, "https://www.example.com/path/to/resource");
 
-        // Create a second client, this time setting a task_set_host.
+        // Create a second user, this time setting a task_set_host.
         let base_url = get_base_url(
             None,
             Some("http://www2.example.com/".to_string()),
             Some("http://www.example.com/".to_string()),
         );
-        let client2 = GooseClient::new(0, base_url, 1, 3, &configuration, 0);
-        assert_eq!(client2.min_wait, 1);
-        assert_eq!(client2.max_wait, 3);
+        let user2 = GooseUser::new(0, base_url, 1, 3, &configuration, 0);
+        assert_eq!(user2.min_wait, 1);
+        assert_eq!(user2.max_wait, 3);
 
         // Confirm the URLs are correctly built using the task_set_host.
-        let url = client2.build_url("/foo").await;
+        let url = user2.build_url("/foo").await;
         assert_eq!(url, "http://www2.example.com/foo");
 
         // Confirm URLs are still built with their own specified host.
-        let url = client.build_url("https://example.com/foo").await;
+        let url = user2.build_url("https://example.com/foo").await;
         assert_eq!(url, "https://example.com/foo");
 
-        // Recreate client.
-        let client = setup_client().await;
+        // Recreate user2.
+        let user2 = setup_user().await;
         const MOCKHOST: &str = "http://127.0.0.1:5000/";
 
         // Create a GET request.
-        let mut goose_request = client.goose_get("/foo").await;
+        let mut goose_request = user2.goose_get("/foo").await;
         let mut built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::GET);
         assert_eq!(built_request.url().as_str(), &[MOCKHOST, "foo"].concat());
         assert_eq!(built_request.timeout(), None);
 
         // Create a POST request.
-        goose_request = client.goose_post("/path/to/post").await;
+        goose_request = user2.goose_post("/path/to/post").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::POST);
         assert_eq!(
@@ -2237,7 +2236,7 @@ mod tests {
         assert_eq!(built_request.timeout(), None);
 
         // Create a PUT request.
-        goose_request = client.goose_put("/path/to/put").await;
+        goose_request = user2.goose_put("/path/to/put").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::PUT);
         assert_eq!(
@@ -2247,7 +2246,7 @@ mod tests {
         assert_eq!(built_request.timeout(), None);
 
         // Create a PATCH request.
-        goose_request = client.goose_patch("/path/to/patch").await;
+        goose_request = user2.goose_patch("/path/to/patch").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::PATCH);
         assert_eq!(
@@ -2257,7 +2256,7 @@ mod tests {
         assert_eq!(built_request.timeout(), None);
 
         // Create a DELETE request.
-        goose_request = client.goose_delete("/path/to/delete").await;
+        goose_request = user2.goose_delete("/path/to/delete").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::DELETE);
         assert_eq!(
@@ -2267,7 +2266,7 @@ mod tests {
         assert_eq!(built_request.timeout(), None);
 
         // Create a HEAD request.
-        goose_request = client.goose_head("/path/to/head").await;
+        goose_request = user2.goose_head("/path/to/head").await;
         built_request = goose_request.build().unwrap();
         assert_eq!(built_request.method(), &Method::HEAD);
         assert_eq!(
@@ -2280,14 +2279,14 @@ mod tests {
     #[tokio::test]
     #[with_mock_server]
     async fn manual_requests() {
-        let client = setup_client().await;
+        let user = setup_user().await;
 
         // Set up a mock http server endpoint.
         let mock_index = mock(GET, "/").return_status(200).create();
 
         // Make a GET request to the mock http server and confirm we get a 200 response.
         assert_eq!(mock_index.times_called(), 0);
-        let response = client.get("/").await;
+        let response = user.get("/").await;
         let status = response.response.unwrap().status();
         assert_eq!(status, 200);
         assert_eq!(mock_index.times_called(), 1);
@@ -2302,7 +2301,7 @@ mod tests {
 
         // Make an invalid GET request to the mock http server and confirm we get a 404 response.
         assert_eq!(mock_404.times_called(), 0);
-        let response = client.get(NO_SUCH_PATH).await;
+        let response = user.get(NO_SUCH_PATH).await;
         let status = response.response.unwrap().status();
         assert_eq!(status, 404);
         assert_eq!(mock_404.times_called(), 1);
@@ -2325,7 +2324,7 @@ mod tests {
 
         // Make a POST request to the mock http server and confirm we get a 200 OK response.
         assert_eq!(mock_comment.times_called(), 0);
-        let response = client.post(COMMENT_PATH, "foo").await;
+        let response = user.post(COMMENT_PATH, "foo").await;
         let unwrapped_response = response.response.unwrap();
         let status = unwrapped_response.status();
         assert_eq!(status, 200);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1232,7 +1232,7 @@ impl GooseAttack {
 
 /// CLI options available when launching a Goose load test.
 #[derive(StructOpt, Debug, Default, Clone, Serialize, Deserialize)]
-#[structopt(name = "client")]
+#[structopt(name = "Goose")]
 pub struct GooseConfiguration {
     /// Host to load test, for example: http://10.21.32.33
     #[structopt(short = "H", long, required = false, default_value = "")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! goose = "0.7"
+//! goose = "0.8"
 //! ```
 //!
 //! Add the following boilerplate `use` declaration at the top of your `src/main.rs`:
@@ -41,23 +41,23 @@
 //!
 //! ```rust
 //! use goose::{GooseAttack, task, taskset};
-//! use goose::goose::{GooseTaskSet, GooseClient, GooseTask};
+//! use goose::goose::{GooseTaskSet, GooseUser, GooseTask};
 //! ```
 //!
 //! Below your `main` function (which currently is the default `Hello, world!`), add
 //! one or more load test functions. The names of these functions are arbitrary, but it is
 //! recommended you use self-documenting names. Load test functions must be async. Each load
-//! test function must accept a mutable GooseClient pointer. For example:
+//! test function must accept a GooseUser pointer. For example:
 //!
 //! ```rust
 //! use goose::prelude::*;
 //!
-//! async fn loadtest_foo(client: &GooseClient) {
-//!   let _response = client.get("/path/to/foo");
+//! async fn loadtest_foo(user: &GooseUser) {
+//!   let _response = user.get("/path/to/foo");
 //! }   
 //! ```
 //!
-//! In the above example, we're using the GooseClient helper method `get` to load a path
+//! In the above example, we're using the GooseUser helper method `get` to load a path
 //! on the website we are load testing. This helper creates a Reqwest request builder, and
 //! uses it to build and execute a request for the above path. If you want access to the
 //! request builder object, you can instead use the `goose_get` helper, for example to
@@ -68,9 +68,9 @@
 //!
 //! use goose::prelude::*;
 //!
-//! async fn loadtest_bar(client: &GooseClient) {
-//!   let request_builder = client.goose_get("/path/to/bar").await;
-//!   let _response = client.goose_send(request_builder.timeout(time::Duration::from_secs(3)), None).await;
+//! async fn loadtest_bar(user: &GooseUser) {
+//!   let request_builder = user.goose_get("/path/to/bar").await;
+//!   let _response = user.goose_send(request_builder.timeout(time::Duration::from_secs(3)), None).await;
 //! }   
 //! ```
 //!
@@ -99,19 +99,19 @@
 //!     //.set_host("http://dev.local/")
 //!     .execute();
 //!
-//! async fn loadtest_foo(client: &GooseClient) {
-//!   let _response = client.get("/path/to/foo");
+//! async fn loadtest_foo(user: &GooseUser) {
+//!   let _response = user.get("/path/to/foo");
 //! }   
 //!
-//! async fn loadtest_bar(client: &GooseClient) {
-//!   let _response = client.get("/path/to/bar");
+//! async fn loadtest_bar(user: &GooseUser) {
+//!   let _response = user.get("/path/to/bar");
 //! }   
 //! ```
 //!
-//! Goose now spins up a configurable number of clients, each simulating a user on your
-//! website. Thanks to Reqwest, each user maintains its own client state, handling cookies
-//! and more so your "users" can log in, fill out forms, and more, as real users on your
-//! sites would do.
+//! Goose now spins up a configurable number of users, each simulating a user on your
+//! website. Thanks to Reqwest, each user maintains its own web client state, handling
+//! cookies and more so your "users" can log in, fill out forms, and more, as real users
+//! on your sites would do.
 //!
 //! ### Running the Goose load test
 //!
@@ -159,28 +159,28 @@
 //!
 //! ```bash
 //! 05:56:30 [ INFO] run_time = 30
-//! 05:56:30 [ INFO] concurrent clients defaulted to 8 (number of CPUs)
+//! 05:56:30 [ INFO] concurrent users defaulted to 8 (number of CPUs)
 //! ```
 //!
-//! Goose will default to launching 1 client per available CPU core, and will launch them all in
-//! one second. You can change how many clients are launched with the `-c` option, and you can
-//! change how many clients are launched per second with the `-r` option. For example, `-c 30 -r 2`
-//! would launch 30 clients over 15 seconds, or two clients per second.
+//! Goose will default to launching 1 user per available CPU core, and will launch them all in
+//! one second. You can change how many users are launched with the `-u` option, and you can
+//! change how many users are launched per second with the `-r` option. For example, `-u 30 -r 2`
+//! would launch 30 users over 15 seconds, or two users per second.
 //!
 //! ```bash
 //! 05:56:30 [ INFO] global host configured: http://dev.local
-//! 05:56:30 [ INFO] launching client 1 from LoadtestTasks...
-//! 05:56:30 [ INFO] launching client 2 from LoadtestTasks...
-//! 05:56:30 [ INFO] launching client 3 from LoadtestTasks...
-//! 05:56:30 [ INFO] launching client 4 from LoadtestTasks...
-//! 05:56:30 [ INFO] launching client 5 from LoadtestTasks...
-//! 05:56:30 [ INFO] launching client 6 from LoadtestTasks...
-//! 05:56:30 [ INFO] launching client 7 from LoadtestTasks...
-//! 05:56:31 [ INFO] launching client 8 from LoadtestTasks...
-//! 05:56:31 [ INFO] launched 8 clients...
+//! 05:56:30 [ INFO] launching user 1 from LoadtestTasks...
+//! 05:56:30 [ INFO] launching user 2 from LoadtestTasks...
+//! 05:56:30 [ INFO] launching user 3 from LoadtestTasks...
+//! 05:56:30 [ INFO] launching user 4 from LoadtestTasks...
+//! 05:56:30 [ INFO] launching user 5 from LoadtestTasks...
+//! 05:56:30 [ INFO] launching user 6 from LoadtestTasks...
+//! 05:56:30 [ INFO] launching user 7 from LoadtestTasks...
+//! 05:56:31 [ INFO] launching user 8 from LoadtestTasks...
+//! 05:56:31 [ INFO] launched 8 users...
 //! ```
 //!
-//! Each client is launched in its own thread with its own client state. Goose is able to make
+//! Each user is launched in its own thread with its own user state. Goose is able to make
 //! very efficient use of server resources.
 //!
 //! ```bash
@@ -223,7 +223,7 @@
 //!
 //! ```bash
 //! 05:37:10 [ INFO] stopping after 30 seconds...
-//! 05:37:10 [ INFO] waiting for clients to exit
+//! 05:37:10 [ INFO] waiting for users to exit
 //! ```
 //!
 //! Our example only runs for 30 seconds, so we only see running statistics once. When
@@ -292,11 +292,11 @@ extern crate structopt;
 
 pub mod goose;
 
-mod client;
 #[cfg(feature = "gaggle")]
 mod manager;
 pub mod prelude;
 mod stats;
+mod user;
 mod util;
 #[cfg(feature = "gaggle")]
 mod worker;
@@ -322,7 +322,7 @@ use tokio::sync::mpsc;
 use url::Url;
 
 use crate::goose::{
-    GooseClient, GooseClientCommand, GooseRawRequest, GooseRequest, GooseTask, GooseTaskSet,
+    GooseRawRequest, GooseRequest, GooseTask, GooseTaskSet, GooseUser, GooseUserCommand,
 };
 
 /// Constant defining how often statistics should be displayed while load test is running.
@@ -349,28 +349,28 @@ pub struct Socket {}
 /// Internal global state for load test.
 #[derive(Clone)]
 pub struct GooseAttack {
-    /// An optional task to run one time before starting clients and running task sets.
+    /// An optional task to run one time before starting users and running task sets.
     test_start_task: Option<GooseTask>,
-    /// An optional task to run one time after clients have finished running task sets.
+    /// An optional task to run one time after users have finished running task sets.
     test_stop_task: Option<GooseTask>,
     /// A vector containing one copy of each GooseTaskSet that will run during this load test.
     task_sets: Vec<GooseTaskSet>,
     /// A checksum of the task_sets vector to be sure all workers are running the same load test.
     task_sets_hash: u64,
-    /// A weighted vector containing a GooseClient object for each client that will run during this load test.
-    weighted_clients: Vec<GooseClient>,
+    /// A weighted vector containing a GooseUser object for each user that will run during this load test.
+    weighted_users: Vec<GooseUser>,
     /// An optional default host to run this load test against.
     host: Option<String>,
     /// Configuration object managed by StructOpt.
     configuration: GooseConfiguration,
-    /// By default launch 1 client per number of CPUs.
+    /// By default launch 1 user per number of CPUs.
     number_of_cpus: usize,
     /// Track how long the load test should run.
     run_time: usize,
-    /// Track total number of clients to run for this load test.
-    clients: usize,
-    /// Track how many clients are already loaded.
-    active_clients: usize,
+    /// Track total number of users to run for this load test.
+    users: usize,
+    /// Track how many users are already loaded.
+    active_users: usize,
     /// All requests statistics merged together.
     merged_requests: HashMap<String, GooseRequest>,
 }
@@ -390,13 +390,13 @@ impl GooseAttack {
             test_stop_task: None,
             task_sets: Vec::new(),
             task_sets_hash: 0,
-            weighted_clients: Vec::new(),
+            weighted_users: Vec::new(),
             host: None,
             configuration: GooseConfiguration::from_args(),
             number_of_cpus: num_cpus::get(),
             run_time: 0,
-            clients: 0,
-            active_clients: 0,
+            users: 0,
+            active_users: 0,
             merged_requests: HashMap::new(),
         };
         goose_attack.setup()
@@ -419,13 +419,13 @@ impl GooseAttack {
             test_stop_task: None,
             task_sets: Vec::new(),
             task_sets_hash: 0,
-            weighted_clients: Vec::new(),
+            weighted_users: Vec::new(),
             host: None,
             configuration: config,
             number_of_cpus: num_cpus::get(),
             run_time: 0,
-            clients: 0,
-            active_clients: 0,
+            users: 0,
+            active_users: 0,
             merged_requests: HashMap::new(),
         }
     }
@@ -503,35 +503,35 @@ impl GooseAttack {
             self.run_time = 0;
         }
 
-        // Configure number of client threads to launch, default to the number of CPU cores available.
-        self.clients = match self.configuration.clients {
-            Some(c) => {
-                if c == 0 {
+        // Configure number of user threads to launch, default to the number of CPU cores available.
+        self.users = match self.configuration.users {
+            Some(u) => {
+                if u == 0 {
                     if self.configuration.worker {
-                        error!("At least 1 client is required.");
+                        error!("At least 1 user is required.");
                         std::process::exit(1);
                     } else {
                         0
                     }
                 } else {
                     if self.configuration.worker {
-                        error!("The --clients option is only available to the manager.");
+                        error!("The --users option is only available to the manager.");
                         std::process::exit(1);
                     }
-                    c
+                    u
                 }
             }
             None => {
-                let c = self.number_of_cpus;
+                let u = self.number_of_cpus;
                 if !self.configuration.manager && !self.configuration.worker {
-                    info!("concurrent clients defaulted to {} (number of CPUs)", c);
+                    info!("concurrent users defaulted to {} (number of CPUs)", u);
                 }
-                c
+                u
             }
         };
 
         if !self.configuration.manager && !self.configuration.worker {
-            debug!("clients = {}", self.clients);
+            debug!("users = {}", self.users);
         }
 
         self
@@ -552,12 +552,12 @@ impl GooseAttack {
     ///             .register_task(task!(other_task))
     ///         );
     ///
-    ///     async fn example_task(client: &GooseClient) {
-    ///       let _response = client.get("/foo");
+    ///     async fn example_task(user: &GooseUser) {
+    ///       let _response = user.get("/foo");
     ///     }
     ///
-    ///     async fn other_task(client: &GooseClient) {
-    ///       let _response = client.get("/bar");
+    ///     async fn other_task(user: &GooseUser) {
+    ///       let _response = user.get("/bar");
     ///     }
     /// ```
     pub fn register_taskset(mut self, mut taskset: GooseTaskSet) -> Self {
@@ -566,7 +566,7 @@ impl GooseAttack {
         self
     }
 
-    /// Optionally define a task to run before clients are started and all task sets
+    /// Optionally define a task to run before users are started and all task sets
     /// start running. This is would generally be used to set up anything required
     /// for the load test.
     ///
@@ -580,7 +580,7 @@ impl GooseAttack {
     ///     GooseAttack::initialize()
     ///         .test_start(task!(setup));
     ///
-    ///     async fn setup(client: &GooseClient) {
+    ///     async fn setup(user: &GooseUser) {
     ///         // do stuff to set up load test ...
     ///     }
     /// ```
@@ -589,7 +589,7 @@ impl GooseAttack {
         self
     }
 
-    /// Optionally define a task to run after all clients have finished running
+    /// Optionally define a task to run after all users have finished running
     /// all defined task sets. This would generally be used to clean up anything
     /// that was specifically set up for the load test.
     ///
@@ -603,7 +603,7 @@ impl GooseAttack {
     ///     GooseAttack::initialize()
     ///         .test_stop(task!(teardown));
     ///
-    ///     async fn teardown(client: &GooseClient) {
+    ///     async fn teardown(user: &GooseUser) {
     ///         // do stuff to tear down the load test ...
     ///     }
     /// ```
@@ -635,9 +635,9 @@ impl GooseAttack {
         self
     }
 
-    /// Allocate a vector of weighted GooseClient.
-    fn weight_task_set_clients(&mut self) -> Vec<GooseClient> {
-        trace!("weight_task_set_clients");
+    /// Allocate a vector of weighted GooseUser.
+    fn weight_task_set_users(&mut self) -> Vec<GooseUser> {
+        trace!("weight_task_set_users");
 
         let mut u: usize = 0;
         let mut v: usize;
@@ -670,10 +670,10 @@ impl GooseAttack {
             weighted_task_sets.append(&mut weighted_sets);
         }
 
-        // Allocate a state for each client that will be spawned.
-        info!("initializing client states...");
-        let mut weighted_clients = Vec::new();
-        let mut client_count = 0;
+        // Allocate a state for each user that will be spawned.
+        info!("initializing user states...");
+        let mut weighted_users = Vec::new();
+        let mut user_count = 0;
         let config = self.configuration.clone();
         loop {
             for task_sets_index in &weighted_task_sets {
@@ -682,7 +682,7 @@ impl GooseAttack {
                     self.task_sets[*task_sets_index].host.clone(),
                     self.host.clone(),
                 );
-                weighted_clients.push(GooseClient::new(
+                weighted_users.push(GooseUser::new(
                     self.task_sets[*task_sets_index].task_sets_index,
                     base_url,
                     self.task_sets[*task_sets_index].min_wait,
@@ -690,10 +690,10 @@ impl GooseAttack {
                     &config,
                     self.task_sets_hash,
                 ));
-                client_count += 1;
-                if client_count >= self.clients {
-                    trace!("created {} weighted_clients", client_count);
-                    return weighted_clients;
+                user_count += 1;
+                if user_count >= self.users {
+                    trace!("created {} weighted_users", user_count);
+                    return weighted_users;
                 }
             }
         }
@@ -712,12 +712,12 @@ impl GooseAttack {
     ///         )
     ///         .execute();
     ///
-    ///     async fn example_task(client: &GooseClient) {
-    ///       let _response = client.get("/foo");
+    ///     async fn example_task(user: &GooseUser) {
+    ///       let _response = user.get("/foo");
     ///     }
     ///
-    ///     async fn another_example_task(client: &GooseClient) {
-    ///       let _response = client.get("/bar");
+    ///     async fn another_example_task(user: &GooseUser) {
+    ///       let _response = user.get("/bar");
     ///     }
     /// ```
     pub fn execute(mut self) {
@@ -751,10 +751,10 @@ impl GooseAttack {
                 error!("You must set --expect-workers to 1 or more.");
                 std::process::exit(1);
             }
-            if self.configuration.expect_workers as usize > self.clients {
+            if self.configuration.expect_workers as usize > self.users {
                 error!(
-                    "You must enable at least as many clients ({}) as workers ({}).",
-                    self.clients, self.configuration.expect_workers
+                    "You must enable at least as many users ({}) as workers ({}).",
+                    self.users, self.configuration.expect_workers
                 );
                 std::process::exit(1);
             }
@@ -818,10 +818,10 @@ impl GooseAttack {
             std::process::exit(1);
         }
 
-        // Configure number of client threads to launch per second, defaults to 1.
+        // Configure number of user threads to launch per second, defaults to 1.
         let hatch_rate = self.configuration.hatch_rate;
         if hatch_rate < 1 {
-            error!("Hatch rate must be greater than 0, or no clients will launch.");
+            error!("Hatch rate must be greater than 0, or no users will launch.");
             std::process::exit(1);
         }
         if hatch_rate > 1 && self.configuration.worker {
@@ -874,9 +874,9 @@ impl GooseAttack {
             );
         }
 
-        // Allocate a state for each of the clients we are about to start.
+        // Allocate a state for each of the users we are about to start.
         if !self.configuration.worker {
-            self.weighted_clients = self.weight_task_set_clients();
+            self.weighted_users = self.weight_task_set_users();
         }
 
         // Calculate a unique hash for the current load test.
@@ -887,7 +887,7 @@ impl GooseAttack {
 
         // Our load test is officially starting.
         let started = time::Instant::now();
-        // Spawn clients at hatch_rate per second, or one every 1 / hatch_rate fraction of a second.
+        // Spawn users at hatch_rate per second, or one every 1 / hatch_rate fraction of a second.
         let sleep_float = 1.0 / hatch_rate as f32;
         let sleep_duration = time::Duration::from_secs_f32(sleep_float);
 
@@ -924,7 +924,7 @@ impl GooseAttack {
         // Start goose in single-process mode.
         else {
             let mut rt = tokio::runtime::Runtime::new().unwrap();
-            self = rt.block_on(self.launch_clients(started, sleep_duration, None));
+            self = rt.block_on(self.launch_users(started, sleep_duration, None));
         }
 
         if !self.configuration.no_stats && !self.configuration.worker {
@@ -942,95 +942,95 @@ impl GooseAttack {
     }
 
     /// Called internally in local-mode and gaggle-mode.
-    async fn launch_clients(
+    async fn launch_users(
         mut self,
         mut started: time::Instant,
         sleep_duration: time::Duration,
         socket: Option<Socket>,
     ) -> GooseAttack {
         trace!(
-            "launch clients: started({:?}) sleep_duration({:?}) socket({:?})",
+            "launch users: started({:?}) sleep_duration({:?}) socket({:?})",
             started,
             sleep_duration,
             socket
         );
 
-        // Initilize per-client states.
+        // Initilize per-user states.
         if !self.configuration.worker {
             // First run global test_start_task, if defined.
             match &self.test_start_task {
                 Some(t) => {
                     info!("running test_start_task");
-                    // Create a one-time-use Client to run the test_start_task.
+                    // Create a one-time-use User to run the test_start_task.
                     let base_url =
                         goose::get_base_url(self.get_configuration_host(), None, self.host.clone());
-                    let client = GooseClient::single(base_url, &self.configuration);
+                    let user = GooseUser::single(base_url, &self.configuration);
                     let function = t.function;
-                    function(&client).await;
+                    function(&user).await;
                 }
                 // No test_start_task defined, nothing to do.
                 None => (),
             }
         }
 
-        // Collect client threads in a vector for when we want to stop them later.
-        let mut clients = vec![];
-        // Collect client thread channels in a vector so we can talk to the client threads.
-        let mut client_channels = vec![];
+        // Collect user threads in a vector for when we want to stop them later.
+        let mut users = vec![];
+        // Collect user thread channels in a vector so we can talk to the user threads.
+        let mut user_channels = vec![];
         // Create a single channel allowing all Goose child threads to sync state back to parent
         let (all_threads_sender, mut parent_receiver): (
             mpsc::UnboundedSender<GooseRawRequest>,
             mpsc::UnboundedReceiver<GooseRawRequest>,
         ) = mpsc::unbounded_channel();
-        // Spawn clients, each with their own weighted task_set.
-        for mut thread_client in self.weighted_clients.clone() {
+        // Spawn users, each with their own weighted task_set.
+        for mut thread_user in self.weighted_users.clone() {
             // Stop launching threads if the run_timer has expired.
             if util::timer_expired(started, self.run_time) {
                 break;
             }
 
-            // Copy weighted tasks and weighted on start tasks into the client thread.
-            thread_client.weighted_tasks = self.task_sets[thread_client.task_sets_index]
+            // Copy weighted tasks and weighted on start tasks into the user thread.
+            thread_user.weighted_tasks = self.task_sets[thread_user.task_sets_index]
                 .weighted_tasks
                 .clone();
-            thread_client.weighted_on_start_tasks = self.task_sets[thread_client.task_sets_index]
+            thread_user.weighted_on_start_tasks = self.task_sets[thread_user.task_sets_index]
                 .weighted_on_start_tasks
                 .clone();
-            thread_client.weighted_on_stop_tasks = self.task_sets[thread_client.task_sets_index]
+            thread_user.weighted_on_stop_tasks = self.task_sets[thread_user.task_sets_index]
                 .weighted_on_stop_tasks
                 .clone();
-            // Remember which task group this client is using.
-            thread_client.weighted_clients_index = self.active_clients;
+            // Remember which task group this user is using.
+            thread_user.weighted_users_index = self.active_users;
 
             // Create a per-thread channel allowing parent thread to control child threads.
             let (parent_sender, thread_receiver): (
-                mpsc::UnboundedSender<GooseClientCommand>,
-                mpsc::UnboundedReceiver<GooseClientCommand>,
+                mpsc::UnboundedSender<GooseUserCommand>,
+                mpsc::UnboundedReceiver<GooseUserCommand>,
             ) = mpsc::unbounded_channel();
-            client_channels.push(parent_sender);
+            user_channels.push(parent_sender);
 
-            // Copy the client-to-parent sender channel, used by all threads.
-            thread_client.parent = Some(all_threads_sender.clone());
+            // Copy the user-to-parent sender channel, used by all threads.
+            thread_user.parent = Some(all_threads_sender.clone());
 
             // Copy the appropriate task_set into the thread.
-            let thread_task_set = self.task_sets[thread_client.task_sets_index].clone();
+            let thread_task_set = self.task_sets[thread_user.task_sets_index].clone();
 
-            // We number threads from 1 as they're human-visible (in the logs), whereas active_clients starts at 0.
-            let thread_number = self.active_clients + 1;
+            // We number threads from 1 as they're human-visible (in the logs), whereas active_users starts at 0.
+            let thread_number = self.active_users + 1;
 
             let is_worker = self.configuration.worker;
 
-            // Launch a new client.
-            let client = tokio::spawn(client::client_main(
+            // Launch a new user.
+            let user = tokio::spawn(user::user_main(
                 thread_number,
                 thread_task_set,
-                thread_client,
+                thread_user,
                 thread_receiver,
                 is_worker,
             ));
 
-            clients.push(client);
-            self.active_clients += 1;
+            users.push(user);
+            self.active_users += 1;
             debug!("sleeping {:?} milliseconds...", sleep_duration);
             tokio::time::delay_for(sleep_duration).await;
         }
@@ -1038,15 +1038,15 @@ impl GooseAttack {
         started = time::Instant::now();
         if self.configuration.worker {
             info!(
-                "[{}] launched {} clients...",
+                "[{}] launched {} users...",
                 get_worker_id(),
-                self.active_clients
+                self.active_users
             );
         } else {
-            info!("launched {} clients...", self.active_clients);
+            info!("launched {} users...", self.active_users);
         }
 
-        // Track whether or not we've (optionally) reset the statistics after all clients started.
+        // Track whether or not we've (optionally) reset the statistics after all users started.
         let mut statistics_reset: bool = false;
 
         // Catch ctrl-c to allow clean shutdown to display statistics.
@@ -1058,9 +1058,9 @@ impl GooseAttack {
         let mut display_running_statistics = false;
 
         loop {
-            // When displaying running statistics, sync data from client threads first.
+            // When displaying running statistics, sync data from user threads first.
             if !self.configuration.no_stats {
-                // Synchronize statistics from client threads into parent.
+                // Synchronize statistics from user threads into parent.
                 if util::timer_expired(statistics_timer, RUNNING_STATS_EVERY) {
                     statistics_timer = time::Instant::now();
                     if !self.configuration.only_summary {
@@ -1068,7 +1068,7 @@ impl GooseAttack {
                     }
                 }
 
-                // Load messages from client threads until the receiver queue is empty.
+                // Load messages from user threads until the receiver queue is empty.
                 let mut received_message = false;
                 let mut message = parent_receiver.try_recv();
                 while message.is_ok() {
@@ -1122,7 +1122,7 @@ impl GooseAttack {
                     }
                 }
 
-                // Flush statistics collected prior to all client threads running
+                // Flush statistics collected prior to all user threads running
                 if self.configuration.reset_stats && !statistics_reset {
                     info!("statistics reset...");
                     self.merged_requests = HashMap::new();
@@ -1140,25 +1140,25 @@ impl GooseAttack {
                 } else {
                     info!("stopping after {} seconds...", started.elapsed().as_secs());
                 }
-                for (index, send_to_client) in client_channels.iter().enumerate() {
-                    match send_to_client.send(GooseClientCommand::EXIT) {
+                for (index, send_to_user) in user_channels.iter().enumerate() {
+                    match send_to_user.send(GooseUserCommand::EXIT) {
                         Ok(_) => {
-                            debug!("telling client {} to exit", index);
+                            debug!("telling user {} to exit", index);
                         }
                         Err(e) => {
-                            info!("failed to tell client {} to exit: {}", index, e);
+                            info!("failed to tell user {} to exit: {}", index, e);
                         }
                     }
                 }
                 if self.configuration.worker {
-                    info!("[{}] waiting for clients to exit", get_worker_id());
+                    info!("[{}] waiting for users to exit", get_worker_id());
                 } else {
-                    info!("waiting for clients to exit");
+                    info!("waiting for users to exit");
                 }
-                futures::future::join_all(clients).await;
-                debug!("all clients exited");
+                futures::future::join_all(users).await;
+                debug!("all users exited");
 
-                // If we're printing statistics, collect the final messages received from clients
+                // If we're printing statistics, collect the final messages received from users.
                 if !self.configuration.no_stats {
                     let mut message = parent_receiver.try_recv();
                     while message.is_ok() {
@@ -1195,7 +1195,7 @@ impl GooseAttack {
                     }
                 }
 
-                // All clients are done, exit out of loop for final cleanup.
+                // All users are done, exit out of loop for final cleanup.
                 break;
             }
 
@@ -1216,10 +1216,10 @@ impl GooseAttack {
                     info!("running test_stop_task");
                     let base_url =
                         goose::get_base_url(self.get_configuration_host(), None, self.host.clone());
-                    // Create a one-time-use Client to run the test_stop_task.
-                    let client = GooseClient::single(base_url, &self.configuration);
+                    // Create a one-time-use user to run the test_stop_task.
+                    let user = GooseUser::single(base_url, &self.configuration);
                     let function = t.function;
-                    function(&client).await;
+                    function(&user).await;
                 }
                 // No test_stop_task defined, nothing to do.
                 None => (),
@@ -1240,7 +1240,7 @@ pub struct GooseConfiguration {
 
     /// Number of concurrent Goose users (defaults to available CPUs).
     #[structopt(short, long)]
-    pub clients: Option<usize>,
+    pub users: Option<usize>,
 
     /// How many users to spawn per second.
     #[structopt(short = "r", long, required = false, default_value = "1")]
@@ -1284,7 +1284,7 @@ pub struct GooseConfiguration {
     #[structopt(long, default_value = "goose.log")]
     pub log_file: String,
 
-    /// Client follows redirect of base_url with subsequent requests
+    /// User follows redirect of base_url with subsequent requests
     #[structopt(long)]
     pub sticky_follow: bool,
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,2 +1,2 @@
-pub use crate::goose::{GooseClient, GooseMethod, GooseTask, GooseTaskSet};
+pub use crate::goose::{GooseMethod, GooseTask, GooseTaskSet, GooseUser};
 pub use crate::{task, taskset, GooseAttack};

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -13,7 +13,7 @@ pub fn merge_response_times(
     mut global_response_times: BTreeMap<usize, usize>,
     local_response_times: BTreeMap<usize, usize>,
 ) -> BTreeMap<usize, usize> {
-    // Iterate over client response times, and merge into global response times.
+    // Iterate over user response times, and merge into global response times.
     for (response_time, count) in &local_response_times {
         let counter = match global_response_times.get(&response_time) {
             // We've seen this response_time before, increment counter.
@@ -175,7 +175,7 @@ fn print_response_times(requests: &HashMap<String, GooseRequest>, display_percen
     );
     println!(" ----------------------------------------------------------------------------- ");
     for (request_key, request) in requests.clone() {
-        // Iterate over client response times, and merge into global response times.
+        // Iterate over user response times, and merge into global response times.
         aggregate_response_times =
             merge_response_times(aggregate_response_times, request.response_times.clone());
 
@@ -185,11 +185,11 @@ fn print_response_times(requests: &HashMap<String, GooseRequest>, display_percen
         // Increment counter tracking individual response times seen.
         aggregate_response_time_counter += &request.response_time_counter;
 
-        // If client had new fastest response time, update global fastest response time.
+        // If user had new fastest response time, update global fastest response time.
         aggregate_min_response_time =
             update_min_response_time(aggregate_min_response_time, request.min_response_time);
 
-        // If client had new slowest response time, update global slowest resposne time.
+        // If user had new slowest response time, update global slowest resposne time.
         aggregate_max_response_time =
             update_max_response_time(aggregate_max_response_time, request.max_response_time);
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -5,7 +5,7 @@ pub fn build_configuration() -> GooseConfiguration {
     // CLI options.
     GooseConfiguration {
         host: "http://127.0.0.1:5000".to_string(),
-        clients: Some(1),
+        users: Some(1),
         hatch_rate: 1,
         run_time: "1".to_string(),
         no_stats: true,

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -9,12 +9,12 @@ use goose::prelude::*;
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
-pub async fn get_index(client: &GooseClient) {
-    let _response = client.get(INDEX_PATH).await;
+pub async fn get_index(user: &GooseUser) {
+    let _response = user.get(INDEX_PATH).await;
 }
 
-pub async fn get_about(client: &GooseClient) {
-    let _response = client.get(ABOUT_PATH).await;
+pub async fn get_about(user: &GooseUser) {
+    let _response = user.get(ABOUT_PATH).await;
 }
 
 /// Test test_start alone.
@@ -29,7 +29,7 @@ fn test_gaggle() {
     // Start manager instance of the load test.
     let mut master_configuration = configuration.clone();
     let master_handle = thread::spawn(move || {
-        master_configuration.clients = Some(2);
+        master_configuration.users = Some(2);
         master_configuration.hatch_rate = 4;
         master_configuration.manager = true;
         master_configuration.expect_workers = 1;
@@ -45,7 +45,7 @@ fn test_gaggle() {
     let worker_handle = thread::spawn(move || {
         configuration.worker = true;
         configuration.host = "".to_string();
-        configuration.clients = None;
+        configuration.users = None;
         configuration.no_stats = false;
         configuration.run_time = "".to_string();
         crate::GooseAttack::initialize_with_config(configuration)

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -8,14 +8,14 @@ use goose::prelude::*;
 const LOGIN_PATH: &str = "/login";
 const LOGOUT_PATH: &str = "/logout";
 
-pub async fn login(client: &GooseClient) -> () {
-    let request_builder = client.goose_post(LOGIN_PATH).await;
+pub async fn login(user: &GooseUser) -> () {
+    let request_builder = user.goose_post(LOGIN_PATH).await;
     let params = [("username", "me"), ("password", "s3crET!")];
-    let _response = client.goose_send(request_builder.form(&params), None).await;
+    let _response = user.goose_send(request_builder.form(&params), None).await;
 }
 
-pub async fn logout(client: &GooseClient) -> () {
-    let _response = client.get(LOGOUT_PATH).await;
+pub async fn logout(user: &GooseUser) -> () {
+    let _response = user.get(LOGOUT_PATH).await;
 }
 
 #[test]

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -8,12 +8,12 @@ use goose::prelude::*;
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
-pub async fn get_index(client: &GooseClient) -> () {
-    let _response = client.get(INDEX_PATH).await;
+pub async fn get_index(user: &GooseUser) -> () {
+    let _response = user.get(INDEX_PATH).await;
 }
 
-pub async fn get_about(client: &GooseClient) -> () {
-    let _response = client.get(ABOUT_PATH).await;
+pub async fn get_about(user: &GooseUser) -> () {
+    let _response = user.get(ABOUT_PATH).await;
 }
 
 #[test]

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -13,30 +13,30 @@ const REDIRECT3_PATH: &str = "/redirect3";
 const ABOUT_PATH: &str = "/about.php";
 
 // Task function, load INDEX_PATH.
-pub async fn get_index(client: &GooseClient) -> () {
-    let _response = client.get(INDEX_PATH).await;
+pub async fn get_index(user: &GooseUser) -> () {
+    let _response = user.get(INDEX_PATH).await;
 }
 
 // Task function, load ABOUT PATH
-pub async fn get_about(client: &GooseClient) -> () {
-    let _response = client.get(ABOUT_PATH).await;
+pub async fn get_about(user: &GooseUser) -> () {
+    let _response = user.get(ABOUT_PATH).await;
 }
 
 // Task function, load REDRECT_PATH and follow redirects to ABOUT_PATH.
-pub async fn get_redirect(client: &GooseClient) -> () {
-    let mut response = client.get(REDIRECT_PATH).await;
+pub async fn get_redirect(user: &GooseUser) -> () {
+    let mut response = user.get(REDIRECT_PATH).await;
     match response.response {
         Ok(r) => match r.text().await {
             Ok(html) => {
                 // Confirm that we followed redirects and loaded the about page.
                 if !html.contains("about page") {
                     eprintln!("about page body wrong");
-                    client.set_failure(&mut response.request);
+                    user.set_failure(&mut response.request);
                 }
             }
             Err(e) => {
                 eprintln!("unexpected error parsing about page: {}", e);
-                client.set_failure(&mut response.request);
+                user.set_failure(&mut response.request);
             }
         },
         // Goose will catch this error.
@@ -45,8 +45,8 @@ pub async fn get_redirect(client: &GooseClient) -> () {
 }
 
 // Task function, load REDRECT_PATH and follow redirect to new domain.
-pub async fn get_domain_redirect(client: &GooseClient) -> () {
-    let _response = client.get(REDIRECT_PATH).await;
+pub async fn get_domain_redirect(user: &GooseUser) -> () {
+    let _response = user.get(REDIRECT_PATH).await;
 }
 
 #[test]

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -9,18 +9,18 @@ const INDEX_PATH: &str = "/";
 const SETUP_PATH: &str = "/setup";
 const TEARDOWN_PATH: &str = "/teardown";
 
-pub async fn setup(client: &GooseClient) {
-    let _response = client.post(SETUP_PATH, "setting up load test").await;
+pub async fn setup(user: &GooseUser) {
+    let _response = user.post(SETUP_PATH, "setting up load test").await;
 }
 
-pub async fn teardown(client: &GooseClient) {
-    let _response = client
+pub async fn teardown(user: &GooseUser) {
+    let _response = user
         .post(TEARDOWN_PATH, "cleaning up after load test")
         .await;
 }
 
-pub async fn get_index(client: &GooseClient) {
-    let _response = client.get(INDEX_PATH).await;
+pub async fn get_index(user: &GooseUser) {
+    let _response = user.get(INDEX_PATH).await;
 }
 
 /// Test test_start alone.
@@ -87,8 +87,8 @@ fn test_setup_teardown() {
     let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
 
     let mut configuration = common::build_configuration();
-    // Launch several client threads, confirm we still only setup and teardown one time.
-    configuration.clients = Some(5);
+    // Launch several user threads, confirm we still only setup and teardown one time.
+    configuration.users = Some(5);
     configuration.hatch_rate = 5;
 
     crate::GooseAttack::initialize_with_config(configuration)


### PR DESCRIPTION
Prior to 0.8.0 we used `client` to refer to both the HTTP client, and individual user threads. With this PR, `GooseClient` is renamed to `GooseUser`, which results in a lot of name changes in nearly every file in the project.

Going forward:
 - a User is an individual thread running tasks from a given task set
 - a Client is the HTTP client object user's use to make requests

Anyone upgrading from Goose 0.7 to 0.8 will need to update their load tests for this change. For an example on how to upgrade to the new API, review the changes made to `examples/simple.rs` and `examples/drupal_loadtest.rs`.