### PR TITLE
fix panic that happens if no host is provided from cli, even if `GooseAttack::set_host` was used.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,11 +731,10 @@ impl GooseAttack {
         info!("initializing user states...");
         let mut weighted_users = Vec::new();
         let mut user_count = 0;
-        let config = self.configuration.clone();
         loop {
             for task_sets_index in &weighted_task_sets {
                 let base_url = goose::get_base_url(
-                    Some(config.host.to_string()),
+                    self.get_configuration_host(),
                     self.task_sets[*task_sets_index].host.clone(),
                     self.host.clone(),
                 );
@@ -744,7 +743,7 @@ impl GooseAttack {
                     base_url,
                     self.task_sets[*task_sets_index].min_wait,
                     self.task_sets[*task_sets_index].max_wait,
-                    &config,
+                    &self.configuration,
                     self.task_sets_hash,
                 ));
                 user_count += 1;

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -46,3 +46,38 @@ fn test_single_taskset() {
     let difference = called_about as i32 - one_third_index as i32;
     assert!(difference >= -2 && difference <= 2);
 }
+
+#[test]
+#[with_mock_server]
+fn test_single_taskset_empty_config_host() {
+    let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
+    let mock_about = mock(GET, ABOUT_PATH)
+        .return_status(200)
+        .return_body("<HTML><BODY>about page</BODY></HTML>")
+        .create();
+
+    let mut config = common::build_configuration();
+    // this will leave an empty string in config.host
+    let host = std::mem::take(&mut config.host);
+    crate::GooseAttack::initialize_with_config(config)
+        .setup()
+        .register_taskset(
+            taskset!("LoadTest")
+                .register_task(task!(get_index).set_weight(9))
+                .register_task(task!(get_about).set_weight(3)),
+        )
+        .set_host(&host)
+        .execute();
+
+    let called_index = mock_index.times_called();
+    let called_about = mock_about.times_called();
+
+    // Confirm that we loaded the mock endpoints.
+    assert_ne!(called_index, 0);
+    assert_ne!(called_about, 0);
+
+    // Confirm that we loaded the index roughly three times as much as the about page.
+    let one_third_index = called_index / 3;
+    let difference = called_about as i32 - one_third_index as i32;
+    assert!(difference >= -2 && difference <= 2);
+}


### PR DESCRIPTION
I tried to write a test, but I didn't find an easy way, and it's a small fix.