### PR TITLE
actually log in JSON Lines format; also support csv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ regex = "1"
 reqwest = { version = "0.10", features = ["cookies", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
+serde_json = "1.0"
 simplelog = "0.7"
 structopt = "0.3"
 tokio = { version = "0.2.20", features = ["fs", "io-util", "macros", "rt-core", "sync", "time"] }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -471,7 +471,7 @@ fn goose_method_from_method(method: Method) -> GooseMethod {
 /// or
 /// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_failure)
 /// so Goose knows which request is being updated.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GooseRawRequest {
     /// The method being used (ie, GET, POST, etc).
     pub method: GooseMethod,
@@ -484,9 +484,9 @@ pub struct GooseRawRequest {
     /// How many milliseconds the request took.
     pub redirected: bool,
     /// How many milliseconds the request took.
-    pub response_time: u128,
+    pub response_time: u64,
     /// How many milliseconds the load test has been running.
-    pub elapsed: u128,
+    pub elapsed: u64,
     /// The HTTP response code (optional).
     pub status_code: u16,
     /// Whether or not the request was successful.
@@ -505,7 +505,7 @@ impl GooseRawRequest {
             final_url: "".to_string(),
             redirected: false,
             response_time: 0,
-            elapsed: elapsed,
+            elapsed: elapsed as u64,
             status_code: 0,
             success: true,
             update: false,
@@ -522,7 +522,7 @@ impl GooseRawRequest {
     }
 
     fn set_response_time(&mut self, response_time: u128) {
-        self.response_time = response_time;
+        self.response_time = response_time as u64;
     }
 
     fn set_status_code(&mut self, status_code: Option<StatusCode>) {
@@ -578,7 +578,7 @@ impl GooseRequest {
     }
 
     /// Track response time.
-    pub fn set_response_time(&mut self, response_time: u128) {
+    pub fn set_response_time(&mut self, response_time: u64) {
         // Perform this conversin only once, then re-use throughout this funciton.
         let response_time_usize = response_time as usize;
 
@@ -1965,7 +1965,7 @@ mod tests {
         assert_eq!(raw_request.method, GooseMethod::GET);
         assert_eq!(raw_request.name, "/".to_string());
         assert_eq!(raw_request.url, PATH.to_string());
-        assert_eq!(raw_request.response_time, response_time);
+        assert_eq!(raw_request.response_time, response_time as u64);
         assert_eq!(raw_request.status_code, 0);
         assert_eq!(raw_request.success, true);
         assert_eq!(raw_request.update, false);
@@ -1975,7 +1975,7 @@ mod tests {
         assert_eq!(raw_request.method, GooseMethod::GET);
         assert_eq!(raw_request.name, "/".to_string());
         assert_eq!(raw_request.url, PATH.to_string());
-        assert_eq!(raw_request.response_time, response_time);
+        assert_eq!(raw_request.response_time, response_time as u64);
         assert_eq!(raw_request.status_code, 200);
         assert_eq!(raw_request.success, true);
         assert_eq!(raw_request.update, false);

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -473,6 +473,8 @@ fn goose_method_from_method(method: Method) -> GooseMethod {
 /// so Goose knows which request is being updated.
 #[derive(Debug, Clone, Serialize)]
 pub struct GooseRawRequest {
+    /// How many milliseconds the load test has been running.
+    pub elapsed: u64,
     /// The method being used (ie, GET, POST, etc).
     pub method: GooseMethod,
     /// The optional name of the request.
@@ -485,8 +487,6 @@ pub struct GooseRawRequest {
     pub redirected: bool,
     /// How many milliseconds the request took.
     pub response_time: u64,
-    /// How many milliseconds the load test has been running.
-    pub elapsed: u64,
     /// The HTTP response code (optional).
     pub status_code: u16,
     /// Whether or not the request was successful.
@@ -499,13 +499,13 @@ pub struct GooseRawRequest {
 impl GooseRawRequest {
     pub fn new(method: GooseMethod, name: &str, url: &str, elapsed: u128, user: usize) -> Self {
         GooseRawRequest {
+            elapsed: elapsed as u64,
             method,
             name: name.to_string(),
             url: url.to_string(),
             final_url: "".to_string(),
             redirected: false,
             response_time: 0,
-            elapsed: elapsed as u64,
             status_code: 0,
             success: true,
             update: false,
@@ -532,6 +532,7 @@ impl GooseRawRequest {
         };
     }
 }
+
 /// Statistics collected about a path-method pair, (for example `/index`-`GET`).
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GooseRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,6 +499,30 @@ impl GooseAttack {
                 error!("You must not enable --no-stats when enabling --stats-log-file.");
                 std::process::exit(1);
             }
+
+            // There is nothing to log if statistics are disabled.
+            if !self.configuration.stats_log_file.is_empty() {
+                error!("You must not enable --no-stats when enabling --stats-log-format.");
+                std::process::exit(1);
+            }
+        }
+
+        if self.configuration.stats_log_format != "json" {
+            // Log format isn't relevant if log not enabled.
+            if self.configuration.stats_log_file.is_empty() {
+                error!("You must enable --stats-log-file when setting --stats-log-format.");
+                std::process::exit(1);
+            }
+
+            // All of these options must be defined below, search for formatted_log.
+            let options = vec!["json", "csv", "raw"];
+            if !options.contains(&self.configuration.stats_log_format.as_str()) {
+                error!(
+                    "The --stats-log-format must be set to one of: {}.",
+                    options.join(", ")
+                );
+                std::process::exit(1);
+            }
         }
 
         // Configure maximum run time if specified, otherwise run until canceled.
@@ -1084,6 +1108,43 @@ impl GooseAttack {
             }
         }
 
+        // Add a header when stats_log_format is csv.
+        if self.configuration.stats_log_format.as_str() == "csv" {
+            match stats_log_file.as_mut() {
+                Some(file) => {
+                    match file
+                        .write(
+                            format!(
+                                "{},{},{},{},{},{},{},{},{},{},{}\n",
+                                "method",
+                                "name",
+                                "url",
+                                "final_url",
+                                "redirected",
+                                "response_time",
+                                "elapsed",
+                                "status_code",
+                                "success",
+                                "update",
+                                "user"
+                            )
+                            .as_ref(),
+                        )
+                        .await
+                    {
+                        Ok(_) => (),
+                        Err(e) => {
+                            warn!(
+                                "failed to write statistics to {}: {}",
+                                &self.configuration.stats_log_file, e
+                            );
+                        }
+                    }
+                }
+                None => (),
+            }
+        }
+
         loop {
             // When displaying running statistics, sync data from user threads first.
             if !self.configuration.no_stats {
@@ -1102,12 +1163,34 @@ impl GooseAttack {
                     received_message = true;
                     let raw_request = message.unwrap();
 
+                    // Options should appear above, search for formatted_log.
+                    let formatted_log = match self.configuration.stats_log_format.as_str() {
+                        // Use serde_json to create JSON.
+                        "json" => json!(raw_request).to_string(),
+                        // Manually create CSV, library doesn't support single-row string conversion.
+                        "csv" => format!(
+                            "{:?},\"{}\",\"{}\",\"{}\",{},{},{},{},{},{},{}",
+                            raw_request.method,
+                            raw_request.name,
+                            raw_request.url,
+                            raw_request.final_url,
+                            raw_request.redirected,
+                            raw_request.response_time,
+                            raw_request.elapsed,
+                            raw_request.status_code,
+                            raw_request.success,
+                            raw_request.update,
+                            raw_request.user,
+                        )
+                        .to_string(),
+                        // Raw format is Debug output for GooseRawRequest structure.
+                        "raw" => format!("{:?}", raw_request).to_string(),
+                        _ => unreachable!(),
+                    };
+
                     match stats_log_file.as_mut() {
                         Some(file) => {
-                            match file
-                                .write(format!("{}\n", json!(raw_request).to_string()).as_ref())
-                                .await
-                            {
+                            match file.write(format!("{}\n", formatted_log).as_ref()).await {
                                 Ok(_) => (),
                                 Err(e) => {
                                     warn!(
@@ -1348,6 +1431,10 @@ pub struct GooseConfiguration {
     /// Statistics log file name
     #[structopt(short = "s", long, default_value = "")]
     pub stats_log_file: String,
+
+    /// Statistics log file format
+    #[structopt(long, default_value = "json")]
+    pub stats_log_format: String,
 
     /// User follows redirect of base_url with subsequent requests
     #[structopt(long)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1116,13 +1116,13 @@ impl GooseAttack {
                         .write(
                             format!(
                                 "{},{},{},{},{},{},{},{},{},{},{}\n",
+                                "elapsed",
                                 "method",
                                 "name",
                                 "url",
                                 "final_url",
                                 "redirected",
                                 "response_time",
-                                "elapsed",
                                 "status_code",
                                 "success",
                                 "update",
@@ -1169,14 +1169,14 @@ impl GooseAttack {
                         "json" => json!(raw_request).to_string(),
                         // Manually create CSV, library doesn't support single-row string conversion.
                         "csv" => format!(
-                            "{:?},\"{}\",\"{}\",\"{}\",{},{},{},{},{},{},{}",
+                            "{},{:?},\"{}\",\"{}\",\"{}\",{},{},{},{},{},{}",
+                            raw_request.elapsed,
                             raw_request.method,
                             raw_request.name,
                             raw_request.url,
                             raw_request.final_url,
                             raw_request.redirected,
                             raw_request.response_time,
-                            raw_request.elapsed,
                             raw_request.status_code,
                             raw_request.success,
                             raw_request.update,
@@ -1390,7 +1390,7 @@ pub struct GooseConfiguration {
     #[structopt(short = "r", long, required = false, default_value = "1")]
     pub hatch_rate: usize,
 
-    /// Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.).
+    /// Stop after e.g. (300s, 20m, 3h, 1h30m, etc.).
     #[structopt(short = "t", long, required = false, default_value = "")]
     pub run_time: String,
 
@@ -1432,7 +1432,7 @@ pub struct GooseConfiguration {
     #[structopt(short = "s", long, default_value = "")]
     pub stats_log_file: String,
 
-    /// Statistics log file format
+    /// Statistics log format ('csv', 'json', or 'raw')
     #[structopt(long, default_value = "json")]
     pub stats_log_format: String,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "gaggle")]
 use nng::Socket;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use simplelog::*;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashMap};
@@ -1103,7 +1104,10 @@ impl GooseAttack {
 
                     match stats_log_file.as_mut() {
                         Some(file) => {
-                            match file.write(format!("{:?}\n", &raw_request).as_ref()).await {
+                            match file
+                                .write(format!("{}\n", json!(raw_request).to_string()).as_ref())
+                                .await
+                            {
                                 Ok(_) => (),
                                 Err(e) => {
                                     warn!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -994,7 +994,7 @@ impl GooseAttack {
             raw_request.update,
             raw_request.user
         );
-        // Concatonate the header before the body one time.
+        // Concatenate the header before the body one time.
         if *header {
             *header = false;
             format!(

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -17,6 +17,7 @@ pub fn build_configuration() -> GooseConfiguration {
         log_level: 0,
         log_file: "goose.log".to_string(),
         stats_log_file: "".to_string(),
+        stats_log_format: "json".to_string(),
         sticky_follow: false,
         manager: false,
         no_hash_check: false,


### PR DESCRIPTION
The statistics log is intended to be written in JSON Lines format, but was instead simply writing raw Debug output of `GooseRawRequest` structs.

This PR updates the log writing logic to properly format the GooseRawRequest as JSON when writing the log. It also adds support for writing the log in `csv` and `raw` format (the latter being the format it was previously writing the log in).

CSV files are manually crafted, as the csv library with serde support wants to write directly to file and doesn't have async support. As the GooseRawRequest file only has a few different data types this is simple and very fast.

Also adds documentation for the new `--stats-log-format` command line option.