### PR TITLE
fix two missed conversions from `response` wrapper to `goose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ environments without recompiling:
 
 ```rust
 async fn loadtest_index(user: &GooseUser) {
-    let _response = user.get("/").await;
+    let _goose = user.get("/").await;
 }
 ```
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -42,15 +42,15 @@ async fn website_login(user: &GooseUser) {
     let request_builder = user.goose_post("/login").await;
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
-    let _response = user.goose_send(request_builder.form(&params), None).await;
+    let _goose = user.goose_send(request_builder.form(&params), None).await;
 }
 
 /// A very simple task that simply loads the front page.
 async fn website_index(user: &GooseUser) {
-    let _response = user.get("/").await;
+    let _goose = user.get("/").await;
 }
 
 /// A very simple task that simply loads the about page.
 async fn website_about(user: &GooseUser) {
-    let _response = user.get("/about/").await;
+    let _goose = user.get("/about/").await;
 }


### PR DESCRIPTION
Followup to #98 

Fixes two Missed conversions from `response` wrapper to `goose`.