### PR TITLE
document --debug-log-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 0.8.2-dev
- - `client.log_error()` will log errors to file when load test is started with `--error-log-file=` and specifies an error log file
+ - `client.log_debug()` will write debug logs to file when specified with `--debug-log-file=`
+ - add `-debug-log-format=` to switch between `json` (default) and `raw` formats
 
 ## 0.8.1 June 30, 2020
  - sort stats by method:name to ease comparisons

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ FLAGS:
 
 OPTIONS:
     -d, --debug-log-file <debug-log-file>          Debug log file name [default: ]
+        --debug-log-format <debug-log-format>      Debug log format ('json' or 'raw') [default: json]
         --expect-workers <expect-workers>
             Required when in manager mode, how many workers to expect [default: 0]
 
@@ -363,6 +364,10 @@ to this file. Debug is logged in JSON Lines format. For example:
 ```
 
 If `--debug-log-file=foo` is not specified at run time, nothing will be logged.
+
+By default Goose writes debug logs in JSON Lines format. The `--debug-log-format` option
+can be used to log in `json` or `raw` format. The `raw` format is Rust's debug
+output of the entire `GooseDebug` object.
 
 ## Gaggle: Distributed Load Test
 


### PR DESCRIPTION
add missing documentation for `--debug-log-format`