### PR TITLE
rename outer response wrapper to goose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.3-dev
  - fix code documentation, requests are async and require await
  - properly support setting host when registering task set 
+ - rename `response` wrapper to `goose`, so we end up with `goose.request` and `goose.response`
 
 ## 0.8.2 July 2, 2020
  - `client.log_debug()` will write debug logs to file when specified with `--debug-log-file=`

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -82,10 +82,10 @@ fn main() {
 
 /// View the front page.
 async fn drupal_loadtest_front_page(user: &GooseUser) {
-    let mut response = user.get("/").await;
+    let mut goose = user.get("/").await;
 
     // Grab some static assets from the front page.
-    match response.response {
+    match goose.response {
         Ok(r) => {
             // Copy the headers so we have them for logging if there are errors.
             let headers = &r.headers().clone();
@@ -104,20 +104,20 @@ async fn drupal_loadtest_front_page(user: &GooseUser) {
                     }
                 }
                 Err(e) => {
-                    user.set_failure(&mut response.request);
+                    user.set_failure(&mut goose.request);
                     let error = format!("front_page: failed to parse pag: {}", e);
                     // We choose to both log and display errors to stdout.
                     eprintln!("{}", &error);
-                    user.log_debug(&error, Some(response.request), Some(&headers), None);
+                    user.log_debug(&error, Some(goose.request), Some(&headers), None);
                 }
             }
         }
         Err(e) => {
-            user.set_failure(&mut response.request);
+            user.set_failure(&mut goose.request);
             let error = format!("front_page: no response from server: {}", e);
             // We choose to both log and display errors to stdout.
             eprintln!("{}", &error);
-            user.log_debug(&error, Some(response.request), None, None);
+            user.log_debug(&error, Some(goose.request), None, None);
         }
     }
 }
@@ -125,19 +125,19 @@ async fn drupal_loadtest_front_page(user: &GooseUser) {
 /// View a node from 1 to 10,000, created by preptest.sh.
 async fn drupal_loadtest_node_page(user: &GooseUser) {
     let nid = rand::thread_rng().gen_range(1, 10_000);
-    let _response = user.get(format!("/node/{}", &nid).as_str()).await;
+    let _goose = user.get(format!("/node/{}", &nid).as_str()).await;
 }
 
 /// View a profile from 2 to 5,001, created by preptest.sh.
 async fn drupal_loadtest_profile_page(user: &GooseUser) {
     let uid = rand::thread_rng().gen_range(2, 5_001);
-    let _response = user.get(format!("/user/{}", &uid).as_str()).await;
+    let _goose = user.get(format!("/user/{}", &uid).as_str()).await;
 }
 
 /// Log in.
 async fn drupal_loadtest_login(user: &GooseUser) {
-    let mut response = user.get("/user").await;
-    match response.response {
+    let mut goose = user.get("/user").await;
+    match goose.response {
         Ok(r) => {
             // Copy the headers so we have them for logging if there are errors.
             let headers = &r.headers().clone();
@@ -147,13 +147,13 @@ async fn drupal_loadtest_login(user: &GooseUser) {
                     let form_build_id = match re.captures(&html) {
                         Some(f) => f,
                         None => {
-                            user.set_failure(&mut response.request);
+                            user.set_failure(&mut goose.request);
                             let error = "login: no form_build_id on page: /user page";
                             // We choose to both log and display errors to stdout.
                             eprintln!("{}", error);
                             user.log_debug(
                                 error,
-                                Some(response.request),
+                                Some(goose.request),
                                 Some(&headers),
                                 Some(html.clone()),
                             );
@@ -172,15 +172,15 @@ async fn drupal_loadtest_login(user: &GooseUser) {
                         ("op", "Log+in"),
                     ];
                     let request_builder = user.goose_post("/user").await;
-                    let _response = user.goose_send(request_builder.form(&params), None).await;
+                    let _goose = user.goose_send(request_builder.form(&params), None).await;
                     // @TODO: verify that we actually logged in.
                 }
                 Err(e) => {
-                    user.set_failure(&mut response.request);
+                    user.set_failure(&mut goose.request);
                     let error = format!("login: unexpected error when loading /user page: {}", e);
                     // We choose to both log and display errors to stdout.
                     eprintln!("{}", &error);
-                    user.log_debug(&error, Some(response.request), Some(&headers), None);
+                    user.log_debug(&error, Some(goose.request), Some(&headers), None);
                 }
             }
         }
@@ -201,8 +201,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
     let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);
-    let mut response = user.get(&node_path).await;
-    match response.response {
+    let mut goose = user.get(&node_path).await;
+    match goose.response {
         Ok(r) => {
             // Copy the headers so we have them for logging if there are errors.
             let headers = &r.headers().clone();
@@ -213,14 +213,14 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                     let form_build_id = match re.captures(&html) {
                         Some(f) => f,
                         None => {
-                            user.set_failure(&mut response.request);
+                            user.set_failure(&mut goose.request);
                             let error =
                                 format!("post_comment: no form_build_id found on {}", &node_path);
                             // We choose to both log and display errors to stdout.
                             eprintln!("{}", &error);
                             user.log_debug(
                                 &error,
-                                Some(response.request),
+                                Some(goose.request),
                                 Some(headers),
                                 Some(html.clone()),
                             );
@@ -232,14 +232,14 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                     let form_token = match re.captures(&html) {
                         Some(f) => f,
                         None => {
-                            user.set_failure(&mut response.request);
+                            user.set_failure(&mut goose.request);
                             let error =
                                 format!("post_comment: no form_token found on {}", &node_path);
                             // We choose to both log and display errors to stdout.
                             eprintln!("{}", &error);
                             user.log_debug(
                                 &error,
-                                Some(response.request),
+                                Some(goose.request),
                                 Some(&headers),
                                 Some(html.clone()),
                             );
@@ -251,13 +251,13 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                     let form_id = match re.captures(&html) {
                         Some(f) => f,
                         None => {
-                            user.set_failure(&mut response.request);
+                            user.set_failure(&mut goose.request);
                             let error = format!("post_comment: no form_id found on {}", &node_path);
                             // We choose to both log and display errors to stdout.
                             eprintln!("{}", &error);
                             user.log_debug(
                                 &error,
-                                Some(response.request),
+                                Some(goose.request),
                                 Some(&headers),
                                 Some(html.clone()),
                             );
@@ -277,28 +277,28 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                         ("op", "Save"),
                     ];
                     let request_builder = user.goose_post(&comment_path).await;
-                    let mut response = user.goose_send(request_builder.form(&params), None).await;
-                    match response.response {
+                    let mut goose = user.goose_send(request_builder.form(&params), None).await;
+                    match goose.response {
                         Ok(r) => {
                             // Copy the headers so we have them for logging if there are errors.
                             let headers = &r.headers().clone();
                             match r.text().await {
                                 Ok(html) => {
                                     if !html.contains(&comment_body) {
-                                        user.set_failure(&mut response.request);
+                                        user.set_failure(&mut goose.request);
                                         let error = format!("post_comment: no comment showed up after posting to {}", &comment_path);
                                         // We choose to both log and display errors to stdout.
                                         eprintln!("{}", &error);
                                         user.log_debug(
                                             &error,
-                                            Some(response.request),
+                                            Some(goose.request),
                                             Some(&headers),
                                             Some(html),
                                         );
                                     }
                                 }
                                 Err(e) => {
-                                    user.set_failure(&mut response.request);
+                                    user.set_failure(&mut goose.request);
                                     let error = format!(
                                         "post_comment: unexpected error when posting to {}: {}",
                                         &comment_path, e
@@ -307,7 +307,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                                     eprintln!("{}", &error);
                                     user.log_debug(
                                         &error,
-                                        Some(response.request),
+                                        Some(goose.request),
                                         Some(&headers),
                                         None,
                                     );
@@ -322,16 +322,16 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                             );
                             // We choose to both log and display errors to stdout.
                             eprintln!("{}", &error);
-                            user.log_debug(&error, Some(response.request), None, None);
+                            user.log_debug(&error, Some(goose.request), None, None);
                         }
                     }
                 }
                 Err(e) => {
-                    user.set_failure(&mut response.request);
+                    user.set_failure(&mut goose.request);
                     let error = format!("post_comment: no text when loading {}: {}", &node_path, e);
                     // We choose to both log and display errors to stdout.
                     eprintln!("{}", &error);
-                    user.log_debug(&error, Some(response.request), None, None);
+                    user.log_debug(&error, Some(goose.request), None, None);
                 }
             }
         }
@@ -343,7 +343,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
             );
             // We choose to both log and display errors to stdout.
             eprintln!("{}", &error);
-            user.log_debug(&error, Some(response.request), None, None);
+            user.log_debug(&error, Some(goose.request), None, None);
         }
     }
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -73,7 +73,7 @@
 //!
 //!     /// A very simple task that simply loads the front page.
 //!     async fn task_function(user: &GooseUser) {
-//!       let _response = user.get("/").await;
+//!       let _goose = user.get("/").await;
 //!     }
 //! ```
 //!
@@ -89,7 +89,7 @@
 //!
 //!     /// A very simple task that simply loads the front page.
 //!     async fn task_function(user: &GooseUser) {
-//!       let _response = user.get("/").await;
+//!       let _goose = user.get("/").await;
 //!     }
 //! ```
 //!
@@ -107,12 +107,12 @@
 //!
 //!     /// A very simple task that simply loads the "a" page.
 //!     async fn a_task_function(user: &GooseUser) {
-//!       let _response = user.get("/a/").await;
+//!       let _goose = user.get("/a/").await;
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
 //!     async fn b_task_function(user: &GooseUser) {
-//!       let _response = user.get("/b/").await;
+//!       let _goose = user.get("/b/").await;
 //!     }
 //! ```
 //!
@@ -135,17 +135,17 @@
 //!
 //!     /// A very simple task that simply loads the "a" page.
 //!     async fn a_task_function(user: &GooseUser) {
-//!       let _response = user.get("/a/").await;
+//!       let _goose = user.get("/a/").await;
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
 //!     async fn b_task_function(user: &GooseUser) {
-//!       let _response = user.get("/b/").await;
+//!       let _goose = user.get("/b/").await;
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "c" page.
 //!     async fn c_task_function(user: &GooseUser) {
-//!       let _response = user.get("/c/").await;
+//!       let _goose = user.get("/c/").await;
 //!     }
 //! ```
 //!
@@ -164,7 +164,7 @@
 //!
 //!     /// A very simple task that simply loads the "a" page.
 //!     async fn a_task_function(user: &GooseUser) {
-//!       let _response = user.get("/a/").await;
+//!       let _goose = user.get("/a/").await;
 //!     }
 //! ```
 //!
@@ -183,7 +183,7 @@
 //!
 //!     /// Another very simple task that simply loads the "b" page.
 //!     async fn b_task_function(user: &GooseUser) {
-//!       let _response = user.get("/b/").await;
+//!       let _goose = user.get("/b/").await;
 //!     }
 //! ```
 //!
@@ -211,7 +211,7 @@
 //!
 //!     /// A very simple task that makes a GET request.
 //!     async  fn get_function(user: &GooseUser) {
-//!       let _response = user.get("/path/to/foo/").await;
+//!       let _goose = user.get("/path/to/foo/").await;
 //!     }
 //! ```
 //!
@@ -223,7 +223,7 @@
 //!
 //! A helper to make a `POST` request of a string value to the path and collect relevant
 //! statistics. Automatically prepends the correct host. The returned response is a
-//! [`reqwest::blocking::Response`](https://docs.rs/reqwest/*/reqwest/blocking/struct.Response.html)
+//! [`reqwest::Response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)
 //!
 //! ```rust
 //!     use goose::prelude::*;
@@ -232,7 +232,7 @@
 //!
 //!     /// A very simple task that makes a POST request.
 //!     async fn post_function(user: &GooseUser) {
-//!       let _response = user.post("/path/to/foo/", "string value to post").await;
+//!       let _goose = user.post("/path/to/foo/", "string value to post").await;
 //!     }
 //! ```
 //!
@@ -347,7 +347,7 @@ impl GooseTaskSet {
     ///
     ///     /// A very simple task that simply loads the "a" page.
     ///     async fn a_task_function(user: &GooseUser) {
-    ///       let _response = user.get("/a/").await;
+    ///       let _goose = user.get("/a/").await;
     ///     }
     /// ```
     pub fn register_task(mut self, mut task: GooseTask) -> Self {
@@ -840,8 +840,8 @@ impl GooseUser {
     ///
     /// Calls to `user.get` return a `GooseResponse` object which contains a copy of
     /// the request you made
-    /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
+    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -851,7 +851,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a GET request.
     ///     async fn get_function(user: &GooseUser) {
-    ///       let _response = user.get("/path/to/foo/").await;
+    ///       let _goose = user.get("/path/to/foo/").await;
     ///     }
     /// ```
     pub async fn get(&self, path: &str) -> GooseResponse {
@@ -865,8 +865,8 @@ impl GooseUser {
     ///
     /// Calls to `user.get_named` return a `GooseResponse` object which contains a copy of
     /// the request you made
-    /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
+    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -876,7 +876,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a GET request.
     ///     async fn get_function(user: &GooseUser) {
-    ///       let _response = user.get_named("/path/to/foo/", "foo").await;
+    ///       let _goose = user.get_named("/path/to/foo/", "foo").await;
     ///     }
     /// ```
     pub async fn get_named(&self, path: &str, request_name: &str) -> GooseResponse {
@@ -894,8 +894,8 @@ impl GooseUser {
     ///
     /// Calls to `user.post` return a `GooseResponse` object which contains a copy of
     /// the request you made
-    /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
+    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -905,7 +905,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a POST request.
     ///     async fn post_function(user: &GooseUser) {
-    ///       let _response = user.post("/path/to/foo/", "BODY BEING POSTED").await;
+    ///       let _goose = user.post("/path/to/foo/", "BODY BEING POSTED").await;
     ///     }
     /// ```
     pub async fn post(&self, path: &str, body: &str) -> GooseResponse {
@@ -919,8 +919,8 @@ impl GooseUser {
     ///
     /// Calls to `user.post` return a `GooseResponse` object which contains a copy of
     /// the request you made
-    /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
+    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -930,7 +930,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a POST request.
     ///     async fn post_function(user: &GooseUser) {
-    ///       let _response = user.post_named("/path/to/foo/", "foo", "BODY BEING POSTED").await;
+    ///       let _goose = user.post_named("/path/to/foo/", "foo", "BODY BEING POSTED").await;
     ///     }
     /// ```
     pub async fn post_named(&self, path: &str, request_name: &str, body: &str) -> GooseResponse {
@@ -948,8 +948,8 @@ impl GooseUser {
     ///
     /// Calls to `user.head` return a `GooseResponse` object which contains a copy of
     /// the request you made
-    /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
+    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -959,7 +959,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a HEAD request.
     ///     async fn head_function(user: &GooseUser) {
-    ///       let _response = user.head("/path/to/foo/").await;
+    ///       let _goose = user.head("/path/to/foo/").await;
     ///     }
     /// ```
     pub async fn head(&self, path: &str) -> GooseResponse {
@@ -973,8 +973,8 @@ impl GooseUser {
     ///
     /// Calls to `user.head` return a `GooseResponse` object which contains a copy of
     /// the request you made
-    /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
+    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -984,7 +984,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a HEAD request.
     ///     async fn head_function(user: &GooseUser) {
-    ///       let _response = user.head_named("/path/to/foo/", "foo").await;
+    ///       let _goose = user.head_named("/path/to/foo/", "foo").await;
     ///     }
     /// ```
     pub async fn head_named(&self, path: &str, request_name: &str) -> GooseResponse {
@@ -1002,8 +1002,8 @@ impl GooseUser {
     ///
     /// Calls to `user.delete` return a `GooseResponse` object which contains a copy of
     /// the request you made
-    /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
+    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -1013,7 +1013,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a DELETE request.
     ///     async fn delete_function(user: &GooseUser) {
-    ///       let _response = user.delete("/path/to/foo/").await;
+    ///       let _goose = user.delete("/path/to/foo/").await;
     ///     }
     /// ```
     pub async fn delete(&self, path: &str) -> GooseResponse {
@@ -1027,8 +1027,8 @@ impl GooseUser {
     ///
     /// Calls to `user.delete` return a `GooseResponse` object which contains a copy of
     /// the request you made
-    /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
+    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -1038,7 +1038,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a DELETE request.
     ///     async fn delete_function(user: &GooseUser) {
-    ///       let _response = user.delete_named("/path/to/foo/", "foo").await;
+    ///       let _goose = user.delete_named("/path/to/foo/", "foo").await;
     ///     }
     /// ```
     pub async fn delete_named(&self, path: &str, request_name: &str) -> GooseResponse {
@@ -1062,7 +1062,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn get_function(user: &GooseUser) {
     ///       let request_builder = user.goose_get("/path/to/foo").await;
-    ///       let response = user.goose_send(request_builder, None).await;
+    ///       let goose = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_get(&self, path: &str) -> RequestBuilder {
@@ -1086,7 +1086,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn post_function(user: &GooseUser) {
     ///       let request_builder = user.goose_post("/path/to/foo").await;
-    ///       let response = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_post(&self, path: &str) -> RequestBuilder {
@@ -1110,7 +1110,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn head_function(user: &GooseUser) {
     ///       let request_builder = user.goose_head("/path/to/foo").await;
-    ///       let response = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_head(&self, path: &str) -> RequestBuilder {
@@ -1134,7 +1134,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn put_function(user: &GooseUser) {
     ///       let request_builder = user.goose_put("/path/to/foo").await;
-    ///       let response = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_put(&self, path: &str) -> RequestBuilder {
@@ -1158,7 +1158,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn patch_function(user: &GooseUser) {
     ///       let request_builder = user.goose_patch("/path/to/foo").await;
-    ///       let response = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_patch(&self, path: &str) -> RequestBuilder {
@@ -1182,7 +1182,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn delete_function(user: &GooseUser) {
     ///       let request_builder = user.goose_delete("/path/to/foo").await;
-    ///       let response = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_delete(&self, path: &str) -> RequestBuilder {
@@ -1201,8 +1201,8 @@ impl GooseUser {
     ///
     /// Calls to `user.goose_send` return a `GooseResponse` object which contains a
     /// copy of the request you made
-    /// ([`response.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
-    /// ([`response.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the response
+    /// ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
     /// # Example
     /// ```rust
@@ -1214,7 +1214,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn get_function(user: &GooseUser) {
     ///       let request_builder = user.goose_get("/path/to/foo").await;
-    ///       let response = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await;
     ///     }
     /// ```
     pub async fn goose_send(
@@ -1344,12 +1344,12 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a GET request.
     ///     async fn get_function(user: &GooseUser) {
-    ///         let mut response = user.get("/404").await;
-    ///         match &response.response {
+    ///         let mut goose = user.get("/404").await;
+    ///         match &goose.response {
     ///             Ok(r) => {
     ///                 // We expect a 404 here.
     ///                 if r.status() == 404 {
-    ///                     user.set_success(&mut response.request);
+    ///                     user.set_success(&mut goose.request);
     ///                 }
     ///             },
     ///             Err(_) => (),
@@ -1379,9 +1379,9 @@ impl GooseUser {
     ///     let mut task = task!(loadtest_index_page);
     ///
     ///     async fn loadtest_index_page(user: &GooseUser) {
-    ///         let mut response = user.get_named("/", "index").await;
+    ///         let mut goose = user.get_named("/", "index").await;
     ///         // Extract the response Result.
-    ///         match response.response {
+    ///         match goose.response {
     ///             Ok(r) => {
     ///                 // We only need to check pages that returned a success status code.
     ///                 if r.status().is_success() {
@@ -1391,11 +1391,11 @@ impl GooseUser {
     ///                             // was a failure.
     ///                             if !text.contains("this string must exist") {
     ///                                 // As this is a named request, pass in the name not the URL
-    ///                                 user.set_failure(&mut response.request);
+    ///                                 user.set_failure(&mut goose.request);
     ///                             }
     ///                         }
     ///                         // Empty page, this is a failure.
-    ///                         Err(_) => user.set_failure(&mut response.request),
+    ///                         Err(_) => user.set_failure(&mut goose.request),
     ///                     }
     ///                 }
     ///             },
@@ -1434,9 +1434,9 @@ impl GooseUser {
     ///     let mut task = task!(loadtest_index_page);
     ///
     ///     async fn loadtest_index_page(user: &GooseUser) {
-    ///         let mut response = user.get_named("/", "index").await;
+    ///         let mut goose = user.get_named("/", "index").await;
     ///         // Extract the response Result.
-    ///         match response.response {
+    ///         match goose.response {
     ///             Ok(r) => {
     ///                 // Grab a copy of the headers so we can include them when logging errors.
     ///                 let headers = &r.headers().clone();
@@ -1447,7 +1447,7 @@ impl GooseUser {
     ///                             // Server returned an error code, log everything.
     ///                             user.log_debug(
     ///                                 "error loading /",
-    ///                                 Some(response.request),
+    ///                                 Some(goose.request),
     ///                                 Some(headers),
     ///                                 Some(html.clone()),
     ///                             );
@@ -1456,7 +1456,7 @@ impl GooseUser {
     ///                             // No body was returned, log everything else.
     ///                             user.log_debug(
     ///                                 "error loading /",
-    ///                                 Some(response.request),
+    ///                                 Some(goose.request),
     ///                                 Some(headers),
     ///                                 None,
     ///                             );
@@ -1468,7 +1468,7 @@ impl GooseUser {
     ///             Err(e) => {
     ///                 user.log_debug(
     ///                     "no response from server when loading /",
-    ///                     Some(response.request),
+    ///                     Some(goose.request),
     ///                     None,
     ///                     None,
     ///                 );
@@ -1609,7 +1609,7 @@ impl GooseUser {
     ///     .execute();
     ///
     ///     async fn task_foo(user: &GooseUser) {
-    ///       let _response = user.get("/").await;
+    ///       let _goose = user.get("/").await;
     ///     }
     ///
     ///     async fn task_bar(user: &GooseUser) {
@@ -1617,7 +1617,7 @@ impl GooseUser {
     ///       // http://foo.example.com, after this task runs all subsequent
     ///       // requests are made against http://bar.example.com/.
     ///       user.set_base_url("http://bar.example.com/");
-    ///       let _response = user.get("/").await;
+    ///       let _goose = user.get("/").await;
     ///     }
     /// ```
     pub async fn set_base_url(&self, host: &str) {
@@ -1704,7 +1704,7 @@ impl GooseTask {
     ///     task!(my_task_function).set_name("foo");
     ///
     ///     async fn my_task_function(user: &GooseUser) {
-    ///       let _response = user.get("/").await;
+    ///       let _goose = user.get("/").await;
     ///     }
     /// ```
     pub fn set_name(mut self, name: &str) -> Self {
@@ -1730,7 +1730,7 @@ impl GooseTask {
     ///     task!(my_on_start_function).set_on_start();
     ///
     ///     async fn my_on_start_function(user: &GooseUser) {
-    ///       let _response = user.get("/").await;
+    ///       let _goose = user.get("/").await;
     ///     }
     /// ```
     pub fn set_on_start(mut self) -> Self {
@@ -1756,7 +1756,7 @@ impl GooseTask {
     ///     task!(my_on_stop_function).set_on_stop();
     ///
     ///     async fn my_on_stop_function(user: &GooseUser) {
-    ///       let _response = user.get("/").await;
+    ///       let _goose = user.get("/").await;
     ///     }
     /// ```
     pub fn set_on_stop(mut self) -> Self {
@@ -1776,7 +1776,7 @@ impl GooseTask {
     ///     task!(task_function).set_weight(3);
     ///
     ///     async fn task_function(user: &GooseUser) {
-    ///       let _response = user.get("/").await;
+    ///       let _goose = user.get("/").await;
     ///     }
     /// ```
     pub fn set_weight(mut self, weight: usize) -> Self {
@@ -1813,15 +1813,15 @@ impl GooseTask {
     ///     let runs_last = task!(third_task_function);
     ///
     ///     async fn first_task_function(user: &GooseUser) {
-    ///       let _response = user.get("/1").await;
+    ///       let _goose = user.get("/1").await;
     ///     }
     ///
     ///     async fn second_task_function(user: &GooseUser) {
-    ///       let _response = user.get("/2").await;
+    ///       let _goose = user.get("/2").await;
     ///     }
     ///
     ///     async fn third_task_function(user: &GooseUser) {
-    ///       let _response = user.get("/3").await;
+    ///       let _goose = user.get("/3").await;
     ///     }
     /// ```
     ///
@@ -1837,15 +1837,15 @@ impl GooseTask {
     ///     let also_runs_second = task!(second_task_function_b).set_sequence(2).set_weight(2);
     ///
     ///     async fn first_task_function(user: &GooseUser) {
-    ///       let _response = user.get("/1").await;
+    ///       let _goose = user.get("/1").await;
     ///     }
     ///
     ///     async fn second_task_function_a(user: &GooseUser) {
-    ///       let _response = user.get("/2a").await;
+    ///       let _goose = user.get("/2a").await;
     ///     }
     ///
     ///     async fn second_task_function_b(user: &GooseUser) {
-    ///       let _response = user.get("/2b").await;
+    ///       let _goose = user.get("/2b").await;
     ///     }
     /// ```
     pub fn set_sequence(mut self, sequence: usize) -> Self {
@@ -1893,11 +1893,11 @@ mod tests {
     fn goose_task_set() {
         // Simplistic test task functions.
         async fn test_function_a(user: &GooseUser) {
-            let _response = user.get("/a/").await;
+            let _goose = user.get("/a/").await;
         }
 
         async fn test_function_b(user: &GooseUser) {
-            let _response = user.get("/b/").await;
+            let _goose = user.get("/b/").await;
         }
 
         let mut task_set = taskset!("foo");
@@ -1990,7 +1990,7 @@ mod tests {
     fn goose_task() {
         // Simplistic test task functions.
         async fn test_function_a(user: &GooseUser) {
-            let _response = user.get("/a/");
+            let _goose = user.get("/a/");
         }
 
         // Initialize task set.
@@ -2426,30 +2426,30 @@ mod tests {
 
         // Make a GET request to the mock http server and confirm we get a 200 response.
         assert_eq!(mock_index.times_called(), 0);
-        let response = user.get("/").await;
-        let status = response.response.unwrap().status();
+        let goose = user.get("/").await;
+        let status = goose.response.unwrap().status();
         assert_eq!(status, 200);
         assert_eq!(mock_index.times_called(), 1);
-        assert_eq!(response.request.method, GooseMethod::GET);
-        assert_eq!(response.request.name, "/");
-        assert_eq!(response.request.success, true);
-        assert_eq!(response.request.update, false);
-        assert_eq!(response.request.status_code, 200);
+        assert_eq!(goose.request.method, GooseMethod::GET);
+        assert_eq!(goose.request.name, "/");
+        assert_eq!(goose.request.success, true);
+        assert_eq!(goose.request.update, false);
+        assert_eq!(goose.request.status_code, 200);
 
         const NO_SUCH_PATH: &str = "/no/such/path";
         let mock_404 = mock(GET, NO_SUCH_PATH).return_status(404).create();
 
         // Make an invalid GET request to the mock http server and confirm we get a 404 response.
         assert_eq!(mock_404.times_called(), 0);
-        let response = user.get(NO_SUCH_PATH).await;
-        let status = response.response.unwrap().status();
+        let goose = user.get(NO_SUCH_PATH).await;
+        let status = goose.response.unwrap().status();
         assert_eq!(status, 404);
         assert_eq!(mock_404.times_called(), 1);
-        assert_eq!(response.request.method, GooseMethod::GET);
-        assert_eq!(response.request.name, NO_SUCH_PATH);
-        assert_eq!(response.request.success, false);
-        assert_eq!(response.request.update, false);
-        assert_eq!(response.request.status_code, 404,);
+        assert_eq!(goose.request.method, GooseMethod::GET);
+        assert_eq!(goose.request.name, NO_SUCH_PATH);
+        assert_eq!(goose.request.success, false);
+        assert_eq!(goose.request.update, false);
+        assert_eq!(goose.request.status_code, 404,);
 
         // Set up a mock http server endpoint.
         const COMMENT_PATH: &str = "/comment";
@@ -2461,17 +2461,17 @@ mod tests {
 
         // Make a POST request to the mock http server and confirm we get a 200 OK response.
         assert_eq!(mock_comment.times_called(), 0);
-        let response = user.post(COMMENT_PATH, "foo").await;
-        let unwrapped_response = response.response.unwrap();
+        let goose = user.post(COMMENT_PATH, "foo").await;
+        let unwrapped_response = goose.response.unwrap();
         let status = unwrapped_response.status();
         assert_eq!(status, 200);
         let body = unwrapped_response.text().await.unwrap();
         assert_eq!(body, "foo");
         assert_eq!(mock_comment.times_called(), 1);
-        assert_eq!(response.request.method, GooseMethod::POST);
-        assert_eq!(response.request.name, COMMENT_PATH);
-        assert_eq!(response.request.success, true);
-        assert_eq!(response.request.update, false);
-        assert_eq!(response.request.status_code, 200);
+        assert_eq!(goose.request.method, GooseMethod::POST);
+        assert_eq!(goose.request.name, COMMENT_PATH);
+        assert_eq!(goose.request.success, true);
+        assert_eq!(goose.request.update, false);
+        assert_eq!(goose.request.status_code, 200);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! use goose::prelude::*;
 //!
 //! async fn loadtest_foo(user: &GooseUser) {
-//!   let _response = user.get("/path/to/foo").await;
+//!   let _goose = user.get("/path/to/foo").await;
 //! }   
 //! ```
 //!
@@ -70,7 +70,7 @@
 //!
 //! async fn loadtest_bar(user: &GooseUser) {
 //!   let request_builder = user.goose_get("/path/to/bar").await;
-//!   let _response = user.goose_send(request_builder.timeout(time::Duration::from_secs(3)), None).await;
+//!   let _goose = user.goose_send(request_builder.timeout(time::Duration::from_secs(3)), None).await;
 //! }   
 //! ```
 //!
@@ -100,11 +100,11 @@
 //!     .execute();
 //!
 //! async fn loadtest_foo(user: &GooseUser) {
-//!   let _response = user.get("/path/to/foo").await;
+//!   let _goose = user.get("/path/to/foo").await;
 //! }   
 //!
 //! async fn loadtest_bar(user: &GooseUser) {
-//!   let _response = user.get("/path/to/bar").await;
+//!   let _goose = user.get("/path/to/bar").await;
 //! }   
 //! ```
 //!
@@ -610,11 +610,11 @@ impl GooseAttack {
     ///         );
     ///
     ///     async fn example_task(user: &GooseUser) {
-    ///       let _response = user.get("/foo").await;
+    ///       let _goose = user.get("/foo").await;
     ///     }
     ///
     ///     async fn other_task(user: &GooseUser) {
-    ///       let _response = user.get("/bar").await;
+    ///       let _goose = user.get("/bar").await;
     ///     }
     /// ```
     pub fn register_taskset(mut self, mut taskset: GooseTaskSet) -> Self {
@@ -769,11 +769,11 @@ impl GooseAttack {
     ///         .execute();
     ///
     ///     async fn example_task(user: &GooseUser) {
-    ///       let _response = user.get("/foo").await;
+    ///       let _goose = user.get("/foo").await;
     ///     }
     ///
     ///     async fn another_example_task(user: &GooseUser) {
-    ///       let _response = user.get("/bar").await;
+    ///       let _goose = user.get("/bar").await;
     ///     }
     /// ```
     pub fn execute(mut self) {

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -10,11 +10,11 @@ const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
 pub async fn get_index(user: &GooseUser) {
-    let _response = user.get(INDEX_PATH).await;
+    let _goose = user.get(INDEX_PATH).await;
 }
 
 pub async fn get_about(user: &GooseUser) {
-    let _response = user.get(ABOUT_PATH).await;
+    let _goose = user.get(ABOUT_PATH).await;
 }
 
 /// Test test_start alone.

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -12,19 +12,19 @@ const STATS_LOG_FILE: &str = "stats.log";
 const DEBUG_LOG_FILE: &str = "debug.log";
 
 pub async fn get_index(user: &GooseUser) {
-    let _response = user.get(INDEX_PATH).await;
+    let _goose = user.get(INDEX_PATH).await;
 }
 
 pub async fn get_error(user: &GooseUser) {
-    let response = user.get(ERROR_PATH).await;
-    if let Ok(r) = response.response {
+    let goose = user.get(ERROR_PATH).await;
+    if let Ok(r) = goose.response {
         let headers = &r.headers().clone();
         match r.text().await {
             Ok(_) => {}
             Err(_) => {
                 user.log_debug(
                     "there was an error",
-                    Some(response.request),
+                    Some(goose.request),
                     Some(headers),
                     None,
                 );

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -11,11 +11,11 @@ const LOGOUT_PATH: &str = "/logout";
 pub async fn login(user: &GooseUser) {
     let request_builder = user.goose_post(LOGIN_PATH).await;
     let params = [("username", "me"), ("password", "s3crET!")];
-    let _response = user.goose_send(request_builder.form(&params), None).await;
+    let _goose = user.goose_send(request_builder.form(&params), None).await;
 }
 
 pub async fn logout(user: &GooseUser) {
-    let _response = user.get(LOGOUT_PATH).await;
+    let _goose = user.get(LOGOUT_PATH).await;
 }
 
 #[test]

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -9,11 +9,11 @@ const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
 pub async fn get_index(user: &GooseUser) {
-    let _response = user.get(INDEX_PATH).await;
+    let _goose = user.get(INDEX_PATH).await;
 }
 
 pub async fn get_about(user: &GooseUser) {
-    let _response = user.get(ABOUT_PATH).await;
+    let _goose = user.get(ABOUT_PATH).await;
 }
 
 #[test]

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -13,29 +13,29 @@ const ABOUT_PATH: &str = "/about.php";
 
 // Task function, load INDEX_PATH.
 pub async fn get_index(user: &GooseUser) {
-    let _response = user.get(INDEX_PATH).await;
+    let _goose = user.get(INDEX_PATH).await;
 }
 
 // Task function, load ABOUT PATH
 pub async fn get_about(user: &GooseUser) {
-    let _response = user.get(ABOUT_PATH).await;
+    let _goose = user.get(ABOUT_PATH).await;
 }
 
 // Task function, load REDRECT_PATH and follow redirects to ABOUT_PATH.
 pub async fn get_redirect(user: &GooseUser) {
-    let mut response = user.get(REDIRECT_PATH).await;
-    if let Ok(r) = response.response {
+    let mut goose = user.get(REDIRECT_PATH).await;
+    if let Ok(r) = goose.response {
         match r.text().await {
             Ok(html) => {
                 // Confirm that we followed redirects and loaded the about page.
                 if !html.contains("about page") {
                     eprintln!("about page body wrong");
-                    user.set_failure(&mut response.request);
+                    user.set_failure(&mut goose.request);
                 }
             }
             Err(e) => {
                 eprintln!("unexpected error parsing about page: {}", e);
-                user.set_failure(&mut response.request);
+                user.set_failure(&mut goose.request);
             }
         }
     }
@@ -43,7 +43,7 @@ pub async fn get_redirect(user: &GooseUser) {
 
 // Task function, load REDRECT_PATH and follow redirect to new domain.
 pub async fn get_domain_redirect(user: &GooseUser) {
-    let _response = user.get(REDIRECT_PATH).await;
+    let _goose = user.get(REDIRECT_PATH).await;
 }
 
 #[test]

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -10,17 +10,17 @@ const SETUP_PATH: &str = "/setup";
 const TEARDOWN_PATH: &str = "/teardown";
 
 pub async fn setup(user: &GooseUser) {
-    let _response = user.post(SETUP_PATH, "setting up load test").await;
+    let _goose = user.post(SETUP_PATH, "setting up load test").await;
 }
 
 pub async fn teardown(user: &GooseUser) {
-    let _response = user
+    let _goose = user
         .post(TEARDOWN_PATH, "cleaning up after load test")
         .await;
 }
 
 pub async fn get_index(user: &GooseUser) {
-    let _response = user.get(INDEX_PATH).await;
+    let _goose = user.get(INDEX_PATH).await;
 }
 
 /// Test test_start alone.


### PR DESCRIPTION
Splitting out the rename of the outer `response` wrapper into a separate PR, to remove noise/distraction from the functional changes in #97 .

Prior to this change, we referred to the outer wrapper of a GooseResponse as `response`, which is confusing as it also contained a `response` field. This changes referring to the outer wrapper more generically as `goose`, which then contains two fields: `goose.request` and `goose.response`.