### PR TITLE
fix #42 optionally log all requests to json lines formatted log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.8.1-dev
  - sort stats by method:name to ease comparisons
+ - optionally log all requests in JSON Lines format to file specified with `--log-stats-file=`
 
 ## 0.8.0 June 26, 2020
  - properly subtract previous statistic when handling `set_failure()` and `set_success()`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 simplelog = "0.7"
 structopt = "0.3"
-tokio = { version = "0.2.20", features = ["macros", "rt-core", "time", "sync"] }
+tokio = { version = "0.2.20", features = ["fs", "io-util", "macros", "rt-core", "sync", "time"] }
 url = "2.1"
 
 # optional dependencies

--- a/README.md
+++ b/README.md
@@ -294,15 +294,21 @@ exist will be overwritten.
 Logs are written in the following format:
 
 ```
-GooseRawRequest { method: GET, name: "/", url: "http://apache/", final_url: "http://apache/", redirected: false, response_time: 3, status_code: 200, success: true, update: false }
-GooseRawRequest { method: GET, name: "/about/", url: "http://apache/about/", final_url: "http://apache/about/", redirected: false, response_time: 13, status_code: 404, success: false, update: false }
-GooseRawRequest { method: POST, name: "/login", url: "http://apache/login", final_url: "http://apache/user/1", redirected: true, response_time: 244, status_code: 200, success: true, update: false }
+GooseRawRequest { method: GET, name: "/", url: "http://apache/", final_url: "http://apache/", redirected: false, response_time: 3, elapsed: 1031, status_code: 200, success: true, update: false, user: 0 }
+GooseRawRequest { method: GET, name: "/about/", url: "http://apache/about/", final_url: "http://apache/about/", redirected: false, response_time: 13, elapsed: 1059, status_code: 404, success: false, update: false, user: 5 }
+GooseRawRequest { method: POST, name: "/login", url: "http://apache/login", final_url: "http://apache/user/1", redirected: true, response_time: 244, elapsed: 2028, status_code: 200, success: true, update: false, user: 4 }
 ```
 
-In the above example, the first line is a successful GET request of `/`, which took 3
+In the above example, the first line is a successful `GET` request of `/`, which took 3
 milliseconds to load. The second line is a failed request for `/about/` which returned
-a 404 error in 13 milliseconds. The third line is a failed POST request to `/login`
+a 404 error in 13 milliseconds. The third line is a failed `POST` request to `/login`
 which resulted in a redirect to `/user/1` and took 244 milliseconds.
+
+The `elapsed` entry is the number of milliseconds since the `GooseUser` thread started
+to when it started this request. The `response_time` entry is the number of milliseconds
+it takes the thread to make the request and get a response from the server being load
+tested. The `user` value is the thread number that invoked the request (for example if
+Goose is started with `-u10` there will be logs for 10 threads numbered from 0 to 9).
 
 The final field, `update`, will only be true if this is a reccurence of a previous log
 entry, but with `success` toggling between `true` and `false`. This happens when a load

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,7 +493,7 @@ impl GooseAttack {
                 std::process::exit(1);
             }
 
-            // There is nothing to log if statistics are disabled
+            // There is nothing to log if statistics are disabled.
             if !self.configuration.stats_log_file.is_empty() {
                 error!("You must not enable --no-stats when enabling --stats-log-file.");
                 std::process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,9 +310,9 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashMap};
 use std::f32;
 use std::fs::File;
+use std::hash::{Hash, Hasher};
 use std::io::prelude::*;
 use std::io::BufWriter;
-use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -1064,7 +1064,10 @@ impl GooseAttack {
             stats_log_file = match File::create(&self.configuration.stats_log_file) {
                 Ok(f) => Some(BufWriter::new(f)),
                 Err(e) => {
-                    error!("failed to create stats_log_file ({}): {}", self.configuration.stats_log_file, e);
+                    error!(
+                        "failed to create stats_log_file ({}): {}",
+                        self.configuration.stats_log_file, e
+                    );
                     std::process::exit(1);
                 }
             }
@@ -1089,12 +1092,13 @@ impl GooseAttack {
                     let raw_request = message.unwrap();
 
                     match stats_log_file.as_mut() {
-                        Some(file) => {
-                            match writeln!(*file, "{:?}", &raw_request) {
-                                Ok(_) => (),
-                                Err(e) => {
-                                    warn!("failed to write statistics to {}: {}", &self.configuration.stats_log_file, e);
-                                }
+                        Some(file) => match writeln!(*file, "{:?}", &raw_request) {
+                            Ok(_) => (),
+                            Err(e) => {
+                                warn!(
+                                    "failed to write statistics to {}: {}",
+                                    &self.configuration.stats_log_file, e
+                                );
                             }
                         },
                         None => (),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -16,6 +16,7 @@ pub fn build_configuration() -> GooseConfiguration {
         verbose: 0,
         log_level: 0,
         log_file: "goose.log".to_string(),
+        stats_log_file: "".to_string(),
         sticky_follow: false,
         manager: false,
         no_hash_check: false,


### PR DESCRIPTION
- write request logs from parent thread when statistics are received
- convert internal representation of status code from `Option<StatusCode>` to simple `u16`
- document log format
- asynchronously log to file
- include time elapsed since start of load test, and client thread id in logged data