### PR TITLE
optionally throttle requests per second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - fix code documentation, requests are async and require await
  - properly support setting host when registering task set 
  - rename `response` wrapper to `goose`, so we end up with `goose.request` and `goose.response`
+ - add `--throttle-requests` to optionally limit the maximum requests per second
 
 ## 0.8.2 July 2, 2020
  - `client.log_debug()` will write debug logs to file when specified with `--debug-log-file=`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 0.8.3-dev
+## 0.9.0-dev
  - fix code documentation, requests are async and require await
  - properly support setting host when registering task set 
  - rename `response` wrapper to `goose`, so we end up with `goose.request` and `goose.response`
- - add `--throttle-requests` to optionally limit the maximum requests per second
+ - add `--throttle-requests` to optionally limit the maximum requests per second (api change)
 
 ## 0.8.2 July 2, 2020
  - `client.log_debug()` will write debug logs to file when specified with `--debug-log-file=`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["loadtesting", "performance", "web", "framework", "tool"]
 license = "Apache-2.0"
 
 [dependencies]
-async-std = { version = "1.6", features = ["unstable", "tokio02"] }
 ctrlc = "3.1"
 futures = "0.3"
 http = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.8.3-dev"
+version = "0.9.0-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["loadtesting", "performance", "web", "framework", "tool"]
 license = "Apache-2.0"
 
 [dependencies]
+async-std = { version = "1.6", features = ["unstable", "tokio02"] }
 ctrlc = "3.1"
 futures = "0.3"
 http = "0.2"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ heading:
 
 ```toml
 [dependencies]
-goose = "^0.8"
+goose = "^0.9"
 ```
 
 At this point it's possible to compile all dependencies, though the
@@ -47,9 +47,9 @@ resulting binary only displays "Hello, world!":
 ```
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.8.2
+  Downloaded goose v0.9.0
       ...
-   Compiling goose v0.8.2
+   Compiling goose v0.9.0
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`
@@ -165,7 +165,7 @@ load tests. For example, pass the `-h` flag to the `simple` example,
 `cargo run --example simple -- -h`:
 
 ```
-Goose 0.8.2
+Goose 0.9.0
 CLI options available when launching a Goose load test
 
 USAGE:
@@ -202,6 +202,7 @@ OPTIONS:
     -t, --run-time <run-time>                      Stop after e.g. (300s, 20m, 3h, 1h30m, etc.) [default: ]
     -s, --stats-log-file <stats-log-file>          Statistics log file name [default: ]
         --stats-log-format <stats-log-format>      Statistics log format ('csv', 'json', or 'raw') [default: json]
+        --throttle-requests <throttle-requests>    Throttle (max) requests per second
     -u, --users <users>                            Number of concurrent Goose users (defaults to available CPUs)
 ```
 
@@ -284,6 +285,23 @@ $ cargo run --release --example simple -- --host http://apache.fosciana -v -u102
 -------------------------------------------------------------------------------
  Aggregated              | 67,953 [200]              
 ```
+
+## Throttling Requests
+
+By default, Goose will generate as much load as it can. If this is not desirable, the
+throttle allows optionally limiting the maximum number of requests per second made during
+a load test. This can be helpful to ensure consistency when running a load test from
+multiple different servers with different available resources.
+
+The throttle is specified as an integer. For example:
+
+```rust
+$ cargo run --example simple -- --host http://local.dev/ -u100 -r20 -t10s -v --throttle-requests 5
+```
+
+In this example, Goose will launch 100 GooseUser threads, but the throttle will prevent them from
+generating a combined total of more than 5 requests per second. The `--throttle-requests` command
+line option imposes a maximum number of requests, not a minimum number of requests.
 
 ## Logging Load Test Requests
 
@@ -392,7 +410,7 @@ feature in the `dependencies` section of your `Cargo.toml`, for example:
 
 ```toml
 [dependencies]
-goose = { version = "^0.8", features = ["gaggle"] }
+goose = { version = "^0.9", features = ["gaggle"] }
 ```
 
 ### Goose Manager
@@ -451,6 +469,9 @@ The `--no-stats`, `--only-summary`, `--reset-stats`, `--status-codes`, and `--no
 
 The `--users`, `--hatch-rate`, `--host`, and `--run-time` options must be set on the manager. Workers inheret these options from the manager.
 
+The `--throttle-requests` option must be configured on each worker, and can be set to a different value
+on each worker if desired.
+
 ### Technical Details
 
 Goose uses [`nng`](https://docs.rs/nng/) to send network messages between
@@ -470,7 +491,7 @@ disable default features and enable `rustls` in `Cargo.toml` as follows:
 
 ```toml
 [dependencies]
-goose = { version = "^0.8", default-features = false, features = ["rustls"] }
+goose = { version = "^0.9", default-features = false, features = ["rustls"] }
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ multiple different servers with different available resources.
 The throttle is specified as an integer. For example:
 
 ```rust
-$ cargo run --example simple -- --host http://local.dev/ -u100 -r20 -t10s -v --throttle-requests 5
+$ cargo run --example simple -- --host http://local.dev/ -u100 -r20 -v --throttle-requests 5
 ```
 
 In this example, Goose will launch 100 GooseUser threads, but the throttle will prevent them from

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -82,42 +82,46 @@ fn main() {
 
 /// View the front page.
 async fn drupal_loadtest_front_page(user: &GooseUser) {
-    if let Ok(mut goose) = user.get("/").await {
-        // Grab some static assets from the front page.
-        match goose.response {
-            Ok(response) => {
-                // Copy the headers so we have them for logging if there are errors.
-                let headers = &response.headers().clone();
-                match response.text().await {
-                    Ok(t) => {
-                        let re = Regex::new(r#"src="(.*?)""#).unwrap();
-                        // Collect copy of URLs to run them async
-                        let mut urls = Vec::new();
-                        for url in re.captures_iter(&t) {
-                            if url[1].contains("/misc") || url[1].contains("/themes") {
-                                urls.push(url[1].to_string());
-                            }
-                        }
-                        for asset in &urls {
-                            let _ = user.get_named(asset, "static asset").await;
+    let mut goose = match user.get("/").await {
+        // Return early if get fails, there's nothing else to do.
+        Err(_) => return,
+        // Otherwise unwrap the Result.
+        Ok(g) => g,
+    };
+
+    match goose.response {
+        Ok(response) => {
+            // Copy the headers so we have them for logging if there are errors.
+            let headers = &response.headers().clone();
+            match response.text().await {
+                Ok(t) => {
+                    let re = Regex::new(r#"src="(.*?)""#).unwrap();
+                    // Collect copy of URLs to run them async
+                    let mut urls = Vec::new();
+                    for url in re.captures_iter(&t) {
+                        if url[1].contains("/misc") || url[1].contains("/themes") {
+                            urls.push(url[1].to_string());
                         }
                     }
-                    Err(e) => {
-                        user.set_failure(&mut goose.request);
-                        let error = format!("front_page: failed to parse pag: {}", e);
-                        // We choose to both log and display errors to stdout.
-                        eprintln!("{}", &error);
-                        user.log_debug(&error, Some(goose.request), Some(&headers), None);
+                    for asset in &urls {
+                        let _ = user.get_named(asset, "static asset").await;
                     }
                 }
+                Err(e) => {
+                    user.set_failure(&mut goose.request);
+                    let error = format!("front_page: failed to parse pag: {}", e);
+                    // We choose to both log and display errors to stdout.
+                    eprintln!("{}", &error);
+                    user.log_debug(&error, Some(goose.request), Some(&headers), None);
+                }
             }
-            Err(e) => {
-                user.set_failure(&mut goose.request);
-                let error = format!("front_page: no response from server: {}", e);
-                // We choose to both log and display errors to stdout.
-                eprintln!("{}", &error);
-                user.log_debug(&error, Some(goose.request), None, None);
-            }
+        }
+        Err(e) => {
+            user.set_failure(&mut goose.request);
+            let error = format!("front_page: no response from server: {}", e);
+            // We choose to both log and display errors to stdout.
+            eprintln!("{}", &error);
+            user.log_debug(&error, Some(goose.request), None, None);
         }
     }
 }
@@ -136,64 +140,68 @@ async fn drupal_loadtest_profile_page(user: &GooseUser) {
 
 /// Log in.
 async fn drupal_loadtest_login(user: &GooseUser) {
-    if let Ok(mut goose) = user.get("/user").await {
-        match goose.response {
-            Ok(response) => {
-                // Copy the headers so we have them for logging if there are errors.
-                let headers = &response.headers().clone();
-                match response.text().await {
-                    Ok(html) => {
-                        let re = Regex::new(r#"name="form_build_id" value=['"](.*?)['"]"#).unwrap();
-                        let form_build_id = match re.captures(&html) {
-                            Some(f) => f,
-                            None => {
-                                user.set_failure(&mut goose.request);
-                                let error = "login: no form_build_id on page: /user page";
-                                // We choose to both log and display errors to stdout.
-                                eprintln!("{}", error);
-                                user.log_debug(
-                                    error,
-                                    Some(goose.request),
-                                    Some(&headers),
-                                    Some(html.clone()),
-                                );
-                                return;
-                            }
-                        };
+    let mut goose = match user.get("/user").await {
+        // Return early if get fails, there's nothing else to do.
+        Err(_) => return,
+        // Otherwise unwrap the Result.
+        Ok(g) => g,
+    };
 
-                        // Log the user in.
-                        let uid: usize = rand::thread_rng().gen_range(3, 5_002);
-                        let username = format!("user{}", uid);
-                        let params = [
-                            ("name", username.as_str()),
-                            ("pass", "12345"),
-                            ("form_build_id", &form_build_id[1]),
-                            ("form_id", "user_login"),
-                            ("op", "Log+in"),
-                        ];
-                        let request_builder = user.goose_post("/user").await;
-                        let _goose = user.goose_send(request_builder.form(&params), None).await;
-                        // @TODO: verify that we actually logged in.
-                    }
-                    Err(e) => {
-                        user.set_failure(&mut goose.request);
-                        let error =
-                            format!("login: unexpected error when loading /user page: {}", e);
-                        // We choose to both log and display errors to stdout.
-                        eprintln!("{}", &error);
-                        user.log_debug(&error, Some(goose.request), Some(&headers), None);
-                    }
+    match goose.response {
+        Ok(response) => {
+            // Copy the headers so we have them for logging if there are errors.
+            let headers = &response.headers().clone();
+            match response.text().await {
+                Ok(html) => {
+                    let re = Regex::new(r#"name="form_build_id" value=['"](.*?)['"]"#).unwrap();
+                    let form_build_id = match re.captures(&html) {
+                        Some(f) => f,
+                        None => {
+                            user.set_failure(&mut goose.request);
+                            let error = "login: no form_build_id on page: /user page";
+                            // We choose to both log and display errors to stdout.
+                            eprintln!("{}", error);
+                            user.log_debug(
+                                error,
+                                Some(goose.request),
+                                Some(&headers),
+                                Some(html.clone()),
+                            );
+                            return;
+                        }
+                    };
+
+                    // Log the user in.
+                    let uid: usize = rand::thread_rng().gen_range(3, 5_002);
+                    let username = format!("user{}", uid);
+                    let params = [
+                        ("name", username.as_str()),
+                        ("pass", "12345"),
+                        ("form_build_id", &form_build_id[1]),
+                        ("form_id", "user_login"),
+                        ("op", "Log+in"),
+                    ];
+                    let request_builder = user.goose_post("/user").await;
+                    let _goose = user.goose_send(request_builder.form(&params), None).await;
+                    // @TODO: verify that we actually logged in.
+                }
+                Err(e) => {
+                    user.set_failure(&mut goose.request);
+                    let error = format!("login: unexpected error when loading /user page: {}", e);
+                    // We choose to both log and display errors to stdout.
+                    eprintln!("{}", &error);
+                    user.log_debug(&error, Some(goose.request), Some(&headers), None);
                 }
             }
-            // Goose will catch this error.
-            Err(e) => {
-                user.log_debug(
-                    format!("login: no response from server: {}", e).as_str(),
-                    None,
-                    None,
-                    None,
-                );
-            }
+        }
+        // Goose will catch this error.
+        Err(e) => {
+            user.log_debug(
+                format!("login: no response from server: {}", e).as_str(),
+                None,
+                None,
+                None,
+            );
         }
     }
 }
@@ -203,157 +211,166 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
     let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);
-    if let Ok(mut goose) = user.get(&node_path).await {
-        match goose.response {
-            Ok(response) => {
-                // Copy the headers so we have them for logging if there are errors.
-                let headers = &response.headers().clone();
-                match response.text().await {
-                    Ok(html) => {
-                        // Extract the form_build_id from the user login form.
-                        let re = Regex::new(r#"name="form_build_id" value=['"](.*?)['"]"#).unwrap();
-                        let form_build_id = match re.captures(&html) {
-                            Some(f) => f,
-                            None => {
-                                user.set_failure(&mut goose.request);
-                                let error = format!(
-                                    "post_comment: no form_build_id found on {}",
-                                    &node_path
-                                );
-                                // We choose to both log and display errors to stdout.
-                                eprintln!("{}", &error);
-                                user.log_debug(
-                                    &error,
-                                    Some(goose.request),
-                                    Some(headers),
-                                    Some(html.clone()),
-                                );
-                                return;
-                            }
-                        };
 
-                        let re = Regex::new(r#"name="form_token" value=['"](.*?)['"]"#).unwrap();
-                        let form_token = match re.captures(&html) {
-                            Some(f) => f,
-                            None => {
-                                user.set_failure(&mut goose.request);
-                                let error =
-                                    format!("post_comment: no form_token found on {}", &node_path);
-                                // We choose to both log and display errors to stdout.
-                                eprintln!("{}", &error);
-                                user.log_debug(
-                                    &error,
-                                    Some(goose.request),
-                                    Some(&headers),
-                                    Some(html.clone()),
-                                );
-                                return;
-                            }
-                        };
+    let mut goose = match user.get(&node_path).await {
+        // Return early if get fails, there's nothing else to do.
+        Err(_) => return,
+        // Otherwise unwrap the Result.
+        Ok(g) => g,
+    };
 
-                        let re = Regex::new(r#"name="form_id" value=['"](.*?)['"]"#).unwrap();
-                        let form_id = match re.captures(&html) {
-                            Some(f) => f,
-                            None => {
-                                user.set_failure(&mut goose.request);
-                                let error =
-                                    format!("post_comment: no form_id found on {}", &node_path);
-                                // We choose to both log and display errors to stdout.
-                                eprintln!("{}", &error);
-                                user.log_debug(
-                                    &error,
-                                    Some(goose.request),
-                                    Some(&headers),
-                                    Some(html.clone()),
-                                );
-                                return;
-                            }
-                        };
-                        //println!("form_id: {}, form_build_id: {}, form_token: {}", &form_id, &form_build_id, &form_token);
+    match goose.response {
+        Ok(response) => {
+            // Copy the headers so we have them for logging if there are errors.
+            let headers = &response.headers().clone();
+            match response.text().await {
+                Ok(html) => {
+                    // Extract the form_build_id from the user login form.
+                    let re = Regex::new(r#"name="form_build_id" value=['"](.*?)['"]"#).unwrap();
+                    let form_build_id = match re.captures(&html) {
+                        Some(f) => f,
+                        None => {
+                            user.set_failure(&mut goose.request);
+                            let error =
+                                format!("post_comment: no form_build_id found on {}", &node_path);
+                            // We choose to both log and display errors to stdout.
+                            eprintln!("{}", &error);
+                            user.log_debug(
+                                &error,
+                                Some(goose.request),
+                                Some(headers),
+                                Some(html.clone()),
+                            );
+                            return;
+                        }
+                    };
 
-                        let comment_body = "this is a test comment body";
-                        let params = [
-                            ("subject", "this is a test comment subject"),
-                            ("comment_body[und][0][value]", &comment_body),
-                            ("comment_body[und][0][format]", "filtered_html"),
-                            ("form_build_id", &form_build_id[1]),
-                            ("form_token", &form_token[1]),
-                            ("form_id", &form_id[1]),
-                            ("op", "Save"),
-                        ];
-                        let request_builder = user.goose_post(&comment_path).await;
-                        if let Ok(mut goose) =
-                            user.goose_send(request_builder.form(&params), None).await
-                        {
-                            match goose.response {
-                                Ok(response) => {
-                                    // Copy the headers so we have them for logging if there are errors.
-                                    let headers = &response.headers().clone();
-                                    match response.text().await {
-                                        Ok(html) => {
-                                            if !html.contains(&comment_body) {
-                                                user.set_failure(&mut goose.request);
-                                                let error = format!("post_comment: no comment showed up after posting to {}", &comment_path);
-                                                // We choose to both log and display errors to stdout.
-                                                eprintln!("{}", &error);
-                                                user.log_debug(
-                                                    &error,
-                                                    Some(goose.request),
-                                                    Some(&headers),
-                                                    Some(html),
-                                                );
-                                            }
-                                        }
-                                        Err(e) => {
-                                            user.set_failure(&mut goose.request);
-                                            let error = format!(
-                                                "post_comment: unexpected error when posting to {}: {}",
-                                                &comment_path, e
-                                            );
-                                            // We choose to both log and display errors to stdout.
-                                            eprintln!("{}", &error);
-                                            user.log_debug(
-                                                &error,
-                                                Some(goose.request),
-                                                Some(&headers),
-                                                None,
-                                            );
-                                        }
+                    let re = Regex::new(r#"name="form_token" value=['"](.*?)['"]"#).unwrap();
+                    let form_token = match re.captures(&html) {
+                        Some(f) => f,
+                        None => {
+                            user.set_failure(&mut goose.request);
+                            let error =
+                                format!("post_comment: no form_token found on {}", &node_path);
+                            // We choose to both log and display errors to stdout.
+                            eprintln!("{}", &error);
+                            user.log_debug(
+                                &error,
+                                Some(goose.request),
+                                Some(&headers),
+                                Some(html.clone()),
+                            );
+                            return;
+                        }
+                    };
+
+                    let re = Regex::new(r#"name="form_id" value=['"](.*?)['"]"#).unwrap();
+                    let form_id = match re.captures(&html) {
+                        Some(f) => f,
+                        None => {
+                            user.set_failure(&mut goose.request);
+                            let error = format!("post_comment: no form_id found on {}", &node_path);
+                            // We choose to both log and display errors to stdout.
+                            eprintln!("{}", &error);
+                            user.log_debug(
+                                &error,
+                                Some(goose.request),
+                                Some(&headers),
+                                Some(html.clone()),
+                            );
+                            return;
+                        }
+                    };
+                    //println!("form_id: {}, form_build_id: {}, form_token: {}", &form_id, &form_build_id, &form_token);
+
+                    let comment_body = "this is a test comment body";
+                    let params = [
+                        ("subject", "this is a test comment subject"),
+                        ("comment_body[und][0][value]", &comment_body),
+                        ("comment_body[und][0][format]", "filtered_html"),
+                        ("form_build_id", &form_build_id[1]),
+                        ("form_token", &form_token[1]),
+                        ("form_id", &form_id[1]),
+                        ("op", "Save"),
+                    ];
+
+                    // Post the comment.
+                    let request_builder = user.goose_post(&comment_path).await;
+                    let mut goose = match user.goose_send(request_builder.form(&params), None).await
+                    {
+                        // Return early if get fails, there's nothing else to do.
+                        Err(_) => return,
+                        // Otherwise unwrap the Result.
+                        Ok(g) => g,
+                    };
+
+                    // Verify that the comment posted.
+                    match goose.response {
+                        Ok(response) => {
+                            // Copy the headers so we have them for logging if there are errors.
+                            let headers = &response.headers().clone();
+                            match response.text().await {
+                                Ok(html) => {
+                                    if !html.contains(&comment_body) {
+                                        user.set_failure(&mut goose.request);
+                                        let error = format!("post_comment: no comment showed up after posting to {}", &comment_path);
+                                        // We choose to both log and display errors to stdout.
+                                        eprintln!("{}", &error);
+                                        user.log_debug(
+                                            &error,
+                                            Some(goose.request),
+                                            Some(&headers),
+                                            Some(html),
+                                        );
                                     }
                                 }
-                                // Goose will catch this error.
                                 Err(e) => {
+                                    user.set_failure(&mut goose.request);
                                     let error = format!(
-                                        "post_comment: no response when posting to {}: {}",
+                                        "post_comment: unexpected error when posting to {}: {}",
                                         &comment_path, e
                                     );
                                     // We choose to both log and display errors to stdout.
                                     eprintln!("{}", &error);
-                                    user.log_debug(&error, Some(goose.request), None, None);
+                                    user.log_debug(
+                                        &error,
+                                        Some(goose.request),
+                                        Some(&headers),
+                                        None,
+                                    );
                                 }
                             }
                         }
-                    }
-                    Err(e) => {
-                        user.set_failure(&mut goose.request);
-                        let error =
-                            format!("post_comment: no text when loading {}: {}", &node_path, e);
-                        // We choose to both log and display errors to stdout.
-                        eprintln!("{}", &error);
-                        user.log_debug(&error, Some(goose.request), None, None);
+                        // Goose will catch this error.
+                        Err(e) => {
+                            let error = format!(
+                                "post_comment: no response when posting to {}: {}",
+                                &comment_path, e
+                            );
+                            // We choose to both log and display errors to stdout.
+                            eprintln!("{}", &error);
+                            user.log_debug(&error, Some(goose.request), None, None);
+                        }
                     }
                 }
+                Err(e) => {
+                    user.set_failure(&mut goose.request);
+                    let error = format!("post_comment: no text when loading {}: {}", &node_path, e);
+                    // We choose to both log and display errors to stdout.
+                    eprintln!("{}", &error);
+                    user.log_debug(&error, Some(goose.request), None, None);
+                }
             }
-            // Goose will catch this error.
-            Err(e) => {
-                let error = format!(
-                    "post_comment: no response when loading {}: {}",
-                    &node_path, e
-                );
-                // We choose to both log and display errors to stdout.
-                eprintln!("{}", &error);
-                user.log_debug(&error, Some(goose.request), None, None);
-            }
+        }
+        // Goose will catch this error.
+        Err(e) => {
+            let error = format!(
+                "post_comment: no response when loading {}: {}",
+                &node_path, e
+            );
+            // We choose to both log and display errors to stdout.
+            eprintln!("{}", &error);
+            user.log_debug(&error, Some(goose.request), None, None);
         }
     }
 }

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -85,39 +85,41 @@ async fn drupal_loadtest_front_page(user: &GooseUser) {
     let mut goose = user.get("/").await;
 
     // Grab some static assets from the front page.
-    match goose.response {
-        Ok(r) => {
-            // Copy the headers so we have them for logging if there are errors.
-            let headers = &r.headers().clone();
-            match r.text().await {
-                Ok(t) => {
-                    let re = Regex::new(r#"src="(.*?)""#).unwrap();
-                    // Collect copy of URLs to run them async
-                    let mut urls = Vec::new();
-                    for url in re.captures_iter(&t) {
-                        if url[1].contains("/misc") || url[1].contains("/themes") {
-                            urls.push(url[1].to_string());
+    if let Some(response) = goose.response {
+        match response {
+            Ok(r) => {
+                // Copy the headers so we have them for logging if there are errors.
+                let headers = &r.headers().clone();
+                match r.text().await {
+                    Ok(t) => {
+                        let re = Regex::new(r#"src="(.*?)""#).unwrap();
+                        // Collect copy of URLs to run them async
+                        let mut urls = Vec::new();
+                        for url in re.captures_iter(&t) {
+                            if url[1].contains("/misc") || url[1].contains("/themes") {
+                                urls.push(url[1].to_string());
+                            }
+                        }
+                        for asset in &urls {
+                            user.get_named(asset, "static asset").await;
                         }
                     }
-                    for asset in &urls {
-                        user.get_named(asset, "static asset").await;
+                    Err(e) => {
+                        user.set_failure(&mut goose.request);
+                        let error = format!("front_page: failed to parse pag: {}", e);
+                        // We choose to both log and display errors to stdout.
+                        eprintln!("{}", &error);
+                        user.log_debug(&error, Some(goose.request), Some(&headers), None);
                     }
                 }
-                Err(e) => {
-                    user.set_failure(&mut goose.request);
-                    let error = format!("front_page: failed to parse pag: {}", e);
-                    // We choose to both log and display errors to stdout.
-                    eprintln!("{}", &error);
-                    user.log_debug(&error, Some(goose.request), Some(&headers), None);
-                }
             }
-        }
-        Err(e) => {
-            user.set_failure(&mut goose.request);
-            let error = format!("front_page: no response from server: {}", e);
-            // We choose to both log and display errors to stdout.
-            eprintln!("{}", &error);
-            user.log_debug(&error, Some(goose.request), None, None);
+            Err(e) => {
+                user.set_failure(&mut goose.request);
+                let error = format!("front_page: no response from server: {}", e);
+                // We choose to both log and display errors to stdout.
+                eprintln!("{}", &error);
+                user.log_debug(&error, Some(goose.request), None, None);
+            }
         }
     }
 }
@@ -137,61 +139,65 @@ async fn drupal_loadtest_profile_page(user: &GooseUser) {
 /// Log in.
 async fn drupal_loadtest_login(user: &GooseUser) {
     let mut goose = user.get("/user").await;
-    match goose.response {
-        Ok(r) => {
-            // Copy the headers so we have them for logging if there are errors.
-            let headers = &r.headers().clone();
-            match r.text().await {
-                Ok(html) => {
-                    let re = Regex::new(r#"name="form_build_id" value=['"](.*?)['"]"#).unwrap();
-                    let form_build_id = match re.captures(&html) {
-                        Some(f) => f,
-                        None => {
-                            user.set_failure(&mut goose.request);
-                            let error = "login: no form_build_id on page: /user page";
-                            // We choose to both log and display errors to stdout.
-                            eprintln!("{}", error);
-                            user.log_debug(
-                                error,
-                                Some(goose.request),
-                                Some(&headers),
-                                Some(html.clone()),
-                            );
-                            return;
-                        }
-                    };
 
-                    // Log the user in.
-                    let uid: usize = rand::thread_rng().gen_range(3, 5_002);
-                    let username = format!("user{}", uid);
-                    let params = [
-                        ("name", username.as_str()),
-                        ("pass", "12345"),
-                        ("form_build_id", &form_build_id[1]),
-                        ("form_id", "user_login"),
-                        ("op", "Log+in"),
-                    ];
-                    let request_builder = user.goose_post("/user").await;
-                    let _goose = user.goose_send(request_builder.form(&params), None).await;
-                    // @TODO: verify that we actually logged in.
-                }
-                Err(e) => {
-                    user.set_failure(&mut goose.request);
-                    let error = format!("login: unexpected error when loading /user page: {}", e);
-                    // We choose to both log and display errors to stdout.
-                    eprintln!("{}", &error);
-                    user.log_debug(&error, Some(goose.request), Some(&headers), None);
+    if let Some(response) = goose.response {
+        match response {
+            Ok(r) => {
+                // Copy the headers so we have them for logging if there are errors.
+                let headers = &r.headers().clone();
+                match r.text().await {
+                    Ok(html) => {
+                        let re = Regex::new(r#"name="form_build_id" value=['"](.*?)['"]"#).unwrap();
+                        let form_build_id = match re.captures(&html) {
+                            Some(f) => f,
+                            None => {
+                                user.set_failure(&mut goose.request);
+                                let error = "login: no form_build_id on page: /user page";
+                                // We choose to both log and display errors to stdout.
+                                eprintln!("{}", error);
+                                user.log_debug(
+                                    error,
+                                    Some(goose.request),
+                                    Some(&headers),
+                                    Some(html.clone()),
+                                );
+                                return;
+                            }
+                        };
+
+                        // Log the user in.
+                        let uid: usize = rand::thread_rng().gen_range(3, 5_002);
+                        let username = format!("user{}", uid);
+                        let params = [
+                            ("name", username.as_str()),
+                            ("pass", "12345"),
+                            ("form_build_id", &form_build_id[1]),
+                            ("form_id", "user_login"),
+                            ("op", "Log+in"),
+                        ];
+                        let request_builder = user.goose_post("/user").await;
+                        let _goose = user.goose_send(request_builder.form(&params), None).await;
+                        // @TODO: verify that we actually logged in.
+                    }
+                    Err(e) => {
+                        user.set_failure(&mut goose.request);
+                        let error =
+                            format!("login: unexpected error when loading /user page: {}", e);
+                        // We choose to both log and display errors to stdout.
+                        eprintln!("{}", &error);
+                        user.log_debug(&error, Some(goose.request), Some(&headers), None);
+                    }
                 }
             }
-        }
-        // Goose will catch this error.
-        Err(e) => {
-            user.log_debug(
-                format!("login: no response from server: {}", e).as_str(),
-                None,
-                None,
-                None,
-            );
+            // Goose will catch this error.
+            Err(e) => {
+                user.log_debug(
+                    format!("login: no response from server: {}", e).as_str(),
+                    None,
+                    None,
+                    None,
+                );
+            }
         }
     }
 }
@@ -202,148 +208,156 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);
     let mut goose = user.get(&node_path).await;
-    match goose.response {
-        Ok(r) => {
-            // Copy the headers so we have them for logging if there are errors.
-            let headers = &r.headers().clone();
-            match r.text().await {
-                Ok(html) => {
-                    // Extract the form_build_id from the user login form.
-                    let re = Regex::new(r#"name="form_build_id" value=['"](.*?)['"]"#).unwrap();
-                    let form_build_id = match re.captures(&html) {
-                        Some(f) => f,
-                        None => {
-                            user.set_failure(&mut goose.request);
-                            let error =
-                                format!("post_comment: no form_build_id found on {}", &node_path);
-                            // We choose to both log and display errors to stdout.
-                            eprintln!("{}", &error);
-                            user.log_debug(
-                                &error,
-                                Some(goose.request),
-                                Some(headers),
-                                Some(html.clone()),
-                            );
-                            return;
-                        }
-                    };
+    if let Some(response) = goose.response {
+        match response {
+            Ok(r) => {
+                // Copy the headers so we have them for logging if there are errors.
+                let headers = &r.headers().clone();
+                match r.text().await {
+                    Ok(html) => {
+                        // Extract the form_build_id from the user login form.
+                        let re = Regex::new(r#"name="form_build_id" value=['"](.*?)['"]"#).unwrap();
+                        let form_build_id = match re.captures(&html) {
+                            Some(f) => f,
+                            None => {
+                                user.set_failure(&mut goose.request);
+                                let error = format!(
+                                    "post_comment: no form_build_id found on {}",
+                                    &node_path
+                                );
+                                // We choose to both log and display errors to stdout.
+                                eprintln!("{}", &error);
+                                user.log_debug(
+                                    &error,
+                                    Some(goose.request),
+                                    Some(headers),
+                                    Some(html.clone()),
+                                );
+                                return;
+                            }
+                        };
 
-                    let re = Regex::new(r#"name="form_token" value=['"](.*?)['"]"#).unwrap();
-                    let form_token = match re.captures(&html) {
-                        Some(f) => f,
-                        None => {
-                            user.set_failure(&mut goose.request);
-                            let error =
-                                format!("post_comment: no form_token found on {}", &node_path);
-                            // We choose to both log and display errors to stdout.
-                            eprintln!("{}", &error);
-                            user.log_debug(
-                                &error,
-                                Some(goose.request),
-                                Some(&headers),
-                                Some(html.clone()),
-                            );
-                            return;
-                        }
-                    };
+                        let re = Regex::new(r#"name="form_token" value=['"](.*?)['"]"#).unwrap();
+                        let form_token = match re.captures(&html) {
+                            Some(f) => f,
+                            None => {
+                                user.set_failure(&mut goose.request);
+                                let error =
+                                    format!("post_comment: no form_token found on {}", &node_path);
+                                // We choose to both log and display errors to stdout.
+                                eprintln!("{}", &error);
+                                user.log_debug(
+                                    &error,
+                                    Some(goose.request),
+                                    Some(&headers),
+                                    Some(html.clone()),
+                                );
+                                return;
+                            }
+                        };
 
-                    let re = Regex::new(r#"name="form_id" value=['"](.*?)['"]"#).unwrap();
-                    let form_id = match re.captures(&html) {
-                        Some(f) => f,
-                        None => {
-                            user.set_failure(&mut goose.request);
-                            let error = format!("post_comment: no form_id found on {}", &node_path);
-                            // We choose to both log and display errors to stdout.
-                            eprintln!("{}", &error);
-                            user.log_debug(
-                                &error,
-                                Some(goose.request),
-                                Some(&headers),
-                                Some(html.clone()),
-                            );
-                            return;
-                        }
-                    };
-                    //println!("form_id: {}, form_build_id: {}, form_token: {}", &form_id, &form_build_id, &form_token);
+                        let re = Regex::new(r#"name="form_id" value=['"](.*?)['"]"#).unwrap();
+                        let form_id = match re.captures(&html) {
+                            Some(f) => f,
+                            None => {
+                                user.set_failure(&mut goose.request);
+                                let error =
+                                    format!("post_comment: no form_id found on {}", &node_path);
+                                // We choose to both log and display errors to stdout.
+                                eprintln!("{}", &error);
+                                user.log_debug(
+                                    &error,
+                                    Some(goose.request),
+                                    Some(&headers),
+                                    Some(html.clone()),
+                                );
+                                return;
+                            }
+                        };
+                        //println!("form_id: {}, form_build_id: {}, form_token: {}", &form_id, &form_build_id, &form_token);
 
-                    let comment_body = "this is a test comment body";
-                    let params = [
-                        ("subject", "this is a test comment subject"),
-                        ("comment_body[und][0][value]", &comment_body),
-                        ("comment_body[und][0][format]", "filtered_html"),
-                        ("form_build_id", &form_build_id[1]),
-                        ("form_token", &form_token[1]),
-                        ("form_id", &form_id[1]),
-                        ("op", "Save"),
-                    ];
-                    let request_builder = user.goose_post(&comment_path).await;
-                    let mut goose = user.goose_send(request_builder.form(&params), None).await;
-                    match goose.response {
-                        Ok(r) => {
-                            // Copy the headers so we have them for logging if there are errors.
-                            let headers = &r.headers().clone();
-                            match r.text().await {
-                                Ok(html) => {
-                                    if !html.contains(&comment_body) {
-                                        user.set_failure(&mut goose.request);
-                                        let error = format!("post_comment: no comment showed up after posting to {}", &comment_path);
-                                        // We choose to both log and display errors to stdout.
-                                        eprintln!("{}", &error);
-                                        user.log_debug(
-                                            &error,
-                                            Some(goose.request),
-                                            Some(&headers),
-                                            Some(html),
-                                        );
+                        let comment_body = "this is a test comment body";
+                        let params = [
+                            ("subject", "this is a test comment subject"),
+                            ("comment_body[und][0][value]", &comment_body),
+                            ("comment_body[und][0][format]", "filtered_html"),
+                            ("form_build_id", &form_build_id[1]),
+                            ("form_token", &form_token[1]),
+                            ("form_id", &form_id[1]),
+                            ("op", "Save"),
+                        ];
+                        let request_builder = user.goose_post(&comment_path).await;
+                        let mut goose = user.goose_send(request_builder.form(&params), None).await;
+                        if let Some(response) = goose.response {
+                            match response {
+                                Ok(r) => {
+                                    // Copy the headers so we have them for logging if there are errors.
+                                    let headers = &r.headers().clone();
+                                    match r.text().await {
+                                        Ok(html) => {
+                                            if !html.contains(&comment_body) {
+                                                user.set_failure(&mut goose.request);
+                                                let error = format!("post_comment: no comment showed up after posting to {}", &comment_path);
+                                                // We choose to both log and display errors to stdout.
+                                                eprintln!("{}", &error);
+                                                user.log_debug(
+                                                    &error,
+                                                    Some(goose.request),
+                                                    Some(&headers),
+                                                    Some(html),
+                                                );
+                                            }
+                                        }
+                                        Err(e) => {
+                                            user.set_failure(&mut goose.request);
+                                            let error = format!(
+                                                "post_comment: unexpected error when posting to {}: {}",
+                                                &comment_path, e
+                                            );
+                                            // We choose to both log and display errors to stdout.
+                                            eprintln!("{}", &error);
+                                            user.log_debug(
+                                                &error,
+                                                Some(goose.request),
+                                                Some(&headers),
+                                                None,
+                                            );
+                                        }
                                     }
                                 }
+                                // Goose will catch this error.
                                 Err(e) => {
-                                    user.set_failure(&mut goose.request);
                                     let error = format!(
-                                        "post_comment: unexpected error when posting to {}: {}",
+                                        "post_comment: no response when posting to {}: {}",
                                         &comment_path, e
                                     );
                                     // We choose to both log and display errors to stdout.
                                     eprintln!("{}", &error);
-                                    user.log_debug(
-                                        &error,
-                                        Some(goose.request),
-                                        Some(&headers),
-                                        None,
-                                    );
+                                    user.log_debug(&error, Some(goose.request), None, None);
                                 }
                             }
                         }
-                        // Goose will catch this error.
-                        Err(e) => {
-                            let error = format!(
-                                "post_comment: no response when posting to {}: {}",
-                                &comment_path, e
-                            );
-                            // We choose to both log and display errors to stdout.
-                            eprintln!("{}", &error);
-                            user.log_debug(&error, Some(goose.request), None, None);
-                        }
+                    }
+                    Err(e) => {
+                        user.set_failure(&mut goose.request);
+                        let error =
+                            format!("post_comment: no text when loading {}: {}", &node_path, e);
+                        // We choose to both log and display errors to stdout.
+                        eprintln!("{}", &error);
+                        user.log_debug(&error, Some(goose.request), None, None);
                     }
                 }
-                Err(e) => {
-                    user.set_failure(&mut goose.request);
-                    let error = format!("post_comment: no text when loading {}: {}", &node_path, e);
-                    // We choose to both log and display errors to stdout.
-                    eprintln!("{}", &error);
-                    user.log_debug(&error, Some(goose.request), None, None);
-                }
             }
-        }
-        // Goose will catch this error.
-        Err(e) => {
-            let error = format!(
-                "post_comment: no response when loading {}: {}",
-                &node_path, e
-            );
-            // We choose to both log and display errors to stdout.
-            eprintln!("{}", &error);
-            user.log_debug(&error, Some(goose.request), None, None);
+            // Goose will catch this error.
+            Err(e) => {
+                let error = format!(
+                    "post_comment: no response when loading {}: {}",
+                    &node_path, e
+                );
+                // We choose to both log and display errors to stdout.
+                eprintln!("{}", &error);
+                user.log_debug(&error, Some(goose.request), None, None);
+            }
         }
     }
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1245,10 +1245,15 @@ impl GooseUser {
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
     ///     async fn get_function(user: &GooseUser) {
-    ///       let request_builder = user.goose_get("/path/to/foo").await;
-    ///       if let Ok(_goose) = user.goose_send(request_builder, None).await {
-    ///         // Do stuff with _goose.request and/or _goose.response here.
-    ///       }
+    ///         let request_builder = user.goose_get("/path/to/foo").await;
+    ///         let goose = match user.goose_send(request_builder, None).await {
+    ///             // Return early if get fails, there's nothing else to do.
+    ///             Err(_) => return,
+    ///             // Otherwise unwrap the Result.
+    ///             Ok(g) => g,
+    ///         };
+    ///
+    ///         // Do stuff with goose.request and/or goose.response here.
     ///     }
     /// ```
     pub async fn goose_send(

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -669,10 +669,10 @@ impl PartialOrd for GooseRequest {
 #[derive(Debug)]
 pub struct GooseResponse {
     pub request: GooseRawRequest,
-    pub response: Option<Result<Response, Error>>,
+    pub response: Result<Response, Error>,
 }
 impl GooseResponse {
-    pub fn new(request: GooseRawRequest, response: Option<Result<Response, Error>>) -> Self {
+    pub fn new(request: GooseRawRequest, response: Result<Response, Error>) -> Self {
         GooseResponse { request, response }
     }
 }
@@ -863,9 +863,9 @@ impl GooseUser {
     ///       let _goose = user.get("/path/to/foo/").await;
     ///     }
     /// ```
-    pub async fn get(&self, path: &str) -> GooseResponse {
+    pub async fn get(&self, path: &str) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
         let request_builder = self.goose_get(path).await;
-        self.goose_send(request_builder, None).await
+        Ok(self.goose_send(request_builder, None).await?)
     }
 
     /// A helper to make a named `GET` request of a path and collect relevant statistics.
@@ -888,9 +888,13 @@ impl GooseUser {
     ///       let _goose = user.get_named("/path/to/foo/", "foo").await;
     ///     }
     /// ```
-    pub async fn get_named(&self, path: &str, request_name: &str) -> GooseResponse {
+    pub async fn get_named(
+        &self,
+        path: &str,
+        request_name: &str,
+    ) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
         let request_builder = self.goose_get(path).await;
-        self.goose_send(request_builder, Some(request_name)).await
+        Ok(self.goose_send(request_builder, Some(request_name)).await?)
     }
 
     /// A helper to make a `POST` request of a path and collect relevant statistics.
@@ -917,9 +921,13 @@ impl GooseUser {
     ///       let _goose = user.post("/path/to/foo/", "BODY BEING POSTED").await;
     ///     }
     /// ```
-    pub async fn post(&self, path: &str, body: &str) -> GooseResponse {
+    pub async fn post(
+        &self,
+        path: &str,
+        body: &str,
+    ) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
         let request_builder = self.goose_post(path).await.body(body.to_string());
-        self.goose_send(request_builder, None).await
+        Ok(self.goose_send(request_builder, None).await?)
     }
 
     /// A helper to make a named `POST` request of a path and collect relevant statistics.
@@ -942,9 +950,14 @@ impl GooseUser {
     ///       let _goose = user.post_named("/path/to/foo/", "foo", "BODY BEING POSTED").await;
     ///     }
     /// ```
-    pub async fn post_named(&self, path: &str, request_name: &str, body: &str) -> GooseResponse {
+    pub async fn post_named(
+        &self,
+        path: &str,
+        request_name: &str,
+        body: &str,
+    ) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
         let request_builder = self.goose_post(path).await.body(body.to_string());
-        self.goose_send(request_builder, Some(request_name)).await
+        Ok(self.goose_send(request_builder, Some(request_name)).await?)
     }
 
     /// A helper to make a `HEAD` request of a path and collect relevant statistics.
@@ -971,9 +984,9 @@ impl GooseUser {
     ///       let _goose = user.head("/path/to/foo/").await;
     ///     }
     /// ```
-    pub async fn head(&self, path: &str) -> GooseResponse {
+    pub async fn head(&self, path: &str) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
         let request_builder = self.goose_head(path).await;
-        self.goose_send(request_builder, None).await
+        Ok(self.goose_send(request_builder, None).await?)
     }
 
     /// A helper to make a named `HEAD` request of a path and collect relevant statistics.
@@ -996,9 +1009,13 @@ impl GooseUser {
     ///       let _goose = user.head_named("/path/to/foo/", "foo").await;
     ///     }
     /// ```
-    pub async fn head_named(&self, path: &str, request_name: &str) -> GooseResponse {
+    pub async fn head_named(
+        &self,
+        path: &str,
+        request_name: &str,
+    ) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
         let request_builder = self.goose_head(path).await;
-        self.goose_send(request_builder, Some(request_name)).await
+        Ok(self.goose_send(request_builder, Some(request_name)).await?)
     }
 
     /// A helper to make a `DELETE` request of a path and collect relevant statistics.
@@ -1025,9 +1042,9 @@ impl GooseUser {
     ///       let _goose = user.delete("/path/to/foo/").await;
     ///     }
     /// ```
-    pub async fn delete(&self, path: &str) -> GooseResponse {
+    pub async fn delete(&self, path: &str) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
         let request_builder = self.goose_delete(path).await;
-        self.goose_send(request_builder, None).await
+        Ok(self.goose_send(request_builder, None).await?)
     }
 
     /// A helper to make a named `DELETE` request of a path and collect relevant statistics.
@@ -1050,9 +1067,13 @@ impl GooseUser {
     ///       let _goose = user.delete_named("/path/to/foo/", "foo").await;
     ///     }
     /// ```
-    pub async fn delete_named(&self, path: &str, request_name: &str) -> GooseResponse {
+    pub async fn delete_named(
+        &self,
+        path: &str,
+        request_name: &str,
+    ) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
         let request_builder = self.goose_delete(path).await;
-        self.goose_send(request_builder, Some(request_name)).await
+        Ok(self.goose_send(request_builder, Some(request_name)).await?)
     }
 
     /// Prepends the correct host on the path, then prepares a
@@ -1208,10 +1229,12 @@ impl GooseUser {
     /// Reqwest without using this helper function, but then Goose is unable to capture
     /// statistics.
     ///
-    /// Calls to `user.goose_send` return a `GooseResponse` object which contains a
-    /// copy of the request you made
-    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// Calls to `user.goose_send()` returns a `Result` containing a `GooseResponse` on success,
+    /// and a `tokio::sync::mpsc::error::SendError<bool>` on failure. Failure only happens when
+    /// `--throttle-requests` is enabled and the load test completes. The `GooseResponse` object
+    // contains a copy of the request made
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the
+    /// Reqwest response ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -1223,14 +1246,16 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn get_function(user: &GooseUser) {
     ///       let request_builder = user.goose_get("/path/to/foo").await;
-    ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       if let Ok(_goose) = user.goose_send(request_builder, None).await {
+    ///         // Do stuff with _goose.request and/or _goose.response here.
+    ///       }
     ///     }
     /// ```
     pub async fn goose_send(
         &self,
         request_builder: RequestBuilder,
         request_name: Option<&str>,
-    ) -> GooseResponse {
+    ) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
         let mut started = Instant::now();
         let request = match request_builder.build() {
             Ok(r) => r,
@@ -1255,20 +1280,8 @@ impl GooseUser {
         if self.is_throttled && self.config.throttle_requests.is_some() {
             // ...wait until there's room to add a token to the throttle channel before proceeding.
             debug!("GooseUser: waiting on throttle");
-            if self.throttle.clone().unwrap().send(true).await.is_err() {
-                // The throttle channel has closed, meaning the load test is over. Cancel this
-                // request.
-                return GooseResponse::new(
-                    GooseRawRequest::new(
-                        method,
-                        &request_name,
-                        &request.url().to_string(),
-                        self.started.elapsed().as_millis(),
-                        self.weighted_users_index,
-                    ),
-                    None,
-                );
-            }
+            // Return mpsc::error:SendError<bool> if this fails.
+            self.throttle.clone().unwrap().send(true).await?;
             // If we got here, reset started timestamp as we may have gotten throttled.
             started = Instant::now();
         };
@@ -1333,7 +1346,7 @@ impl GooseUser {
             self.send_to_parent(&raw_request);
         }
 
-        GooseResponse::new(raw_request, Some(response))
+        Ok(GooseResponse::new(raw_request, response))
     }
 
     fn send_to_parent(&self, raw_request: &GooseRawRequest) {
@@ -1377,16 +1390,12 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a GET request.
     ///     async fn get_function(user: &GooseUser) {
-    ///         let mut goose = user.get("/404").await;
-    ///         if let Some(response) = goose.response {
-    ///             match &response {
-    ///                 Ok(r) => {
-    ///                     // We expect a 404 here.
-    ///                     if r.status() == 404 {
-    ///                         user.set_success(&mut goose.request);
-    ///                     }
-    ///                 },
-    ///                 Err(_) => (),
+    ///         if let Ok(mut goose) = user.get("/404").await {
+    ///             if let Ok(response) = &goose.response {
+    ///                 // We expect a 404 here.
+    ///                 if response.status() == 404 {
+    ///                     user.set_success(&mut goose.request);
+    ///                 }
     ///             }
     ///         }
     ///     }
@@ -1414,14 +1423,13 @@ impl GooseUser {
     ///     let mut task = task!(loadtest_index_page);
     ///
     ///     async fn loadtest_index_page(user: &GooseUser) {
-    ///         let mut goose = user.get_named("/", "index").await;
-    ///         if let Some(response) = goose.response {
+    ///         if let Ok(mut goose) = user.get_named("/", "index").await {
     ///             // Extract the response Result.
-    ///             match response {
-    ///                 Ok(r) => {
+    ///             match goose.response {
+    ///                 Ok(response) => {
     ///                     // We only need to check pages that returned a success status code.
-    ///                     if r.status().is_success() {
-    ///                         match r.text().await {
+    ///                     if response.status().is_success() {
+    ///                         match response.text().await {
     ///                             Ok(text) => {
     ///                                 // If the expected string doesn't exist, this page load
     ///                                 // was a failure.
@@ -1471,16 +1479,15 @@ impl GooseUser {
     ///     let mut task = task!(loadtest_index_page);
     ///
     ///     async fn loadtest_index_page(user: &GooseUser) {
-    ///         let mut goose = user.get_named("/", "index").await;
-    ///         if let Some(response) = goose.response {
+    ///         if let Ok(mut goose) = user.get_named("/", "index").await {
     ///            // Extract the response Result.
-    ///             match response {
-    ///                 Ok(r) => {
+    ///             match goose.response {
+    ///                 Ok(response) => {
     ///                     // Grab a copy of the headers so we can include them when logging errors.
-    ///                     let headers = &r.headers().clone();
+    ///                     let headers = &response.headers().clone();
     ///                     // We only need to check pages that returned a success status code.
-    ///                     if !r.status().is_success() {
-    ///                         match r.text().await {
+    ///                     if !response.status().is_success() {
+    ///                         match response.text().await {
     ///                             Ok(html) => {
     ///                                 // Server returned an error code, log everything.
     ///                                 user.log_debug(
@@ -2465,30 +2472,34 @@ mod tests {
 
         // Make a GET request to the mock http server and confirm we get a 200 response.
         assert_eq!(mock_index.times_called(), 0);
-        let goose = user.get("/").await;
-        let status = goose.response.unwrap().unwrap().status();
-        assert_eq!(status, 200);
+        let response = user.get("/").await;
         assert_eq!(mock_index.times_called(), 1);
-        assert_eq!(goose.request.method, GooseMethod::GET);
-        assert_eq!(goose.request.name, "/");
-        assert_eq!(goose.request.success, true);
-        assert_eq!(goose.request.update, false);
-        assert_eq!(goose.request.status_code, 200);
+        if let Ok(goose) = response {
+            let status = goose.response.unwrap().status();
+            assert_eq!(status, 200);
+            assert_eq!(goose.request.method, GooseMethod::GET);
+            assert_eq!(goose.request.name, "/");
+            assert_eq!(goose.request.success, true);
+            assert_eq!(goose.request.update, false);
+            assert_eq!(goose.request.status_code, 200);
+        }
 
         const NO_SUCH_PATH: &str = "/no/such/path";
         let mock_404 = mock(GET, NO_SUCH_PATH).return_status(404).create();
 
         // Make an invalid GET request to the mock http server and confirm we get a 404 response.
         assert_eq!(mock_404.times_called(), 0);
-        let goose = user.get(NO_SUCH_PATH).await;
-        let status = goose.response.unwrap().unwrap().status();
-        assert_eq!(status, 404);
+        let response = user.get(NO_SUCH_PATH).await;
         assert_eq!(mock_404.times_called(), 1);
-        assert_eq!(goose.request.method, GooseMethod::GET);
-        assert_eq!(goose.request.name, NO_SUCH_PATH);
-        assert_eq!(goose.request.success, false);
-        assert_eq!(goose.request.update, false);
-        assert_eq!(goose.request.status_code, 404,);
+        if let Ok(goose) = response {
+            let status = goose.response.unwrap().status();
+            assert_eq!(status, 404);
+            assert_eq!(goose.request.method, GooseMethod::GET);
+            assert_eq!(goose.request.name, NO_SUCH_PATH);
+            assert_eq!(goose.request.success, false);
+            assert_eq!(goose.request.update, false);
+            assert_eq!(goose.request.status_code, 404,);
+        }
 
         // Set up a mock http server endpoint.
         const COMMENT_PATH: &str = "/comment";
@@ -2500,17 +2511,19 @@ mod tests {
 
         // Make a POST request to the mock http server and confirm we get a 200 OK response.
         assert_eq!(mock_comment.times_called(), 0);
-        let goose = user.post(COMMENT_PATH, "foo").await;
-        let unwrapped_response = goose.response.unwrap().unwrap();
-        let status = unwrapped_response.status();
-        assert_eq!(status, 200);
-        let body = unwrapped_response.text().await.unwrap();
-        assert_eq!(body, "foo");
+        let response = user.post(COMMENT_PATH, "foo").await;
         assert_eq!(mock_comment.times_called(), 1);
-        assert_eq!(goose.request.method, GooseMethod::POST);
-        assert_eq!(goose.request.name, COMMENT_PATH);
-        assert_eq!(goose.request.success, true);
-        assert_eq!(goose.request.update, false);
-        assert_eq!(goose.request.status_code, 200);
+        if let Ok(goose) = response {
+            let unwrapped_response = goose.response.unwrap();
+            let status = unwrapped_response.status();
+            assert_eq!(status, 200);
+            let body = unwrapped_response.text().await.unwrap();
+            assert_eq!(body, "foo");
+            assert_eq!(goose.request.method, GooseMethod::POST);
+            assert_eq!(goose.request.name, COMMENT_PATH);
+            assert_eq!(goose.request.success, true);
+            assert_eq!(goose.request.update, false);
+            assert_eq!(goose.request.status_code, 200);
+        }
     }
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -2470,9 +2470,7 @@ mod tests {
 
         // Make a GET request to the mock http server and confirm we get a 200 response.
         assert_eq!(mock_index.times_called(), 0);
-        let response = user.get("/").await;
-        assert_eq!(mock_index.times_called(), 1);
-        if let Ok(goose) = response {
+        if let Ok(goose) = user.get("/").await {
             let status = goose.response.unwrap().status();
             assert_eq!(status, 200);
             assert_eq!(goose.request.method, GooseMethod::GET);
@@ -2481,15 +2479,14 @@ mod tests {
             assert_eq!(goose.request.update, false);
             assert_eq!(goose.request.status_code, 200);
         }
+        assert_eq!(mock_index.times_called(), 1);
 
         const NO_SUCH_PATH: &str = "/no/such/path";
         let mock_404 = mock(GET, NO_SUCH_PATH).return_status(404).create();
 
         // Make an invalid GET request to the mock http server and confirm we get a 404 response.
         assert_eq!(mock_404.times_called(), 0);
-        let response = user.get(NO_SUCH_PATH).await;
-        assert_eq!(mock_404.times_called(), 1);
-        if let Ok(goose) = response {
+        if let Ok(goose) = user.get(NO_SUCH_PATH).await {
             let status = goose.response.unwrap().status();
             assert_eq!(status, 404);
             assert_eq!(goose.request.method, GooseMethod::GET);
@@ -2498,6 +2495,7 @@ mod tests {
             assert_eq!(goose.request.update, false);
             assert_eq!(goose.request.status_code, 404,);
         }
+        assert_eq!(mock_404.times_called(), 1);
 
         // Set up a mock http server endpoint.
         const COMMENT_PATH: &str = "/comment";
@@ -2509,9 +2507,7 @@ mod tests {
 
         // Make a POST request to the mock http server and confirm we get a 200 OK response.
         assert_eq!(mock_comment.times_called(), 0);
-        let response = user.post(COMMENT_PATH, "foo").await;
-        assert_eq!(mock_comment.times_called(), 1);
-        if let Ok(goose) = response {
+        if let Ok(goose) = user.post(COMMENT_PATH, "foo").await {
             let unwrapped_response = goose.response.unwrap();
             let status = unwrapped_response.status();
             assert_eq!(status, 200);
@@ -2523,5 +2519,6 @@ mod tests {
             assert_eq!(goose.request.update, false);
             assert_eq!(goose.request.status_code, 200);
         }
+        assert_eq!(mock_comment.times_called(), 1);
     }
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1541,7 +1541,7 @@ impl GooseUser {
     ///
     /// By default, Goose configures two options when building a Reqwest client. The first
     /// configures Goose to report itself as the user agent requesting web pages (ie
-    /// `goose/0.8.2`). The second option configures Reqwest to store cookies, which is
+    /// `goose/0.9.0`). The second option configures Reqwest to store cookies, which is
     /// generally necessary if you aim to simulate logged in users.
     ///
     /// # Default configuration:

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1092,7 +1092,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn get_function(user: &GooseUser) {
     ///       let request_builder = user.goose_get("/path/to/foo").await;
-    ///       let goose = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_get(&self, path: &str) -> RequestBuilder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1143,7 +1143,7 @@ impl GooseAttack {
 
             // Launch a new thread for throttling.
             let _ = Some(tokio::spawn(throttle::throttle_main(
-                self.configuration.clone(),
+                throttle_requests,
                 throttle_receiver.unwrap(),
                 throttle_rx,
             )));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -827,11 +827,18 @@ impl GooseAttack {
             }
         }
 
-        if let Some(throttle_requests) = self.configuration.throttle_requests {
-            if throttle_requests > 1_000_000 {
+        // Validate throttle_requests, which must be a value from 1 to 1,000,000.
+        match self.configuration.throttle_requests {
+            Some(throttle) if throttle == 0 => {
+                error!("Throttle must be at least 1 request per second.");
+                std::process::exit(1);
+            }
+            Some(throttle) if throttle > 1_000_000 => {
                 error!("Throttle can not be more than 1,000,000 requests per second.");
                 std::process::exit(1);
             }
+            // Everything else is valid.
+            _ => (),
         }
 
         // Worker mode.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! goose = "0.8"
+//! goose = "0.9"
 //! ```
 //!
 //! Add the following boilerplate `use` declaration at the top of your `src/main.rs`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,6 +820,18 @@ impl GooseAttack {
                 error!("You can only enable --debug-log-file in stand-alone or worker mode, not as manager.");
                 std::process::exit(1);
             }
+
+            if self.configuration.throttle_requests.is_some() {
+                error!("You can only configure --throttle-requests in stand-alone mode or per worker, not as manager.");
+                std::process::exit(1);
+            }
+        }
+
+        if let Some(throttle_requests) = self.configuration.throttle_requests {
+            if throttle_requests > 1_000_000 {
+                error!("Throttle can not be more than 1,000,000 requests per second.");
+                std::process::exit(1);
+            }
         }
 
         // Worker mode.

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -4,8 +4,10 @@ use tokio::time;
 /// This throttle thread limits the maximum number of requests that can be made across
 /// all GooseUser threads. When enabled, GooseUser threads must add a token to the
 /// bounded channel before making a request, and this thread limits how frequently
-/// tokens are removed thereby throttling how fast requests can be made. It is a variation
-/// on the leaky bucket algorithm: instead of leaking the overflow we asynchronously block.
+/// tokens are removed thereby throttling how fast requests can be made. It is an
+/// implementation of the leaky bucket algorithm as a queue: instead of leaking the
+/// overflow we asynchronously block. More information on the leaky bucket algorithm
+/// can be found at: https://en.wikipedia.org/wiki/Leaky_bucket
 pub async fn throttle_main(
     throttle_requests: usize,
     mut throttle_receiver: Receiver<bool>,

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,26 +1,37 @@
-use async_std::sync::Sender;
+use tokio::sync::mpsc::Receiver;
 use tokio::time;
 
 use crate::GooseConfiguration;
 
 /// This throttle thread limits the maximum number of requests that can be made across
-/// all GooseUser threads. It uses a async-std channel as this allows single-sender
-/// max-receiver communication. When enabled, GooseUser threads must grab a token
-/// from the channel before making a request, and this thread limits how many tokens
-/// are available per second.
-pub async fn throttle_main(configuration: GooseConfiguration, throttle_sender: Sender<bool>) {
+/// all GooseUser threads. When enabled, GooseUser threads must add a token to the
+/// bounded channel before making a request, and this thread limits how frequently
+/// tokens are removed thereby throttling how fast requests can be made. It is a variation
+/// on the leaky bucket algorithm: instead of leaking the overflow we asynchronously block.
+pub async fn throttle_main(
+    configuration: GooseConfiguration,
+    mut throttle_receiver: Receiver<bool>,
+    mut parent_receiver: Receiver<bool>,
+) {
     let sleep_duration =
         time::Duration::from_secs_f32(1.0 / configuration.throttle_requests.unwrap() as f32);
     info!("throttle allowing 1 request every {:?}", sleep_duration);
 
     // Loop until parent thread exits, adding one element
     loop {
-        // @TODO: if `sleep_duration` is <10ms, add multiple tokens at once as `delay_for` has
+        debug!("throttle removing token from channel");
+        // @TODO: if `sleep_duration` is <10ms, remove multiple tokens at once as `delay_for` has
         // millisecond granularity.
         time::delay_for(sleep_duration).await;
-        // @TODO: when adding auto-tuning suggestions this should be converted to `try_send`.
-        debug!("parent throttle sending value");
-        // @TODO: if load test is ending, fill queue with `false` so all GooseUser threads exit.
-        let _ = throttle_sender.send(true).await;
+
+        // Check if parent has informed us the load test is over.
+        if parent_receiver.try_recv().is_ok() {
+            info!("load test complete, closing throttle channel");
+            throttle_receiver.close();
+            break;
+        }
+
+        // Remove a token from the channel, freeing a spot for a request to be made.
+        let _ = throttle_receiver.try_recv();
     }
 }

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,0 +1,26 @@
+use async_std::sync::Sender;
+use tokio::time;
+
+use crate::GooseConfiguration;
+
+/// This throttle thread limits the maximum number of requests that can be made across
+/// all GooseUser threads. It uses a async-std channel as this allows single-sender
+/// max-receiver communication. When enabled, GooseUser threads must grab a token
+/// from the channel before making a request, and this thread limits how many tokens
+/// are available per second.
+pub async fn throttle_main(configuration: GooseConfiguration, throttle_sender: Sender<bool>) {
+    let sleep_duration =
+        time::Duration::from_secs_f32(1.0 / configuration.throttle_requests.unwrap() as f32);
+    info!("throttle allowing 1 request every {:?}", sleep_duration);
+
+    // Loop until parent thread exits, adding one element
+    loop {
+        // @TODO: if `sleep_duration` is <10ms, add multiple tokens at once as `delay_for` has
+        // millisecond granularity.
+        time::delay_for(sleep_duration).await;
+        // @TODO: when adding auto-tuning suggestions this should be converted to `try_send`.
+        debug!("parent throttle sending value");
+        // @TODO: if load test is ending, fill queue with `false` so all GooseUser threads exit.
+        let _ = throttle_sender.send(true).await;
+    }
+}

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,21 +1,18 @@
 use tokio::sync::mpsc::Receiver;
 use tokio::time;
 
-use crate::GooseConfiguration;
-
 /// This throttle thread limits the maximum number of requests that can be made across
 /// all GooseUser threads. When enabled, GooseUser threads must add a token to the
 /// bounded channel before making a request, and this thread limits how frequently
 /// tokens are removed thereby throttling how fast requests can be made. It is a variation
 /// on the leaky bucket algorithm: instead of leaking the overflow we asynchronously block.
 pub async fn throttle_main(
-    configuration: GooseConfiguration,
+    throttle_requests: usize,
     mut throttle_receiver: Receiver<bool>,
     mut parent_receiver: Receiver<bool>,
 ) {
     // Use microseconds to allow configurations up to 1,000,000 requests per second.
-    let mut sleep_duration =
-        time::Duration::from_micros(1_000_000 / configuration.throttle_requests.unwrap() as u64);
+    let mut sleep_duration = time::Duration::from_micros(1_000_000 / throttle_requests as u64);
     let tokens_per_duration;
 
     let ten_milliseconds = time::Duration::from_millis(10);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -20,6 +20,7 @@ pub fn build_configuration() -> GooseConfiguration {
         stats_log_format: "json".to_string(),
         debug_log_file: "".to_string(),
         debug_log_format: "json".to_string(),
+        throttle_requests: None,
         sticky_follow: false,
         manager: false,
         no_hash_check: false,

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -17,17 +17,19 @@ pub async fn get_index(user: &GooseUser) {
 
 pub async fn get_error(user: &GooseUser) {
     let goose = user.get(ERROR_PATH).await;
-    if let Ok(r) = goose.response {
-        let headers = &r.headers().clone();
-        match r.text().await {
-            Ok(_) => {}
-            Err(_) => {
-                user.log_debug(
-                    "there was an error",
-                    Some(goose.request),
-                    Some(headers),
-                    None,
-                );
+    if let Some(response) = goose.response {
+        if let Ok(r) = response {
+            let headers = &r.headers().clone();
+            match r.text().await {
+                Ok(_) => {}
+                Err(_) => {
+                    user.log_debug(
+                        "there was an error",
+                        Some(goose.request),
+                        Some(headers),
+                        None,
+                    );
+                }
             }
         }
     }

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -16,9 +16,8 @@ pub async fn get_index(user: &GooseUser) {
 }
 
 pub async fn get_error(user: &GooseUser) {
-    let goose = user.get(ERROR_PATH).await;
-    if let Some(response) = goose.response {
-        if let Ok(r) = response {
+    if let Ok(goose) = user.get(ERROR_PATH).await {
+        if let Ok(r) = goose.response {
             let headers = &r.headers().clone();
             match r.text().await {
                 Ok(_) => {}

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -16,19 +16,24 @@ pub async fn get_index(user: &GooseUser) {
 }
 
 pub async fn get_error(user: &GooseUser) {
-    if let Ok(goose) = user.get(ERROR_PATH).await {
-        if let Ok(r) = goose.response {
-            let headers = &r.headers().clone();
-            match r.text().await {
-                Ok(_) => {}
-                Err(_) => {
-                    user.log_debug(
-                        "there was an error",
-                        Some(goose.request),
-                        Some(headers),
-                        None,
-                    );
-                }
+    let goose = match user.get(ERROR_PATH).await {
+        // Return early if get fails, there's nothing else to do.
+        Err(_) => return,
+        // Otherwise unwrap the Result.
+        Ok(g) => g,
+    };
+
+    if let Ok(r) = goose.response {
+        let headers = &r.headers().clone();
+        match r.text().await {
+            Ok(_) => {}
+            Err(_) => {
+                user.log_debug(
+                    "there was an error",
+                    Some(goose.request),
+                    Some(headers),
+                    None,
+                );
             }
         }
     }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -24,18 +24,20 @@ pub async fn get_about(user: &GooseUser) {
 // Task function, load REDRECT_PATH and follow redirects to ABOUT_PATH.
 pub async fn get_redirect(user: &GooseUser) {
     let mut goose = user.get(REDIRECT_PATH).await;
-    if let Ok(r) = goose.response {
-        match r.text().await {
-            Ok(html) => {
-                // Confirm that we followed redirects and loaded the about page.
-                if !html.contains("about page") {
-                    eprintln!("about page body wrong");
+    if let Some(response) = goose.response {
+        if let Ok(r) = response {
+            match r.text().await {
+                Ok(html) => {
+                    // Confirm that we followed redirects and loaded the about page.
+                    if !html.contains("about page") {
+                        eprintln!("about page body wrong");
+                        user.set_failure(&mut goose.request);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("unexpected error parsing about page: {}", e);
                     user.set_failure(&mut goose.request);
                 }
-            }
-            Err(e) => {
-                eprintln!("unexpected error parsing about page: {}", e);
-                user.set_failure(&mut goose.request);
             }
         }
     }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -23,9 +23,8 @@ pub async fn get_about(user: &GooseUser) {
 
 // Task function, load REDRECT_PATH and follow redirects to ABOUT_PATH.
 pub async fn get_redirect(user: &GooseUser) {
-    let mut goose = user.get(REDIRECT_PATH).await;
-    if let Some(response) = goose.response {
-        if let Ok(r) = response {
+    if let Ok(mut goose) = user.get(REDIRECT_PATH).await {
+        if let Ok(r) = goose.response {
             match r.text().await {
                 Ok(html) => {
                     // Confirm that we followed redirects and loaded the about page.

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -1,0 +1,49 @@
+use httpmock::Method::GET;
+use httpmock::{mock, with_mock_server};
+
+mod common;
+
+use goose::prelude::*;
+
+const INDEX_PATH: &str = "/";
+const ABOUT_PATH: &str = "/about.html";
+
+pub async fn get_index(user: &GooseUser) {
+    let _goose = user.get(INDEX_PATH).await;
+}
+
+pub async fn get_about(user: &GooseUser) {
+    let _goose = user.get(ABOUT_PATH).await;
+}
+
+#[test]
+#[with_mock_server]
+fn test_throttle() {
+    let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
+    let mock_about = mock(GET, ABOUT_PATH).return_status(200).create();
+
+    let mut config = common::build_configuration();
+    config.throttle_requests = Some(10);
+    crate::GooseAttack::initialize_with_config(config)
+        .setup()
+        .register_taskset(
+            taskset!("LoadTest")
+                .register_task(task!(get_index).set_weight(9))
+                .register_task(task!(get_about).set_weight(3)),
+        )
+        .execute();
+
+    let called_index = mock_index.times_called();
+    let called_about = mock_about.times_called();
+
+    // Confirm that we loaded the mock endpoints.
+    assert_ne!(called_index, 0);
+    assert_ne!(called_about, 0);
+
+    // Confirm that we loaded the index roughly three times as much as the about page.
+    let one_third_index = called_index / 3;
+    let difference = called_about as i32 - one_third_index as i32;
+    assert!(difference >= -2 && difference <= 2);
+
+    // @TODO: Parse stats output and confirm requests were throttled.
+}

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -7,6 +7,7 @@ use goose::prelude::*;
 
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
+const STATS_LOG_FILE: &str = "throttle-stats.log";
 
 pub async fn get_index(user: &GooseUser) {
     let _goose = user.get(INDEX_PATH).await;
@@ -19,17 +20,32 @@ pub async fn get_about(user: &GooseUser) {
 #[test]
 #[with_mock_server]
 fn test_throttle() {
+    use std::io::{self, BufRead};
+
     let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
     let mock_about = mock(GET, ABOUT_PATH).return_status(200).create();
 
+    let mut throttle_requests = 25;
+    let users = 5;
+    let run_time = 3;
+
     let mut config = common::build_configuration();
-    config.throttle_requests = Some(10);
+    // Record all requests so we can confirm throttle is working.
+    config.stats_log_file = STATS_LOG_FILE.to_string();
+    config.no_stats = false;
+    // Enable the throttle.
+    config.throttle_requests = Some(throttle_requests);
+    config.users = Some(users);
+    // Start all users in half a second.
+    config.hatch_rate = users;
+    // Run for a few seconds to be sure throttle really works.
+    config.run_time = run_time.to_string();
     crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(
             taskset!("LoadTest")
-                .register_task(task!(get_index).set_weight(9))
-                .register_task(task!(get_about).set_weight(3)),
+                .register_task(task!(get_about))
+                .register_task(task!(get_index)),
         )
         .execute();
 
@@ -40,10 +56,55 @@ fn test_throttle() {
     assert_ne!(called_index, 0);
     assert_ne!(called_about, 0);
 
-    // Confirm that we loaded the index roughly three times as much as the about page.
-    let one_third_index = called_index / 3;
-    let difference = called_about as i32 - one_third_index as i32;
-    assert!(difference >= -2 && difference <= 2);
+    let test1_lines: usize;
+    if let Ok(stats_log) = std::fs::File::open(std::path::Path::new(STATS_LOG_FILE)) {
+        test1_lines = io::BufReader::new(stats_log).lines().count();
+    } else {
+        test1_lines = 0;
+    }
 
-    // @TODO: Parse stats output and confirm requests were throttled.
+    // Requests are made while GooseUsers are hatched, and then for run_time seconds.
+    assert!(test1_lines <= (run_time + 1) * throttle_requests);
+
+    // Increase the throttle and run a second load test, so we can compare the difference
+    // and confirm the throttle is actually working.
+    throttle_requests *= 5;
+
+    let mut config = common::build_configuration();
+    // Record all requests so we can confirm throttle is working.
+    config.stats_log_file = STATS_LOG_FILE.to_string();
+    config.no_stats = false;
+    // Enable the throttle.
+    config.throttle_requests = Some(throttle_requests);
+    config.users = Some(users);
+    // Start all users in half a second.
+    config.hatch_rate = users;
+    config.run_time = run_time.to_string();
+    crate::GooseAttack::initialize_with_config(config)
+        .setup()
+        .register_taskset(
+            taskset!("LoadTest")
+                .register_task(task!(get_about))
+                .register_task(task!(get_index)),
+        )
+        .execute();
+
+    let called_index = mock_index.times_called();
+    let called_about = mock_about.times_called();
+
+    // Confirm that we loaded the mock endpoints.
+    assert_ne!(called_index, 0);
+    assert_ne!(called_about, 0);
+
+    let lines: usize;
+    if let Ok(stats_log) = std::fs::File::open(std::path::Path::new(STATS_LOG_FILE)) {
+        lines = io::BufReader::new(stats_log).lines().count();
+    } else {
+        lines = 0;
+    }
+
+    // Requests are made while GooseUsers are hatched, and then for run_time seconds.
+    assert!(lines <= (run_time + 1) * throttle_requests);
+    // Verify the second load test generated more than 4x the load of the first test.
+    assert!(lines > test1_lines * 4);
 }


### PR DESCRIPTION
Initial implementation of requests/second throttle. Fix #90 

 - rebased on top of #98 and #99 (splitting out rename of outer `response` wrapper to `goose`)
 - return `Result<GooseResponse, Error)` from `goose_send()` to allow a clean and quick shutdown even when the throttle is enabled -- this is an API change, bumping the version from `0.8.y` to `0.9.x`
 - throttle implemented with a modified leaky bucket algorithm, when a `GooseClient` makes a request and the throttle is enabled, they have to put a token in the throttle channel before making a request; a dedicated throttle thread removes tokens freeing up space at the desired rate of throttling
 - support up to a throttle-rate of 1,000,000 requests per second, keeping the minimum sleep time to ~10ms by removing multiple tokens at a time
 - integration test, confirms requests are throttled, and increasing the throttle increases the requests per second accordingly

--

In a followup PR will explore returning `Result<>` from Goose task functions as well, allowing the use of `?` to streamline writing load tests.