### PR TITLE
release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.0-dev
+## 0.8.0 June 26, 2020
  - properly subtract previous statistic when handling `set_failure()` and `set_success()`
  - detect and track redirects in `GooseRawRequest`
  - `--sticky-follow` makes redirect of GooseClient base_url sticky, affecting subsequent requests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.8.0-dev"
+version = "0.8.0"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1361,7 +1361,7 @@ impl GooseUser {
     ///
     /// By default, Goose configures two options when building a Reqwest client. The first
     /// configures Goose to report itself as the user agent requesting web pages (ie
-    /// `goose/0.7.5`). The second option configures Reqwest to store cookies, which is
+    /// `goose/0.8.0`). The second option configures Reqwest to store cookies, which is
     /// generally necessary if you aim to simulate logged in users.
     ///
     /// # Default configuration:


### PR DESCRIPTION
Release 0.8.0

## 0.8.0 June 26, 2020
 - properly subtract previous statistic when handling `set_failure()` and `set_success()`
 - detect and track redirects in `GooseRawRequest`
 - `--sticky-follow` makes redirect of GooseClient base_url sticky, affecting subsequent requests
 - changed `GooseClient` to `GooseUser`
