### PR TITLE
POC: It is possible to define callbacks without using macros if you use a helper trait

### DIFF
--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -30,49 +30,49 @@ use regex::Regex;
 fn main() {
     GooseAttack::initialize()
         .register_taskset(
-            taskset!("AnonBrowsingUser")
+            GooseTaskSet::new("AnonBrowsingUser")
                 .set_weight(4)
                 .register_task(
-                    task!(drupal_loadtest_front_page)
+                    GooseTask::new(drupal_loadtest_front_page)
                         .set_weight(15)
                         .set_name("(Anon) front page"),
                 )
                 .register_task(
-                    task!(drupal_loadtest_node_page)
+                    GooseTask::new(drupal_loadtest_node_page)
                         .set_weight(10)
                         .set_name("(Anon) node page"),
                 )
                 .register_task(
-                    task!(drupal_loadtest_profile_page)
+                    GooseTask::new(drupal_loadtest_profile_page)
                         .set_weight(3)
                         .set_name("(Anon) user page"),
                 ),
         )
         .register_taskset(
-            taskset!("AuthBrowsingUser")
+            GooseTaskSet::new("AuthBrowsingUser")
                 .set_weight(1)
                 .register_task(
-                    task!(drupal_loadtest_login)
+                    GooseTask::new(drupal_loadtest_login)
                         .set_on_start()
                         .set_name("(Auth) login"),
                 )
                 .register_task(
-                    task!(drupal_loadtest_front_page)
+                    GooseTask::new(drupal_loadtest_front_page)
                         .set_weight(15)
                         .set_name("(Auth) front page"),
                 )
                 .register_task(
-                    task!(drupal_loadtest_node_page)
+                    GooseTask::new(drupal_loadtest_node_page)
                         .set_weight(10)
                         .set_name("(Auth) node page"),
                 )
                 .register_task(
-                    task!(drupal_loadtest_profile_page)
+                    GooseTask::new(drupal_loadtest_profile_page)
                         .set_weight(3)
                         .set_name("(Auth) user page"),
                 )
                 .register_task(
-                    task!(drupal_loadtest_post_comment)
+                    GooseTask::new(drupal_loadtest_post_comment)
                         .set_weight(3)
                         .set_name("(Auth) comment form"),
                 ),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -23,14 +23,14 @@ fn main() {
     GooseAttack::initialize()
         // In this example, we only create a single taskset, named "WebsiteUser".
         .register_taskset(
-            taskset!("WebsiteUser")
+            GooseTaskSet::new("WebsiteUser")
                 // After each task runs, sleep randomly from 5 to 15 seconds.
                 .set_wait_time(5, 15)
                 // This task only runs one time when the user first starts.
-                .register_task(task!(website_login).set_on_start())
+                .register_task(GooseTask::new(website_login).set_on_start())
                 // These next two tasks run repeatedly as long as the load test is running.
-                .register_task(task!(website_index))
-                .register_task(task!(website_about)),
+                .register_task(GooseTask::new(website_index))
+                .register_task(GooseTask::new(website_about)),
         )
         .execute();
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -269,11 +269,11 @@ use crate::GooseConfiguration;
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
-/// task!(foo) expands to GooseTask::new(foo), but also does some boxing to work around a limitation in the compiler.
+/// task!(foo) expands to GooseTask::from_async_fn(foo),
 #[macro_export]
 macro_rules! task {
     ($task_func:ident) => {
-        GooseTask::new(move |s| std::boxed::Box::pin($task_func(s)))
+        GooseTask::from_async_fn($task_func)
     };
 }
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -270,11 +270,11 @@ use crate::GooseConfiguration;
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
-/// task!(foo) expands to GooseTask::from_async_fn(foo),
+/// task!(foo) expands to GooseTask::new(foo),
 #[macro_export]
 macro_rules! task {
     ($task_func:ident) => {
-        GooseTask::from_async_fn($task_func)
+        GooseTask::new($task_func)
     };
 }
 
@@ -1601,7 +1601,7 @@ pub struct GooseTask {
 }
 
 impl GooseTask {
-    pub fn from_async_fn<F>(cb: F) -> Self
+    pub fn new<F>(cb: F) -> Self
     where
         for<'a> F: GooseTaskCallback<'a> + 'static,
     {
@@ -1615,21 +1615,6 @@ impl GooseTask {
             callback: Arc::new(cb),
         }
     }
-    pub fn new(
-        function: for<'r> fn(&'r GooseUser) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
-    ) -> Self {
-        trace!("new task");
-        GooseTask {
-            tasks_index: usize::max_value(),
-            name: "".to_string(),
-            weight: 1,
-            sequence: 0,
-            on_start: false,
-            on_stop: false,
-            callback: Arc::new(function),
-        }
-    }
-
     /// Execute the callback function and return a boxed future.
     pub fn function<'r>(
         &self,

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -14,7 +14,7 @@
 //! ```rust
 //!     use goose::prelude::*;
 //!
-//!     let mut loadtest_tasks = taskset!("LoadtestTasks");
+//!     let mut loadtest_tasks = GooseTaskSet::new("LoadtestTasks");
 //! ```
 //!
 //! ### Task Set Weight
@@ -28,8 +28,8 @@
 //! ```rust
 //!     use goose::prelude::*;
 //!
-//!     let mut foo_tasks = taskset!("FooTasks").set_weight(10);
-//!     let mut bar_tasks = taskset!("BarTasks").set_weight(5);
+//!     let mut foo_tasks = GooseTaskSet::new("FooTasks").set_weight(10);
+//!     let mut bar_tasks = GooseTaskSet::new("BarTasks").set_weight(5);
 //! ```
 //!
 //! ### Task Set Host
@@ -43,8 +43,8 @@
 //! ```rust
 //!     use goose::prelude::*;
 //!
-//!     let mut foo_tasks = taskset!("FooTasks").set_host("http://www.local");
-//!     let mut bar_tasks = taskset!("BarTasks").set_host("http://www2.local");
+//!     let mut foo_tasks = GooseTaskSet::new("FooTasks").set_host("http://www.local");
+//!     let mut bar_tasks = GooseTaskSet::new("BarTasks").set_host("http://www2.local");
 //! ```
 //!
 //! ### Task Set Wait Time
@@ -58,8 +58,8 @@
 //! ```rust
 //!     use goose::prelude::*;
 //!
-//!     let mut foo_tasks = taskset!("FooTasks").set_wait_time(0, 3);
-//!     let mut bar_tasks = taskset!("BarTasks").set_wait_time(5, 10);
+//!     let mut foo_tasks = GooseTaskSet::new("FooTasks").set_wait_time(0, 3);
+//!     let mut bar_tasks = GooseTaskSet::new("BarTasks").set_wait_time(5, 10);
 //! ```
 //! ## Creating Tasks
 //!
@@ -270,22 +270,6 @@ use crate::GooseConfiguration;
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
-/// task!(foo) expands to GooseTask::new(foo),
-#[macro_export]
-macro_rules! task {
-    ($task_func:ident) => {
-        GooseTask::new($task_func)
-    };
-}
-
-/// taskset!("foo") expands to GooseTaskSet::new("foo").
-#[macro_export]
-macro_rules! taskset {
-    ($name:tt) => {
-        GooseTaskSet::new($name)
-    };
-}
-
 /// An individual task set.
 #[derive(Clone, Hash)]
 pub struct GooseTaskSet {
@@ -318,7 +302,7 @@ impl GooseTaskSet {
     /// ```rust
     ///     use goose::prelude::*;
     ///
-    ///     let mut example_tasks = taskset!("ExampleTasks");
+    ///     let mut example_tasks = GooseTaskSet::new("ExampleTasks");
     /// ```
     pub fn new(name: &str) -> Self {
         trace!("new taskset: name: {}", &name);
@@ -343,7 +327,7 @@ impl GooseTaskSet {
     /// ```rust
     ///     use goose::prelude::*;
     ///
-    ///     let mut example_tasks = taskset!("ExampleTasks");
+    ///     let mut example_tasks = GooseTaskSet::new("ExampleTasks");
     ///     example_tasks.register_task(task!(a_task_function));
     ///
     ///     /// A very simple task that simply loads the "a" page.
@@ -367,7 +351,7 @@ impl GooseTaskSet {
     /// ```rust
     ///     use goose::prelude::*;
     ///
-    ///     let mut example_tasks = taskset!("ExampleTasks").set_weight(3);
+    ///     let mut example_tasks = GooseTaskSet::new("ExampleTasks").set_weight(3);
     /// ```
     pub fn set_weight(mut self, weight: usize) -> Self {
         trace!("{} set_weight: {}", self.name, weight);
@@ -389,7 +373,7 @@ impl GooseTaskSet {
     /// ```rust
     ///     use goose::prelude::*;
     ///
-    ///     let mut example_tasks = taskset!("ExampleTasks").set_host("http://10.1.1.42");
+    ///     let mut example_tasks = GooseTaskSet::new("ExampleTasks").set_host("http://10.1.1.42");
     /// ```
     pub fn set_host(mut self, host: &str) -> Self {
         trace!("{} set_host: {}", self.name, host);
@@ -406,7 +390,7 @@ impl GooseTaskSet {
     /// ```rust
     ///     use goose::prelude::*;
     ///
-    ///     let mut example_tasks = taskset!("ExampleTasks").set_wait_time(0, 1);
+    ///     let mut example_tasks = GooseTaskSet::new("ExampleTasks").set_wait_time(0, 1);
     /// ```
     pub fn set_wait_time(mut self, min_wait: usize, max_wait: usize) -> Self {
         trace!(
@@ -1486,7 +1470,7 @@ impl GooseUser {
     /// use goose::prelude::*;
     ///
     /// GooseAttack::initialize()
-    ///     .register_taskset(taskset!("LoadtestTasks").set_host("http//foo.example.com/")
+    ///     .register_taskset(GooseTaskSet::new("LoadtestTasks").set_host("http//foo.example.com/")
     ///         .set_wait_time(0, 3)
     ///         .register_task(task!(task_foo).set_weight(10))
     ///         .register_task(task!(task_bar))
@@ -1833,7 +1817,7 @@ mod tests {
             let _response = user.get("/b/").await;
         }
 
-        let mut task_set = taskset!("foo");
+        let mut task_set = GooseTaskSet::new("foo");
         assert_eq!(task_set.name, "foo");
         assert_eq!(task_set.task_sets_index, usize::max_value());
         assert_eq!(task_set.weight, 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1041,7 +1041,7 @@ impl GooseAttack {
                     let base_url =
                         goose::get_base_url(self.get_configuration_host(), None, self.host.clone());
                     let user = GooseUser::single(base_url, &self.configuration);
-                    let function = t.function;
+                    let function = &t.function;
                     function(&user).await;
                 }
                 // No test_start_task defined, nothing to do.
@@ -1338,7 +1338,7 @@ impl GooseAttack {
                         goose::get_base_url(self.get_configuration_host(), None, self.host.clone());
                     // Create a one-time-use user to run the test_stop_task.
                     let user = GooseUser::single(base_url, &self.configuration);
-                    let function = t.function;
+                    let function = &t.function;
                     function(&user).await;
                 }
                 // No test_stop_task defined, nothing to do.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1041,8 +1041,7 @@ impl GooseAttack {
                     let base_url =
                         goose::get_base_url(self.get_configuration_host(), None, self.host.clone());
                     let user = GooseUser::single(base_url, &self.configuration);
-                    let function = &t.function;
-                    function(&user).await;
+                    t.function(&user).await;
                 }
                 // No test_start_task defined, nothing to do.
                 None => (),
@@ -1338,8 +1337,7 @@ impl GooseAttack {
                         goose::get_base_url(self.get_configuration_host(), None, self.host.clone());
                     // Create a one-time-use user to run the test_stop_task.
                     let user = GooseUser::single(base_url, &self.configuration);
-                    let function = &t.function;
-                    function(&user).await;
+                    t.function(&user).await;
                 }
                 // No test_stop_task defined, nothing to do.
                 None => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,14 +86,14 @@
 //! use goose::prelude::*;
 //!
 //! GooseAttack::initialize()
-//!     .register_taskset(taskset!("LoadtestTasks")
+//!     .register_taskset(GooseTaskSet::new("LoadtestTasks")
 //!         .set_wait_time(0, 3)
 //!         // Register the foo task, assigning it a weight of 10.
-//!         .register_task(task!(loadtest_foo).set_weight(10))
+//!         .register_task(GooseTask::new(loadtest_foo).set_weight(10))
 //!         // Register the bar task, assigning it a weight of 2 (so it
 //!         // runs 1/5 as often as bar). Apply a task name which shows up
 //!         // in statistics.
-//!         .register_task(task!(loadtest_bar).set_name("bar").set_weight(2))
+//!         .register_task(GooseTask::new(loadtest_bar).set_name("bar").set_weight(2))
 //!     )
 //!     // You could also set a default host here, for example:
 //!     //.set_host("http://dev.local/")
@@ -581,11 +581,11 @@ impl GooseAttack {
     ///     use goose::prelude::*;
     ///
     ///     GooseAttack::initialize()
-    ///         .register_taskset(taskset!("ExampleTasks")
-    ///             .register_task(task!(example_task))
+    ///         .register_taskset(GooseTaskSet::new("ExampleTasks")
+    ///             .register_task(GooseTask::new(example_task))
     ///         )
-    ///         .register_taskset(taskset!("OtherTasks")
-    ///             .register_task(task!(other_task))
+    ///         .register_taskset(GooseTaskSet::new("OtherTasks")
+    ///             .register_task(GooseTask::new(other_task))
     ///         );
     ///
     ///     async fn example_task(user: &GooseUser) {
@@ -614,7 +614,7 @@ impl GooseAttack {
     ///     use goose::prelude::*;
     ///
     ///     GooseAttack::initialize()
-    ///         .test_start(task!(setup));
+    ///         .test_start(GooseTask::new(setup));
     ///
     ///     async fn setup(user: &GooseUser) {
     ///         // do stuff to set up load test ...
@@ -637,7 +637,7 @@ impl GooseAttack {
     ///     use goose::prelude::*;
     ///
     ///     GooseAttack::initialize()
-    ///         .test_stop(task!(teardown));
+    ///         .test_stop(GooseTask::new(teardown));
     ///
     ///     async fn teardown(user: &GooseUser) {
     ///         // do stuff to tear down the load test ...
@@ -742,9 +742,9 @@ impl GooseAttack {
     ///     use goose::prelude::*;
     ///
     ///     GooseAttack::initialize()
-    ///         .register_taskset(taskset!("ExampleTasks")
-    ///             .register_task(task!(example_task).set_weight(2))
-    ///             .register_task(task!(another_example_task).set_weight(3))
+    ///         .register_taskset(GooseTaskSet::new("ExampleTasks")
+    ///             .register_task(GooseTask::new(example_task).set_weight(2))
+    ///             .register_task(GooseTask::new(another_example_task).set_weight(3))
     ///         )
     ///         .execute();
     ///

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,2 +1,2 @@
 pub use crate::goose::{GooseMethod, GooseTask, GooseTaskSet, GooseUser};
-pub use crate::{task, taskset, GooseAttack};
+pub use crate::GooseAttack;

--- a/src/user.rs
+++ b/src/user.rs
@@ -38,7 +38,6 @@ pub async fn user_main(
             for task_index in &sequence {
                 // Determine which task we're going to run next.
                 let thread_task_name = &thread_task_set.tasks[*task_index].name;
-                let function = &thread_task_set.tasks[*task_index].function;
                 debug!(
                     "launching on_start {} task from {}",
                     thread_task_name, thread_task_set.name
@@ -47,7 +46,9 @@ pub async fn user_main(
                     thread_user.task_request_name = Some(thread_task_name.to_string());
                 }
                 // Invoke the task function.
-                function(&thread_user).await;
+                thread_task_set.tasks[*task_index]
+                    .function(&thread_user)
+                    .await;
             }
         }
     }
@@ -88,7 +89,6 @@ pub async fn user_main(
         let thread_weighted_task =
             thread_user.weighted_tasks[weighted_bucket][weighted_bucket_position];
         let thread_task_name = &thread_task_set.tasks[thread_weighted_task].name;
-        let function = &thread_task_set.tasks[thread_weighted_task].function;
         debug!(
             "launching {} task from {}",
             thread_task_name, thread_task_set.name
@@ -98,7 +98,9 @@ pub async fn user_main(
             thread_user.task_request_name = Some(thread_task_name.to_string());
         }
         // Invoke the task function.
-        function(&thread_user).await;
+        thread_task_set.tasks[thread_weighted_task]
+            .function(&thread_user)
+            .await;
 
         // Prepare to sleep for a random value from min_wait to max_wait.
         let wait_time = if thread_user.max_wait > 0 {
@@ -158,7 +160,6 @@ pub async fn user_main(
             for task_index in &sequence {
                 // Determine which task we're going to run next.
                 let thread_task_name = &thread_task_set.tasks[*task_index].name;
-                let function = &thread_task_set.tasks[*task_index].function;
                 debug!(
                     "launching on_stop {} task from {}",
                     thread_task_name, thread_task_set.name
@@ -167,7 +168,9 @@ pub async fn user_main(
                     thread_user.task_request_name = Some(thread_task_name.to_string());
                 }
                 // Invoke the task function.
-                function(&thread_user).await;
+                thread_task_set.tasks[*task_index]
+                    .function(&thread_user)
+                    .await;
             }
         }
     }

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -36,8 +36,8 @@ fn test_gaggle() {
         master_configuration.run_time = "3".to_string();
         crate::GooseAttack::initialize_with_config(master_configuration)
             .setup()
-            .register_taskset(taskset!("User1").register_task(task!(get_index)))
-            .register_taskset(taskset!("User2").register_task(task!(get_about)))
+            .register_taskset(GooseTaskSet::new("User1").register_task(GooseTask::new(get_index)))
+            .register_taskset(GooseTaskSet::new("User2").register_task(GooseTask::new(get_about)))
             .execute();
     });
 
@@ -50,8 +50,8 @@ fn test_gaggle() {
         configuration.run_time = "".to_string();
         crate::GooseAttack::initialize_with_config(configuration)
             .setup()
-            .register_taskset(taskset!("User1").register_task(task!(get_index)))
-            .register_taskset(taskset!("User2").register_task(task!(get_about)))
+            .register_taskset(GooseTaskSet::new("User1").register_task(GooseTask::new(get_index)))
+            .register_taskset(GooseTaskSet::new("User2").register_task(GooseTask::new(get_about)))
             .execute();
     });
 

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -27,9 +27,9 @@ fn test_no_normal_tasks() {
     crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .register_taskset(
-            taskset!("LoadTest")
-                .register_task(task!(login).set_on_start())
-                .register_task(task!(logout).set_on_stop()),
+            GooseTaskSet::new("LoadTest")
+                .register_task(GooseTask::new(login).set_on_start())
+                .register_task(GooseTask::new(logout).set_on_stop()),
         )
         .execute();
 

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -28,9 +28,9 @@ fn test_single_taskset() {
     crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .register_taskset(
-            taskset!("LoadTest")
-                .register_task(task!(get_index).set_weight(9))
-                .register_task(task!(get_about).set_weight(3)),
+            GooseTaskSet::new("LoadTest")
+                .register_task(GooseTask::new(get_index).set_weight(9))
+                .register_task(GooseTask::new(get_about).set_weight(3)),
         )
         .execute();
 

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -78,12 +78,12 @@ fn test_redirect() {
     crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .register_taskset(
-            taskset!("LoadTest")
+            GooseTaskSet::new("LoadTest")
                 // Load index directly.
-                .register_task(task!(get_index))
+                .register_task(GooseTask::new(get_index))
                 // Load redirect path, redirect to redirect2 path, redirect to
                 // redirect3 path, redirect to about.
-                .register_task(task!(get_redirect)),
+                .register_task(GooseTask::new(get_redirect)),
         )
         .execute();
 
@@ -137,13 +137,13 @@ fn test_domain_redirect() {
     crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .register_taskset(
-            taskset!("LoadTest")
+            GooseTaskSet::new("LoadTest")
                 // First load redirect, takes this request only to another domain.
-                .register_task(task!(get_domain_redirect).set_on_start())
+                .register_task(GooseTask::new(get_domain_redirect).set_on_start())
                 // Load index directly.
-                .register_task(task!(get_index))
+                .register_task(GooseTask::new(get_index))
                 // Load about directly, always on original domain.
-                .register_task(task!(get_about)),
+                .register_task(GooseTask::new(get_about)),
         )
         .execute();
 
@@ -193,14 +193,14 @@ fn test_sticky_domain_redirect() {
     crate::GooseAttack::initialize_with_config(configuration)
         .setup()
         .register_taskset(
-            taskset!("LoadTest")
+            GooseTaskSet::new("LoadTest")
                 // First load redirect, due to stick_follow the load test stays on the
                 // new domain for all subsequent requests.
-                .register_task(task!(get_domain_redirect).set_on_start())
+                .register_task(GooseTask::new(get_domain_redirect).set_on_start())
                 // Due to sticky follow, we should always load the alternative index.
-                .register_task(task!(get_index))
+                .register_task(GooseTask::new(get_index))
                 // Due to sticky follow, we should always load the alternative about.
-                .register_task(task!(get_about)),
+                .register_task(GooseTask::new(get_about)),
         )
         .execute();
 

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -33,8 +33,8 @@ fn test_start() {
 
     crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
-        .test_start(task!(setup))
-        .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
+        .test_start(GooseTask::new(setup))
+        .register_taskset(GooseTaskSet::new("LoadTest").register_task(GooseTask::new(get_index).set_weight(9)))
         .execute();
 
     let called_setup = mock_setup.times_called();
@@ -61,8 +61,8 @@ fn test_stop() {
 
     crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
-        .test_stop(task!(teardown))
-        .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
+        .test_stop(GooseTask::new(teardown))
+        .register_taskset(GooseTaskSet::new("LoadTest").register_task(GooseTask::new(get_index).set_weight(9)))
         .execute();
 
     let called_setup = mock_setup.times_called();
@@ -93,9 +93,9 @@ fn test_setup_teardown() {
 
     crate::GooseAttack::initialize_with_config(configuration)
         .setup()
-        .test_start(task!(setup))
-        .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
-        .test_stop(task!(teardown))
+        .test_start(GooseTask::new(setup))
+        .register_taskset(GooseTaskSet::new("LoadTest").register_task(GooseTask::new(get_index).set_weight(9)))
+        .test_stop(GooseTask::new(teardown))
         .execute();
 
     let called_setup = mock_setup.times_called();


### PR DESCRIPTION
There is a discussion in the gotham gitter around doing a similar thing for route handling: https://gitter.im/gotham-rs/gotham?at=5ef9c6f4405be935cdcc4b7b . I thought I should share our approach here in case you are interested.

https://gist.github.com/87ab93979d770314e6698a9867d1e7e5 is probably worth reading first

`GooseTaskCallback<'a>` is equivalent to `AsyncCallback<'a>` in that gist.

There is a bunch of ugliness lying around (like the fact that I had to wrap it in Arc, because fn implements Clone but Fn does not). I suspect that there is a way around this, because we don't need this in Gotham.

Do you want me to keep pulling on this thread, or are you okay with your current macro-based approach?