### PR TITLE
Make Reqwest use Rustls instead on Nativetls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num_cpus = "1.0"
 num-format = "0.4"
 rand = "0.7"
 regex = "1"
-reqwest = { version = "0.10",  default-features = false, features = ["cookies", "json", "rustls-tls"] }
+reqwest = { version = "0.10",  default-features = false, features = ["cookies", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"
@@ -35,7 +35,9 @@ url = "2.1"
 nng = { version = "0.5", optional = true }
 
 [features]
+default = ["reqwest/default-tls"]
 gaggle = ["nng"]
+rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 httpmock = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num_cpus = "1.0"
 num-format = "0.4"
 rand = "0.7"
 regex = "1"
-reqwest = { version = "0.10", features = ["cookies", "json"] }
+reqwest = { version = "0.10",  default-features = false, features = ["cookies", "json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ heading:
 goose = "^0.8"
 ```
 
+If you prefer using a [pure rust TLS implementation](https://github.com/ctz/rustls) for network requests,
+add Goose as following:
+
+```toml
+[dependencies]
+goose = { version = "^0.8", default-features = false, features = ["rustls"] }
+```
+
+
 At this point it's possible to compile all dependencies, though the
 resulting binary only displays "Hello, world!":
 


### PR DESCRIPTION
### Background
I have added Goose to [a CLI tool](https://github.com/JordiPolo/minos/releases). I create static binary releases for it. To do so in Linux I use the Musl target and it happens that it is a major PITA to work with openssl and Musl. 

It also happens that Reqwest allows to choose between [Rustls](https://github.com/ctz/rustls) or Nativetls (which in Linux depends on openssl). Rustls is pretty nice, based on Ring which recently passed a security audit with flying colors. 

### Changes
Change default from using nativetls to rustls. 

I've not changed the release version as you may add more changes before the next release.
@jeremyandrews 