### PR TITLE
return a Result from Task functions

### DIFF
--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -156,7 +156,7 @@ async fn drupal_loadtest_login(user: &GooseUser) -> GooseTaskResult {
                                 "login: no form_build_id on page: /user page",
                                 &mut goose.request,
                                 Some(&headers),
-                                Some(html.clone()),
+                                Some(&html),
                             );
                         }
                     };
@@ -221,7 +221,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                                 &format!("post_comment: no form_build_id found on {}", &node_path),
                                 &mut goose.request,
                                 Some(&headers),
-                                Some(html.clone()),
+                                Some(&html),
                             );
                         }
                     };
@@ -234,7 +234,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                                 &format!("post_comment: no form_token found on {}", &node_path),
                                 &mut goose.request,
                                 Some(&headers),
-                                Some(html.clone()),
+                                Some(&html),
                             );
                         }
                     };
@@ -247,7 +247,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                                 &format!("post_comment: no form_id found on {}", &node_path),
                                 &mut goose.request,
                                 Some(&headers),
-                                Some(html.clone()),
+                                Some(&html),
                             );
                         }
                     };
@@ -280,7 +280,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                                             &format!("post_comment: no comment showed up after posting to {}", &comment_path),
                                             &mut goose.request,
                                             Some(&headers),
-                                            Some(html),
+                                            Some(&html),
                                         );
                                     }
                                 }

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -103,6 +103,8 @@ async fn drupal_loadtest_front_page(user: &GooseUser) -> GooseTaskResult {
                     }
                 }
                 Err(e) => {
+                    // This will automatically get written to the error log if enabled, and will
+                    // be displayed to stdout if `-v` is enabled when running the load test.
                     return user.set_failure(
                         &format!("front_page: failed to parse page: {}", e),
                         &mut goose.request,
@@ -113,6 +115,8 @@ async fn drupal_loadtest_front_page(user: &GooseUser) -> GooseTaskResult {
             }
         }
         Err(e) => {
+            // This will automatically get written to the error log if enabled, and will
+            // be displayed to stdout if `-v` is enabled when running the load test.
             return user.set_failure(
                 &format!("front_page: no response from server: {}", e),
                 &mut goose.request,
@@ -152,6 +156,8 @@ async fn drupal_loadtest_login(user: &GooseUser) -> GooseTaskResult {
                     let form_build_id = match re.captures(&html) {
                         Some(f) => f,
                         None => {
+                            // This will automatically get written to the error log if enabled, and will
+                            // be displayed to stdout if `-v` is enabled when running the load test.
                             return user.set_failure(
                                 "login: no form_build_id on page: /user page",
                                 &mut goose.request,
@@ -176,6 +182,8 @@ async fn drupal_loadtest_login(user: &GooseUser) -> GooseTaskResult {
                     // @TODO: verify that we actually logged in.
                 }
                 Err(e) => {
+                    // This will automatically get written to the error log if enabled, and will
+                    // be displayed to stdout if `-v` is enabled when running the load test.
                     return user.set_failure(
                         &format!("login: unexpected error when loading /user page: {}", e),
                         &mut goose.request,
@@ -187,6 +195,8 @@ async fn drupal_loadtest_login(user: &GooseUser) -> GooseTaskResult {
         }
         // Goose will catch this error.
         Err(e) => {
+            // This will automatically get written to the error log if enabled, and will
+            // be displayed to stdout if `-v` is enabled when running the load test.
             return user.set_failure(
                 &format!("login: no response from server: {}", e),
                 &mut goose.request,
@@ -217,6 +227,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                     let form_build_id = match re.captures(&html) {
                         Some(f) => f,
                         None => {
+                            // This will automatically get written to the error log if enabled, and will
+                            // be displayed to stdout if `-v` is enabled when running the load test.
                             return user.set_failure(
                                 &format!("post_comment: no form_build_id found on {}", &node_path),
                                 &mut goose.request,
@@ -230,6 +242,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                     let form_token = match re.captures(&html) {
                         Some(f) => f,
                         None => {
+                            // This will automatically get written to the error log if enabled, and will
+                            // be displayed to stdout if `-v` is enabled when running the load test.
                             return user.set_failure(
                                 &format!("post_comment: no form_token found on {}", &node_path),
                                 &mut goose.request,
@@ -243,6 +257,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                     let form_id = match re.captures(&html) {
                         Some(f) => f,
                         None => {
+                            // This will automatically get written to the error log if enabled, and will
+                            // be displayed to stdout if `-v` is enabled when running the load test.
                             return user.set_failure(
                                 &format!("post_comment: no form_id found on {}", &node_path),
                                 &mut goose.request,
@@ -251,7 +267,19 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                             );
                         }
                     };
-                    //println!("form_id: {}, form_build_id: {}, form_token: {}", &form_id, &form_build_id, &form_token);
+                    // Optionally uncomment to log form_id, form_build_id, and form_token, together with
+                    // the full body of the page. This is useful when modifying the load test.
+                    /*
+                    user.log_debug(
+                        &format!(
+                            "form_id: {}, form_build_id: {}, form_token: {}",
+                            &form_id[1], &form_build_id[1], &form_token[1]
+                        ),
+                        Some(&goose.request),
+                        Some(&headers),
+                        Some(&html),
+                    );
+                    */
 
                     let comment_body = "this is a test comment body";
                     let params = [
@@ -276,6 +304,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                             match response.text().await {
                                 Ok(html) => {
                                     if !html.contains(&comment_body) {
+                                        // This will automatically get written to the error log if enabled, and will
+                                        // be displayed to stdout if `-v` is enabled when running the load test.
                                         return user.set_failure(
                                             &format!("post_comment: no comment showed up after posting to {}", &comment_path),
                                             &mut goose.request,
@@ -285,6 +315,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                                     }
                                 }
                                 Err(e) => {
+                                    // This will automatically get written to the error log if enabled, and will
+                                    // be displayed to stdout if `-v` is enabled when running the load test.
                                     return user.set_failure(
                                         &format!(
                                             "post_comment: unexpected error when posting to {}: {}",
@@ -298,6 +330,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                             }
                         }
                         Err(e) => {
+                            // This will automatically get written to the error log if enabled, and will
+                            // be displayed to stdout if `-v` is enabled when running the load test.
                             return user.set_failure(
                                 &format!(
                                     "post_comment: no response when posting to {}: {}",
@@ -311,6 +345,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                     }
                 }
                 Err(e) => {
+                    // This will automatically get written to the error log if enabled, and will
+                    // be displayed to stdout if `-v` is enabled when running the load test.
                     return user.set_failure(
                         &format!("post_comment: no text when loading {}: {}", &node_path, e),
                         &mut goose.request,
@@ -321,6 +357,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
             }
         }
         Err(e) => {
+            // This will automatically get written to the error log if enabled, and will
+            // be displayed to stdout if `-v` is enabled when running the load test.
             return user.set_failure(
                 &format!(
                     "post_comment: no response when loading {}: {}",

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -81,7 +81,7 @@ fn main() {
 }
 
 /// View the front page.
-async fn drupal_loadtest_front_page(user: &GooseUser) -> Result<(), ()> {
+async fn drupal_loadtest_front_page(user: &GooseUser) -> GooseTaskResult {
     let mut goose = match user.get("/").await {
         // Return early if get fails, there's nothing else to do.
         Err(_) => return Err(()),
@@ -130,21 +130,21 @@ async fn drupal_loadtest_front_page(user: &GooseUser) -> Result<(), ()> {
 }
 
 /// View a node from 1 to 10,000, created by preptest.sh.
-async fn drupal_loadtest_node_page(user: &GooseUser) -> Result<(), ()> {
+async fn drupal_loadtest_node_page(user: &GooseUser) -> GooseTaskResult {
     let nid = rand::thread_rng().gen_range(1, 10_000);
     let _goose = user.get(format!("/node/{}", &nid).as_str()).await;
     Ok(())
 }
 
 /// View a profile from 2 to 5,001, created by preptest.sh.
-async fn drupal_loadtest_profile_page(user: &GooseUser) -> Result<(), ()> {
+async fn drupal_loadtest_profile_page(user: &GooseUser) -> GooseTaskResult {
     let uid = rand::thread_rng().gen_range(2, 5_001);
     let _goose = user.get(format!("/user/{}", &uid).as_str()).await;
     Ok(())
 }
 
 /// Log in.
-async fn drupal_loadtest_login(user: &GooseUser) -> Result<(), ()> {
+async fn drupal_loadtest_login(user: &GooseUser) -> GooseTaskResult {
     let mut goose = match user.get("/user").await {
         // Return early if get fails, there's nothing else to do.
         Err(_) => return Err(()),
@@ -215,7 +215,7 @@ async fn drupal_loadtest_login(user: &GooseUser) -> Result<(), ()> {
 }
 
 /// Post a comment.
-async fn drupal_loadtest_post_comment(user: &GooseUser) -> Result<(), ()> {
+async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
     let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -81,10 +81,10 @@ fn main() {
 }
 
 /// View the front page.
-async fn drupal_loadtest_front_page(user: &GooseUser) {
+async fn drupal_loadtest_front_page(user: &GooseUser) -> Result<(), ()> {
     let mut goose = match user.get("/").await {
         // Return early if get fails, there's nothing else to do.
-        Err(_) => return,
+        Err(_) => return Err(()),
         // Otherwise unwrap the Result.
         Ok(g) => g,
     };
@@ -113,6 +113,7 @@ async fn drupal_loadtest_front_page(user: &GooseUser) {
                     // We choose to both log and display errors to stdout.
                     eprintln!("{}", &error);
                     user.log_debug(&error, Some(goose.request), Some(&headers), None);
+                    return Err(());
                 }
             }
         }
@@ -122,27 +123,31 @@ async fn drupal_loadtest_front_page(user: &GooseUser) {
             // We choose to both log and display errors to stdout.
             eprintln!("{}", &error);
             user.log_debug(&error, Some(goose.request), None, None);
+            return Err(());
         }
     }
+    Ok(())
 }
 
 /// View a node from 1 to 10,000, created by preptest.sh.
-async fn drupal_loadtest_node_page(user: &GooseUser) {
+async fn drupal_loadtest_node_page(user: &GooseUser) -> Result<(), ()> {
     let nid = rand::thread_rng().gen_range(1, 10_000);
     let _goose = user.get(format!("/node/{}", &nid).as_str()).await;
+    Ok(())
 }
 
 /// View a profile from 2 to 5,001, created by preptest.sh.
-async fn drupal_loadtest_profile_page(user: &GooseUser) {
+async fn drupal_loadtest_profile_page(user: &GooseUser) -> Result<(), ()> {
     let uid = rand::thread_rng().gen_range(2, 5_001);
     let _goose = user.get(format!("/user/{}", &uid).as_str()).await;
+    Ok(())
 }
 
 /// Log in.
-async fn drupal_loadtest_login(user: &GooseUser) {
+async fn drupal_loadtest_login(user: &GooseUser) -> Result<(), ()> {
     let mut goose = match user.get("/user").await {
         // Return early if get fails, there's nothing else to do.
-        Err(_) => return,
+        Err(_) => return Err(()),
         // Otherwise unwrap the Result.
         Ok(g) => g,
     };
@@ -167,7 +172,7 @@ async fn drupal_loadtest_login(user: &GooseUser) {
                                 Some(&headers),
                                 Some(html.clone()),
                             );
-                            return;
+                            return Err(());
                         }
                     };
 
@@ -191,6 +196,7 @@ async fn drupal_loadtest_login(user: &GooseUser) {
                     // We choose to both log and display errors to stdout.
                     eprintln!("{}", &error);
                     user.log_debug(&error, Some(goose.request), Some(&headers), None);
+                    return Err(());
                 }
             }
         }
@@ -202,19 +208,21 @@ async fn drupal_loadtest_login(user: &GooseUser) {
                 None,
                 None,
             );
+            return Err(());
         }
     }
+    Ok(())
 }
 
 /// Post a comment.
-async fn drupal_loadtest_post_comment(user: &GooseUser) {
+async fn drupal_loadtest_post_comment(user: &GooseUser) -> Result<(), ()> {
     let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);
 
     let mut goose = match user.get(&node_path).await {
         // Return early if get fails, there's nothing else to do.
-        Err(_) => return,
+        Err(_) => return Err(()),
         // Otherwise unwrap the Result.
         Ok(g) => g,
     };
@@ -241,7 +249,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                                 Some(headers),
                                 Some(html.clone()),
                             );
-                            return;
+                            return Err(());
                         }
                     };
 
@@ -260,7 +268,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                                 Some(&headers),
                                 Some(html.clone()),
                             );
-                            return;
+                            return Err(());
                         }
                     };
 
@@ -278,7 +286,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                                 Some(&headers),
                                 Some(html.clone()),
                             );
-                            return;
+                            return Err(());
                         }
                     };
                     //println!("form_id: {}, form_build_id: {}, form_token: {}", &form_id, &form_build_id, &form_token);
@@ -299,7 +307,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                     let mut goose = match user.goose_send(request_builder.form(&params), None).await
                     {
                         // Return early if get fails, there's nothing else to do.
-                        Err(_) => return,
+                        Err(_) => return Err(()),
                         // Otherwise unwrap the Result.
                         Ok(g) => g,
                     };
@@ -338,6 +346,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                                         Some(&headers),
                                         None,
                                     );
+                                    return Err(());
                                 }
                             }
                         }
@@ -350,6 +359,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                             // We choose to both log and display errors to stdout.
                             eprintln!("{}", &error);
                             user.log_debug(&error, Some(goose.request), None, None);
+                            return Err(());
                         }
                     }
                 }
@@ -359,6 +369,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
                     // We choose to both log and display errors to stdout.
                     eprintln!("{}", &error);
                     user.log_debug(&error, Some(goose.request), None, None);
+                    return Err(());
                 }
             }
         }
@@ -371,6 +382,8 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) {
             // We choose to both log and display errors to stdout.
             eprintln!("{}", &error);
             user.log_debug(&error, Some(goose.request), None, None);
+            return Err(());
         }
     }
+    Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -38,19 +38,22 @@ fn main() {
 /// Demonstrates how to log in when a user starts. We flag this task as an
 /// on_start task when registering it above. This means it only runs one time
 /// per user, when the user thread first starts.
-async fn website_login(user: &GooseUser) {
+async fn website_login(user: &GooseUser) -> Result<(), ()> {
     let request_builder = user.goose_post("/login").await;
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
     let _goose = user.goose_send(request_builder.form(&params), None).await;
+    Ok(())
 }
 
 /// A very simple task that simply loads the front page.
-async fn website_index(user: &GooseUser) {
+async fn website_index(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get("/").await;
+    Ok(())
 }
 
 /// A very simple task that simply loads the about page.
-async fn website_about(user: &GooseUser) {
+async fn website_about(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get("/about/").await;
+    Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -38,7 +38,7 @@ fn main() {
 /// Demonstrates how to log in when a user starts. We flag this task as an
 /// on_start task when registering it above. This means it only runs one time
 /// per user, when the user thread first starts.
-async fn website_login(user: &GooseUser) -> Result<(), ()> {
+async fn website_login(user: &GooseUser) -> GooseTaskResult {
     let request_builder = user.goose_post("/login").await;
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
@@ -47,13 +47,13 @@ async fn website_login(user: &GooseUser) -> Result<(), ()> {
 }
 
 /// A very simple task that simply loads the front page.
-async fn website_index(user: &GooseUser) -> Result<(), ()> {
+async fn website_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get("/").await;
     Ok(())
 }
 
 /// A very simple task that simply loads the about page.
-async fn website_about(user: &GooseUser) -> Result<(), ()> {
+async fn website_about(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get("/about/").await;
     Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -42,18 +42,18 @@ async fn website_login(user: &GooseUser) -> GooseTaskResult {
     let request_builder = user.goose_post("/login").await;
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
-    let _goose = user.goose_send(request_builder.form(&params), None).await;
+    let _goose = user.goose_send(request_builder.form(&params), None).await?;
     Ok(())
 }
 
 /// A very simple task that simply loads the front page.
 async fn website_index(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get("/").await;
+    let _goose = user.get("/").await?;
     Ok(())
 }
 
 /// A very simple task that simply loads the about page.
 async fn website_about(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get("/about/").await;
+    let _goose = user.get("/about/").await?;
     Ok(())
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1547,7 +1547,10 @@ impl GooseUser {
             self.send_to_parent(&request);
         }
         // Log failure, converting `&mut request` to `&request` as needed by `log_debug()`.
-        self.log_debug(&tag, Some(&*request), headers, body);
+        self.log_debug(tag, Some(&*request), headers, body);
+
+        // Log to stdout if `-v` is enabled.
+        info!("set_failure: {}", tag);
 
         Err(GooseTaskError::RequestFailed)
     }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -763,7 +763,7 @@ impl GooseDebug {
             // Convert tag from &str to string.
             tag: tag.to_string(),
             // If request is defined, clone it.
-            request: request.map(|r| r.clone()),
+            request: request.cloned(),
             // If header is defined, convert it to a string.
             header: header.map(|h| format!("{:?}", h)),
             // If header is defined, convert from &str to string.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -73,7 +73,7 @@
 //!
 //!     /// A very simple task that simply loads the front page.
 //!     async fn task_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/").await;
+//!       let _goose = user.get("/").await?;
 //!       Ok(())
 //!     }
 //! ```
@@ -90,7 +90,7 @@
 //!
 //!     /// A very simple task that simply loads the front page.
 //!     async fn task_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/").await;
+//!       let _goose = user.get("/").await?;
 //!       Ok(())
 //!     }
 //! ```
@@ -109,13 +109,13 @@
 //!
 //!     /// A very simple task that simply loads the "a" page.
 //!     async fn a_task_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/a/").await;
+//!       let _goose = user.get("/a/").await?;
 //!       Ok(())
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
 //!     async fn b_task_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/b/").await;
+//!       let _goose = user.get("/b/").await?;
 //!       Ok(())
 //!     }
 //! ```
@@ -139,19 +139,19 @@
 //!
 //!     /// A very simple task that simply loads the "a" page.
 //!     async fn a_task_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/a/").await;
+//!       let _goose = user.get("/a/").await?;
 //!       Ok(())
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
 //!     async fn b_task_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/b/").await;
+//!       let _goose = user.get("/b/").await?;
 //!       Ok(())
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "c" page.
 //!     async fn c_task_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/c/").await;
+//!       let _goose = user.get("/c/").await?;
 //!       Ok(())
 //!     }
 //! ```
@@ -171,7 +171,7 @@
 //!
 //!     /// A very simple task that simply loads the "a" page.
 //!     async fn a_task_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/a/").await;
+//!       let _goose = user.get("/a/").await?;
 //!       Ok(())
 //!     }
 //! ```
@@ -191,7 +191,7 @@
 //!
 //!     /// Another very simple task that simply loads the "b" page.
 //!     async fn b_task_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/b/").await;
+//!       let _goose = user.get("/b/").await?;
 //!       Ok(())
 //!     }
 //! ```
@@ -220,7 +220,7 @@
 //!
 //!     /// A very simple task that makes a GET request.
 //!     async  fn get_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.get("/path/to/foo/").await;
+//!       let _goose = user.get("/path/to/foo/").await?;
 //!       Ok(())
 //!     }
 //! ```
@@ -242,7 +242,7 @@
 //!
 //!     /// A very simple task that makes a POST request.
 //!     async fn post_function(user: &GooseUser) -> GooseTaskResult {
-//!       let _goose = user.post("/path/to/foo/", "string value to post").await;
+//!       let _goose = user.post("/path/to/foo/", "string value to post").await?;
 //!       Ok(())
 //!     }
 //! ```
@@ -358,7 +358,7 @@ impl GooseTaskSet {
     ///
     ///     /// A very simple task that simply loads the "a" page.
     ///     async fn a_task_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/a/").await;
+    ///       let _goose = user.get("/a/").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -872,7 +872,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a GET request.
     ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/path/to/foo/").await;
+    ///       let _goose = user.get("/path/to/foo/").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -898,7 +898,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a GET request.
     ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get_named("/path/to/foo/", "foo").await;
+    ///       let _goose = user.get_named("/path/to/foo/", "foo").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -932,7 +932,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a POST request.
     ///     async fn post_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.post("/path/to/foo/", "BODY BEING POSTED").await;
+    ///       let _goose = user.post("/path/to/foo/", "BODY BEING POSTED").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -962,7 +962,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a POST request.
     ///     async fn post_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.post_named("/path/to/foo/", "foo", "BODY BEING POSTED").await;
+    ///       let _goose = user.post_named("/path/to/foo/", "foo", "BODY BEING POSTED").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -997,7 +997,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a HEAD request.
     ///     async fn head_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.head("/path/to/foo/").await;
+    ///       let _goose = user.head("/path/to/foo/").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1023,7 +1023,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a HEAD request.
     ///     async fn head_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.head_named("/path/to/foo/", "foo").await;
+    ///       let _goose = user.head_named("/path/to/foo/", "foo").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1057,7 +1057,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a DELETE request.
     ///     async fn delete_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.delete("/path/to/foo/").await;
+    ///       let _goose = user.delete("/path/to/foo/").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1083,7 +1083,7 @@ impl GooseUser {
     ///
     ///     /// A very simple task that makes a DELETE request.
     ///     async fn delete_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.delete_named("/path/to/foo/", "foo").await;
+    ///       let _goose = user.delete_named("/path/to/foo/", "foo").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1112,7 +1112,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_get("/path/to/foo").await;
-    ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1137,7 +1137,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn post_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_post("/path/to/foo").await;
-    ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1162,7 +1162,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn head_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_head("/path/to/foo").await;
-    ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1187,7 +1187,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn put_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_put("/path/to/foo").await;
-    ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1212,7 +1212,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn patch_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_patch("/path/to/foo").await;
-    ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1237,7 +1237,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn delete_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_delete("/path/to/foo").await;
-    ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       let _goose = user.goose_send(request_builder, None).await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1272,12 +1272,7 @@ impl GooseUser {
     ///     /// request builder.
     ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
     ///         let request_builder = user.goose_get("/path/to/foo").await;
-    ///         let goose = match user.goose_send(request_builder, None).await {
-    ///             // Return early if get fails, there's nothing else to do.
-    ///             Err(_) => return Err(()),
-    ///             // Otherwise unwrap the Result.
-    ///             Ok(g) => g,
-    ///         };
+    ///         let goose = user.goose_send(request_builder, None).await?;
     ///
     ///         // Do stuff with goose.request and/or goose.response here.
     ///         Ok(())
@@ -1420,12 +1415,7 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a GET request.
     ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
-    ///         let mut goose = match user.get("/404").await {
-    ///             // Return early if get fails, there's nothing else to do.
-    ///             Err(_) => return Err(()),
-    ///             // Otherwise unwrap the Result.
-    ///             Ok(g) => g,
-    ///         };
+    ///         let mut goose = user.get("/404").await?;
     ///
     ///         if let Ok(response) = &goose.response {
     ///             // We expect a 404 here.
@@ -1434,7 +1424,7 @@ impl GooseUser {
     ///                 return Ok(());
     ///             }
     ///         }
-    ///         Err(())
+    ///         return Err(Box::new(GooseTaskError::new("didn't get 404 response from /404")));
     ///     }
     /// ````
     pub fn set_success(&self, request: &mut GooseRawRequest) {
@@ -1460,38 +1450,30 @@ impl GooseUser {
     ///     let mut task = task!(loadtest_index_page);
     ///
     ///     async fn loadtest_index_page(user: &GooseUser) -> GooseTaskResult {
-    ///         let mut goose = match user.get_named("/", "index").await {
-    ///             // Return early if get fails, there's nothing else to do.
-    ///             Err(_) => return Err(()),
-    ///             // Otherwise unwrap the Result.
-    ///             Ok(g) => g,
-    ///         };
+    ///         let mut goose = user.get_named("/", "index").await?;
     ///
-    ///         match goose.response {
-    ///             Ok(response) => {
-    ///                 // We only need to check pages that returned a success status code.
-    ///                 if response.status().is_success() {
-    ///                     match response.text().await {
-    ///                         Ok(text) => {
-    ///                             // If the expected string doesn't exist, this page load
-    ///                             // was a failure.
-    ///                             if !text.contains("this string must exist") {
-    ///                                 // As this is a named request, pass in the name not the URL
-    ///                                 user.set_failure(&mut goose.request);
-    ///                                 return Err(());
-    ///                             }
-    ///                         }
-    ///                         // Empty page, this is a failure.
-    ///                         Err(_) => {
+    ///         if let Ok(response) = goose.response {
+    ///             // We only need to check pages that returned a success status code.
+    ///             if response.status().is_success() {
+    ///                 match response.text().await {
+    ///                     Ok(text) => {
+    ///                         // If the expected string doesn't exist, this page load
+    ///                         // was a failure.
+    ///                         if !text.contains("this string must exist") {
+    ///                             // As this is a named request, pass in the name not the URL
     ///                             user.set_failure(&mut goose.request);
-    ///                             return Err(());
+    ///                             return Err(Box::new(GooseTaskError::new("string missing")));
     ///                         }
     ///                     }
+    ///                     // Empty page, this is a failure.
+    ///                     Err(_) => {
+    ///                         user.set_failure(&mut goose.request);
+    ///                         return Err(Box::new(GooseTaskError::new("empty page")));
+    ///                     }
     ///                 }
-    ///             },
-    ///             // Invalid response, this is already a failure.
-    ///             Err(_) => return Err(()),
-    ///         }
+    ///             }
+    ///         };
+    ///
     ///         Ok(())
     ///     }
     /// ````
@@ -1525,12 +1507,7 @@ impl GooseUser {
     ///     let mut task = task!(loadtest_index_page);
     ///
     ///     async fn loadtest_index_page(user: &GooseUser) -> GooseTaskResult {
-    ///         let mut goose = match user.get("/").await {
-    ///             // Return early if get fails, there's nothing else to do.
-    ///             Err(_) => return Err(()),
-    ///             // Otherwise unwrap the Result.
-    ///             Ok(g) => g,
-    ///         };
+    ///         let mut goose = user.get("/").await?;
     ///
     ///         match goose.response {
     ///             Ok(response) => {
@@ -1538,11 +1515,12 @@ impl GooseUser {
     ///                 let headers = &response.headers().clone();
     ///                 // We only need to check pages that returned a success status code.
     ///                 if !response.status().is_success() {
+    ///                     let error = "error loading /";
     ///                     match response.text().await {
     ///                         Ok(html) => {
     ///                             // Server returned an error code, log everything.
     ///                             user.log_debug(
-    ///                                 "error loading /",
+    ///                                 error,
     ///                                 Some(goose.request),
     ///                                 Some(headers),
     ///                                 Some(html.clone()),
@@ -1551,14 +1529,14 @@ impl GooseUser {
     ///                         Err(e) => {
     ///                             // No body was returned, log everything else.
     ///                             user.log_debug(
-    ///                                 "error loading /",
+    ///                                 error,
     ///                                 Some(goose.request),
     ///                                 Some(headers),
     ///                                 None,
     ///                             );
     ///                         }
     ///                     }
-    ///                     return Err(());
+    ///                     return Err(Box::new(GooseTaskError::new(error)));
     ///                 }
     ///             },
     ///             // No response from server.
@@ -1569,7 +1547,7 @@ impl GooseUser {
     ///                     None,
     ///                     None,
     ///                 );
-    ///                 return Err(());
+    ///                 return Err(Box::new(e));
     ///             }
     ///         }
     ///         Ok(())
@@ -1709,7 +1687,7 @@ impl GooseUser {
     ///     .execute();
     ///
     ///     async fn task_foo(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/").await;
+    ///       let _goose = user.get("/").await?;
     ///       Ok(())
     ///     }
     ///
@@ -1718,7 +1696,7 @@ impl GooseUser {
     ///       // http://foo.example.com, after this task runs all subsequent
     ///       // requests are made against http://bar.example.com/.
     ///       user.set_base_url("http://bar.example.com/");
-    ///       let _goose = user.get("/").await;
+    ///       let _goose = user.get("/").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1809,7 +1787,7 @@ impl GooseTask {
     ///     task!(my_task_function).set_name("foo");
     ///
     ///     async fn my_task_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/").await;
+    ///       let _goose = user.get("/").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1836,7 +1814,7 @@ impl GooseTask {
     ///     task!(my_on_start_function).set_on_start();
     ///
     ///     async fn my_on_start_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/").await;
+    ///       let _goose = user.get("/").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1863,7 +1841,7 @@ impl GooseTask {
     ///     task!(my_on_stop_function).set_on_stop();
     ///
     ///     async fn my_on_stop_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/").await;
+    ///       let _goose = user.get("/").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1884,7 +1862,7 @@ impl GooseTask {
     ///     task!(task_function).set_weight(3);
     ///
     ///     async fn task_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/").await;
+    ///       let _goose = user.get("/").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1922,17 +1900,17 @@ impl GooseTask {
     ///     let runs_last = task!(third_task_function);
     ///
     ///     async fn first_task_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/1").await;
+    ///       let _goose = user.get("/1").await?;
     ///       Ok(())
     ///     }
     ///
     ///     async fn second_task_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/2").await;
+    ///       let _goose = user.get("/2").await?;
     ///       Ok(())
     ///     }
     ///
     ///     async fn third_task_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/3").await;
+    ///       let _goose = user.get("/3").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -1949,17 +1927,17 @@ impl GooseTask {
     ///     let also_runs_second = task!(second_task_function_b).set_sequence(2).set_weight(2);
     ///
     ///     async fn first_task_function(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/1").await;
+    ///       let _goose = user.get("/1").await?;
     ///       Ok(())
     ///     }
     ///
     ///     async fn second_task_function_a(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/2a").await;
+    ///       let _goose = user.get("/2a").await?;
     ///       Ok(())
     ///     }
     ///
     ///     async fn second_task_function_b(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/2b").await;
+    ///       let _goose = user.get("/2b").await?;
     ///       Ok(())
     ///     }
     /// ```
@@ -2008,12 +1986,12 @@ mod tests {
     fn goose_task_set() {
         // Simplistic test task functions.
         async fn test_function_a(user: &GooseUser) -> GooseTaskResult {
-            let _goose = user.get("/a/").await;
+            let _goose = user.get("/a/").await?;
             Ok(())
         }
 
         async fn test_function_b(user: &GooseUser) -> GooseTaskResult {
-            let _goose = user.get("/b/").await;
+            let _goose = user.get("/b/").await?;
             Ok(())
         }
 
@@ -2107,7 +2085,7 @@ mod tests {
     fn goose_task() {
         // Simplistic test task functions.
         async fn test_function_a(user: &GooseUser) -> GooseTaskResult {
-            let _goose = user.get("/a/");
+            let _goose = user.get("/a/").await?;
             Ok(())
         }
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -72,7 +72,7 @@
 //!     let mut a_task = task!(task_function);
 //!
 //!     /// A very simple task that simply loads the front page.
-//!     async fn task_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn task_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/").await;
 //!       Ok(())
 //!     }
@@ -89,7 +89,7 @@
 //!     let mut a_task = task!(task_function).set_name("a");
 //!
 //!     /// A very simple task that simply loads the front page.
-//!     async fn task_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn task_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/").await;
 //!       Ok(())
 //!     }
@@ -108,13 +108,13 @@
 //!     let mut b_task = task!(b_task_function).set_weight(3);
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn a_task_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/a/").await;
 //!       Ok(())
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn b_task_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/b/").await;
 //!       Ok(())
 //!     }
@@ -138,19 +138,19 @@
 //!     let mut c_task = task!(c_task_function);
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn a_task_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/a/").await;
 //!       Ok(())
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn b_task_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/b/").await;
 //!       Ok(())
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "c" page.
-//!     async fn c_task_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn c_task_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/c/").await;
 //!       Ok(())
 //!     }
@@ -170,7 +170,7 @@
 //!     let mut a_task = task!(a_task_function).set_sequence(1).set_on_start();
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn a_task_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/a/").await;
 //!       Ok(())
 //!     }
@@ -190,7 +190,7 @@
 //!     let mut b_task = task!(b_task_function).set_sequence(2).set_on_stop();
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn b_task_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/b/").await;
 //!       Ok(())
 //!     }
@@ -219,7 +219,7 @@
 //!     let mut task = task!(get_function);
 //!
 //!     /// A very simple task that makes a GET request.
-//!     async  fn get_function(user: &GooseUser) -> Result<(), ()> {
+//!     async  fn get_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.get("/path/to/foo/").await;
 //!       Ok(())
 //!     }
@@ -241,7 +241,7 @@
 //!     let mut task = task!(post_function);
 //!
 //!     /// A very simple task that makes a POST request.
-//!     async fn post_function(user: &GooseUser) -> Result<(), ()> {
+//!     async fn post_function(user: &GooseUser) -> GooseTaskResult {
 //!       let _goose = user.post("/path/to/foo/", "string value to post").await;
 //!       Ok(())
 //!     }
@@ -276,7 +276,7 @@ use std::{future::Future, pin::Pin, time::Instant};
 use tokio::sync::{mpsc, Mutex, RwLock};
 use url::Url;
 
-use crate::GooseConfiguration;
+use crate::{GooseConfiguration, GooseTaskResult};
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
@@ -357,7 +357,7 @@ impl GooseTaskSet {
     ///     example_tasks.register_task(task!(a_task_function));
     ///
     ///     /// A very simple task that simply loads the "a" page.
-    ///     async fn a_task_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn a_task_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/a/").await;
     ///       Ok(())
     ///     }
@@ -871,7 +871,7 @@ impl GooseUser {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/path/to/foo/").await;
     ///       Ok(())
     ///     }
@@ -897,7 +897,7 @@ impl GooseUser {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get_named("/path/to/foo/", "foo").await;
     ///       Ok(())
     ///     }
@@ -931,7 +931,7 @@ impl GooseUser {
     ///     let mut task = task!(post_function);
     ///
     ///     /// A very simple task that makes a POST request.
-    ///     async fn post_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn post_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.post("/path/to/foo/", "BODY BEING POSTED").await;
     ///       Ok(())
     ///     }
@@ -961,7 +961,7 @@ impl GooseUser {
     ///     let mut task = task!(post_function);
     ///
     ///     /// A very simple task that makes a POST request.
-    ///     async fn post_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn post_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.post_named("/path/to/foo/", "foo", "BODY BEING POSTED").await;
     ///       Ok(())
     ///     }
@@ -996,7 +996,7 @@ impl GooseUser {
     ///     let mut task = task!(head_function);
     ///
     ///     /// A very simple task that makes a HEAD request.
-    ///     async fn head_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn head_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.head("/path/to/foo/").await;
     ///       Ok(())
     ///     }
@@ -1022,7 +1022,7 @@ impl GooseUser {
     ///     let mut task = task!(head_function);
     ///
     ///     /// A very simple task that makes a HEAD request.
-    ///     async fn head_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn head_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.head_named("/path/to/foo/", "foo").await;
     ///       Ok(())
     ///     }
@@ -1056,7 +1056,7 @@ impl GooseUser {
     ///     let mut task = task!(delete_function);
     ///
     ///     /// A very simple task that makes a DELETE request.
-    ///     async fn delete_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn delete_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.delete("/path/to/foo/").await;
     ///       Ok(())
     ///     }
@@ -1082,7 +1082,7 @@ impl GooseUser {
     ///     let mut task = task!(delete_function);
     ///
     ///     /// A very simple task that makes a DELETE request.
-    ///     async fn delete_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn delete_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.delete_named("/path/to/foo/", "foo").await;
     ///       Ok(())
     ///     }
@@ -1110,7 +1110,7 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_get("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
     ///       Ok(())
@@ -1135,7 +1135,7 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a POST request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn post_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn post_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_post("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
     ///       Ok(())
@@ -1160,7 +1160,7 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a HEAD request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn head_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn head_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_head("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
     ///       Ok(())
@@ -1185,7 +1185,7 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a PUT request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn put_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn put_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_put("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
     ///       Ok(())
@@ -1210,7 +1210,7 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a PUT request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn patch_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn patch_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_patch("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
     ///       Ok(())
@@ -1235,7 +1235,7 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a DELETE request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn delete_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn delete_function(user: &GooseUser) -> GooseTaskResult {
     ///       let request_builder = user.goose_delete("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
     ///       Ok(())
@@ -1270,7 +1270,7 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
     ///         let request_builder = user.goose_get("/path/to/foo").await;
     ///         let goose = match user.goose_send(request_builder, None).await {
     ///             // Return early if get fails, there's nothing else to do.
@@ -1419,7 +1419,7 @@ impl GooseUser {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A simple task that makes a GET request.
-    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn get_function(user: &GooseUser) -> GooseTaskResult {
     ///         let mut goose = match user.get("/404").await {
     ///             // Return early if get fails, there's nothing else to do.
     ///             Err(_) => return Err(()),
@@ -1459,7 +1459,7 @@ impl GooseUser {
     ///
     ///     let mut task = task!(loadtest_index_page);
     ///
-    ///     async fn loadtest_index_page(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn loadtest_index_page(user: &GooseUser) -> GooseTaskResult {
     ///         let mut goose = match user.get_named("/", "index").await {
     ///             // Return early if get fails, there's nothing else to do.
     ///             Err(_) => return Err(()),
@@ -1524,7 +1524,7 @@ impl GooseUser {
     ///
     ///     let mut task = task!(loadtest_index_page);
     ///
-    ///     async fn loadtest_index_page(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn loadtest_index_page(user: &GooseUser) -> GooseTaskResult {
     ///         let mut goose = match user.get("/").await {
     ///             // Return early if get fails, there's nothing else to do.
     ///             Err(_) => return Err(()),
@@ -1646,7 +1646,7 @@ impl GooseUser {
     ///
     /// task!(setup_custom_client).set_on_start();
     ///
-    /// async fn setup_custom_client(user: &GooseUser) -> Result<(), ()> {
+    /// async fn setup_custom_client(user: &GooseUser) -> GooseTaskResult {
     ///   use reqwest::{Client, header};
     ///
     ///   // Build a custom HeaderMap to include with all requests made by this client.
@@ -1708,12 +1708,12 @@ impl GooseUser {
     ///     )
     ///     .execute();
     ///
-    ///     async fn task_foo(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn task_foo(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/").await;
     ///       Ok(())
     ///     }
     ///
-    ///     async fn task_bar(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn task_bar(user: &GooseUser) -> GooseTaskResult {
     ///       // Before this task runs, all requests are being made against
     ///       // http://foo.example.com, after this task runs all subsequent
     ///       // requests are made against http://bar.example.com/.
@@ -1775,13 +1775,13 @@ pub struct GooseTask {
     pub on_stop: bool,
     /// A required function that is executed each time this task runs.
     pub function:
-        for<'r> fn(&'r GooseUser) -> Pin<Box<dyn Future<Output = Result<(), ()>> + Send + 'r>>,
+        for<'r> fn(&'r GooseUser) -> Pin<Box<dyn Future<Output = GooseTaskResult> + Send + 'r>>,
 }
 impl GooseTask {
     pub fn new(
         function: for<'r> fn(
             &'r GooseUser,
-        ) -> Pin<Box<dyn Future<Output = Result<(), ()>> + Send + 'r>>,
+        ) -> Pin<Box<dyn Future<Output = GooseTaskResult> + Send + 'r>>,
     ) -> Self {
         trace!("new task");
         GooseTask {
@@ -1808,7 +1808,7 @@ impl GooseTask {
     ///
     ///     task!(my_task_function).set_name("foo");
     ///
-    ///     async fn my_task_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn my_task_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/").await;
     ///       Ok(())
     ///     }
@@ -1835,7 +1835,7 @@ impl GooseTask {
     ///
     ///     task!(my_on_start_function).set_on_start();
     ///
-    ///     async fn my_on_start_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn my_on_start_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/").await;
     ///       Ok(())
     ///     }
@@ -1862,7 +1862,7 @@ impl GooseTask {
     ///
     ///     task!(my_on_stop_function).set_on_stop();
     ///
-    ///     async fn my_on_stop_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn my_on_stop_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/").await;
     ///       Ok(())
     ///     }
@@ -1883,7 +1883,7 @@ impl GooseTask {
     ///
     ///     task!(task_function).set_weight(3);
     ///
-    ///     async fn task_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn task_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/").await;
     ///       Ok(())
     ///     }
@@ -1921,17 +1921,17 @@ impl GooseTask {
     ///     let runs_second = task!(second_task_function).set_sequence(5835);
     ///     let runs_last = task!(third_task_function);
     ///
-    ///     async fn first_task_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn first_task_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/1").await;
     ///       Ok(())
     ///     }
     ///
-    ///     async fn second_task_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn second_task_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/2").await;
     ///       Ok(())
     ///     }
     ///
-    ///     async fn third_task_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn third_task_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/3").await;
     ///       Ok(())
     ///     }
@@ -1948,17 +1948,17 @@ impl GooseTask {
     ///     let runs_second = task!(second_task_function_a).set_sequence(2);
     ///     let also_runs_second = task!(second_task_function_b).set_sequence(2).set_weight(2);
     ///
-    ///     async fn first_task_function(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn first_task_function(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/1").await;
     ///       Ok(())
     ///     }
     ///
-    ///     async fn second_task_function_a(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn second_task_function_a(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/2a").await;
     ///       Ok(())
     ///     }
     ///
-    ///     async fn second_task_function_b(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn second_task_function_b(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/2b").await;
     ///       Ok(())
     ///     }
@@ -2007,12 +2007,12 @@ mod tests {
     #[test]
     fn goose_task_set() {
         // Simplistic test task functions.
-        async fn test_function_a(user: &GooseUser) -> Result<(), ()> {
+        async fn test_function_a(user: &GooseUser) -> GooseTaskResult {
             let _goose = user.get("/a/").await;
             Ok(())
         }
 
-        async fn test_function_b(user: &GooseUser) -> Result<(), ()> {
+        async fn test_function_b(user: &GooseUser) -> GooseTaskResult {
             let _goose = user.get("/b/").await;
             Ok(())
         }
@@ -2106,7 +2106,7 @@ mod tests {
     #[test]
     fn goose_task() {
         // Simplistic test task functions.
-        async fn test_function_a(user: &GooseUser) -> Result<(), ()> {
+        async fn test_function_a(user: &GooseUser) -> GooseTaskResult {
             let _goose = user.get("/a/");
             Ok(())
         }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -72,8 +72,9 @@
 //!     let mut a_task = task!(task_function);
 //!
 //!     /// A very simple task that simply loads the front page.
-//!     async fn task_function(user: &GooseUser) {
+//!     async fn task_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/").await;
+//!       Ok(())
 //!     }
 //! ```
 //!
@@ -88,8 +89,9 @@
 //!     let mut a_task = task!(task_function).set_name("a");
 //!
 //!     /// A very simple task that simply loads the front page.
-//!     async fn task_function(user: &GooseUser) {
+//!     async fn task_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/").await;
+//!       Ok(())
 //!     }
 //! ```
 //!
@@ -106,13 +108,15 @@
 //!     let mut b_task = task!(b_task_function).set_weight(3);
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(user: &GooseUser) {
+//!     async fn a_task_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/a/").await;
+//!       Ok(())
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(user: &GooseUser) {
+//!     async fn b_task_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/b/").await;
+//!       Ok(())
 //!     }
 //! ```
 //!
@@ -134,18 +138,21 @@
 //!     let mut c_task = task!(c_task_function);
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(user: &GooseUser) {
+//!     async fn a_task_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/a/").await;
+//!       Ok(())
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(user: &GooseUser) {
+//!     async fn b_task_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/b/").await;
+//!       Ok(())
 //!     }
 //!
 //!     /// Another very simple task that simply loads the "c" page.
-//!     async fn c_task_function(user: &GooseUser) {
+//!     async fn c_task_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/c/").await;
+//!       Ok(())
 //!     }
 //! ```
 //!
@@ -163,8 +170,9 @@
 //!     let mut a_task = task!(a_task_function).set_sequence(1).set_on_start();
 //!
 //!     /// A very simple task that simply loads the "a" page.
-//!     async fn a_task_function(user: &GooseUser) {
+//!     async fn a_task_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/a/").await;
+//!       Ok(())
 //!     }
 //! ```
 //!
@@ -182,8 +190,9 @@
 //!     let mut b_task = task!(b_task_function).set_sequence(2).set_on_stop();
 //!
 //!     /// Another very simple task that simply loads the "b" page.
-//!     async fn b_task_function(user: &GooseUser) {
+//!     async fn b_task_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/b/").await;
+//!       Ok(())
 //!     }
 //! ```
 //!
@@ -210,8 +219,9 @@
 //!     let mut task = task!(get_function);
 //!
 //!     /// A very simple task that makes a GET request.
-//!     async  fn get_function(user: &GooseUser) {
+//!     async  fn get_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.get("/path/to/foo/").await;
+//!       Ok(())
 //!     }
 //! ```
 //!
@@ -231,8 +241,9 @@
 //!     let mut task = task!(post_function);
 //!
 //!     /// A very simple task that makes a POST request.
-//!     async fn post_function(user: &GooseUser) {
+//!     async fn post_function(user: &GooseUser) -> Result<(), ()> {
 //!       let _goose = user.post("/path/to/foo/", "string value to post").await;
+//!       Ok(())
 //!     }
 //! ```
 //!
@@ -346,8 +357,9 @@ impl GooseTaskSet {
     ///     example_tasks.register_task(task!(a_task_function));
     ///
     ///     /// A very simple task that simply loads the "a" page.
-    ///     async fn a_task_function(user: &GooseUser) {
+    ///     async fn a_task_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/a/").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub fn register_task(mut self, mut task: GooseTask) -> Self {
@@ -859,8 +871,9 @@ impl GooseUser {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(user: &GooseUser) {
+    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/path/to/foo/").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn get(&self, path: &str) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
@@ -884,8 +897,9 @@ impl GooseUser {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A very simple task that makes a GET request.
-    ///     async fn get_function(user: &GooseUser) {
+    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get_named("/path/to/foo/", "foo").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn get_named(
@@ -917,8 +931,9 @@ impl GooseUser {
     ///     let mut task = task!(post_function);
     ///
     ///     /// A very simple task that makes a POST request.
-    ///     async fn post_function(user: &GooseUser) {
+    ///     async fn post_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.post("/path/to/foo/", "BODY BEING POSTED").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn post(
@@ -946,8 +961,9 @@ impl GooseUser {
     ///     let mut task = task!(post_function);
     ///
     ///     /// A very simple task that makes a POST request.
-    ///     async fn post_function(user: &GooseUser) {
+    ///     async fn post_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.post_named("/path/to/foo/", "foo", "BODY BEING POSTED").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn post_named(
@@ -980,8 +996,9 @@ impl GooseUser {
     ///     let mut task = task!(head_function);
     ///
     ///     /// A very simple task that makes a HEAD request.
-    ///     async fn head_function(user: &GooseUser) {
+    ///     async fn head_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.head("/path/to/foo/").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn head(&self, path: &str) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
@@ -1005,8 +1022,9 @@ impl GooseUser {
     ///     let mut task = task!(head_function);
     ///
     ///     /// A very simple task that makes a HEAD request.
-    ///     async fn head_function(user: &GooseUser) {
+    ///     async fn head_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.head_named("/path/to/foo/", "foo").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn head_named(
@@ -1038,8 +1056,9 @@ impl GooseUser {
     ///     let mut task = task!(delete_function);
     ///
     ///     /// A very simple task that makes a DELETE request.
-    ///     async fn delete_function(user: &GooseUser) {
+    ///     async fn delete_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.delete("/path/to/foo/").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn delete(&self, path: &str) -> Result<GooseResponse, mpsc::error::SendError<bool>> {
@@ -1063,8 +1082,9 @@ impl GooseUser {
     ///     let mut task = task!(delete_function);
     ///
     ///     /// A very simple task that makes a DELETE request.
-    ///     async fn delete_function(user: &GooseUser) {
+    ///     async fn delete_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.delete_named("/path/to/foo/", "foo").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn delete_named(
@@ -1090,9 +1110,10 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn get_function(user: &GooseUser) {
+    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
     ///       let request_builder = user.goose_get("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn goose_get(&self, path: &str) -> RequestBuilder {
@@ -1114,9 +1135,10 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a POST request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn post_function(user: &GooseUser) {
+    ///     async fn post_function(user: &GooseUser) -> Result<(), ()> {
     ///       let request_builder = user.goose_post("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn goose_post(&self, path: &str) -> RequestBuilder {
@@ -1138,9 +1160,10 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a HEAD request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn head_function(user: &GooseUser) {
+    ///     async fn head_function(user: &GooseUser) -> Result<(), ()> {
     ///       let request_builder = user.goose_head("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn goose_head(&self, path: &str) -> RequestBuilder {
@@ -1162,9 +1185,10 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a PUT request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn put_function(user: &GooseUser) {
+    ///     async fn put_function(user: &GooseUser) -> Result<(), ()> {
     ///       let request_builder = user.goose_put("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn goose_put(&self, path: &str) -> RequestBuilder {
@@ -1186,9 +1210,10 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a PUT request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn patch_function(user: &GooseUser) {
+    ///     async fn patch_function(user: &GooseUser) -> Result<(), ()> {
     ///       let request_builder = user.goose_patch("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn goose_patch(&self, path: &str) -> RequestBuilder {
@@ -1210,9 +1235,10 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a DELETE request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn delete_function(user: &GooseUser) {
+    ///     async fn delete_function(user: &GooseUser) -> Result<(), ()> {
     ///       let request_builder = user.goose_delete("/path/to/foo").await;
     ///       let _goose = user.goose_send(request_builder, None).await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn goose_delete(&self, path: &str) -> RequestBuilder {
@@ -1244,16 +1270,17 @@ impl GooseUser {
     ///
     ///     /// A simple task that makes a GET request, exposing the Reqwest
     ///     /// request builder.
-    ///     async fn get_function(user: &GooseUser) {
+    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
     ///         let request_builder = user.goose_get("/path/to/foo").await;
     ///         let goose = match user.goose_send(request_builder, None).await {
     ///             // Return early if get fails, there's nothing else to do.
-    ///             Err(_) => return,
+    ///             Err(_) => return Err(()),
     ///             // Otherwise unwrap the Result.
     ///             Ok(g) => g,
     ///         };
     ///
     ///         // Do stuff with goose.request and/or goose.response here.
+    ///         Ok(())
     ///     }
     /// ```
     pub async fn goose_send(
@@ -1392,10 +1419,10 @@ impl GooseUser {
     ///     let mut task = task!(get_function);
     ///
     ///     /// A simple task that makes a GET request.
-    ///     async fn get_function(user: &GooseUser) {
+    ///     async fn get_function(user: &GooseUser) -> Result<(), ()> {
     ///         let mut goose = match user.get("/404").await {
     ///             // Return early if get fails, there's nothing else to do.
-    ///             Err(_) => return,
+    ///             Err(_) => return Err(()),
     ///             // Otherwise unwrap the Result.
     ///             Ok(g) => g,
     ///         };
@@ -1404,8 +1431,10 @@ impl GooseUser {
     ///             // We expect a 404 here.
     ///             if response.status() == 404 {
     ///                 user.set_success(&mut goose.request);
+    ///                 return Ok(());
     ///             }
     ///         }
+    ///         Err(())
     ///     }
     /// ````
     pub fn set_success(&self, request: &mut GooseRawRequest) {
@@ -1430,10 +1459,10 @@ impl GooseUser {
     ///
     ///     let mut task = task!(loadtest_index_page);
     ///
-    ///     async fn loadtest_index_page(user: &GooseUser) {
+    ///     async fn loadtest_index_page(user: &GooseUser) -> Result<(), ()> {
     ///         let mut goose = match user.get_named("/", "index").await {
     ///             // Return early if get fails, there's nothing else to do.
-    ///             Err(_) => return,
+    ///             Err(_) => return Err(()),
     ///             // Otherwise unwrap the Result.
     ///             Ok(g) => g,
     ///         };
@@ -1449,16 +1478,21 @@ impl GooseUser {
     ///                             if !text.contains("this string must exist") {
     ///                                 // As this is a named request, pass in the name not the URL
     ///                                 user.set_failure(&mut goose.request);
+    ///                                 return Err(());
     ///                             }
     ///                         }
     ///                         // Empty page, this is a failure.
-    ///                         Err(_) => user.set_failure(&mut goose.request),
+    ///                         Err(_) => {
+    ///                             user.set_failure(&mut goose.request);
+    ///                             return Err(());
+    ///                         }
     ///                     }
     ///                 }
     ///             },
     ///             // Invalid response, this is already a failure.
-    ///             Err(_) => (),
+    ///             Err(_) => return Err(()),
     ///         }
+    ///         Ok(())
     ///     }
     /// ````
     pub fn set_failure(&self, request: &mut GooseRawRequest) {
@@ -1490,10 +1524,10 @@ impl GooseUser {
     ///
     ///     let mut task = task!(loadtest_index_page);
     ///
-    ///     async fn loadtest_index_page(user: &GooseUser) {
+    ///     async fn loadtest_index_page(user: &GooseUser) -> Result<(), ()> {
     ///         let mut goose = match user.get("/").await {
     ///             // Return early if get fails, there's nothing else to do.
-    ///             Err(_) => return,
+    ///             Err(_) => return Err(()),
     ///             // Otherwise unwrap the Result.
     ///             Ok(g) => g,
     ///         };
@@ -1524,6 +1558,7 @@ impl GooseUser {
     ///                             );
     ///                         }
     ///                     }
+    ///                     return Err(());
     ///                 }
     ///             },
     ///             // No response from server.
@@ -1534,8 +1569,10 @@ impl GooseUser {
     ///                     None,
     ///                     None,
     ///                 );
+    ///                 return Err(());
     ///             }
     ///         }
+    ///         Ok(())
     ///     }
     /// ````
     pub fn log_debug(
@@ -1609,7 +1646,7 @@ impl GooseUser {
     ///
     /// task!(setup_custom_client).set_on_start();
     ///
-    /// async fn setup_custom_client(user: &GooseUser) {
+    /// async fn setup_custom_client(user: &GooseUser) -> Result<(), ()> {
     ///   use reqwest::{Client, header};
     ///
     ///   // Build a custom HeaderMap to include with all requests made by this client.
@@ -1622,6 +1659,7 @@ impl GooseUser {
     ///     .cookie_store(true);
     ///
     ///   user.set_client_builder(builder);
+    ///   Ok(())
     /// }
     /// ```
     pub async fn set_client_builder(&self, builder: ClientBuilder) {
@@ -1670,16 +1708,18 @@ impl GooseUser {
     ///     )
     ///     .execute();
     ///
-    ///     async fn task_foo(user: &GooseUser) {
+    ///     async fn task_foo(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/").await;
+    ///       Ok(())
     ///     }
     ///
-    ///     async fn task_bar(user: &GooseUser) {
+    ///     async fn task_bar(user: &GooseUser) -> Result<(), ()> {
     ///       // Before this task runs, all requests are being made against
     ///       // http://foo.example.com, after this task runs all subsequent
     ///       // requests are made against http://bar.example.com/.
     ///       user.set_base_url("http://bar.example.com/");
     ///       let _goose = user.get("/").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub async fn set_base_url(&self, host: &str) {
@@ -1734,11 +1774,14 @@ pub struct GooseTask {
     /// A flag indicating that this task runs when the user stops.
     pub on_stop: bool,
     /// A required function that is executed each time this task runs.
-    pub function: for<'r> fn(&'r GooseUser) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
+    pub function:
+        for<'r> fn(&'r GooseUser) -> Pin<Box<dyn Future<Output = Result<(), ()>> + Send + 'r>>,
 }
 impl GooseTask {
     pub fn new(
-        function: for<'r> fn(&'r GooseUser) -> Pin<Box<dyn Future<Output = ()> + Send + 'r>>,
+        function: for<'r> fn(
+            &'r GooseUser,
+        ) -> Pin<Box<dyn Future<Output = Result<(), ()>> + Send + 'r>>,
     ) -> Self {
         trace!("new task");
         GooseTask {
@@ -1765,8 +1808,9 @@ impl GooseTask {
     ///
     ///     task!(my_task_function).set_name("foo");
     ///
-    ///     async fn my_task_function(user: &GooseUser) {
+    ///     async fn my_task_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub fn set_name(mut self, name: &str) -> Self {
@@ -1791,8 +1835,9 @@ impl GooseTask {
     ///
     ///     task!(my_on_start_function).set_on_start();
     ///
-    ///     async fn my_on_start_function(user: &GooseUser) {
+    ///     async fn my_on_start_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub fn set_on_start(mut self) -> Self {
@@ -1817,8 +1862,9 @@ impl GooseTask {
     ///
     ///     task!(my_on_stop_function).set_on_stop();
     ///
-    ///     async fn my_on_stop_function(user: &GooseUser) {
+    ///     async fn my_on_stop_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub fn set_on_stop(mut self) -> Self {
@@ -1837,8 +1883,9 @@ impl GooseTask {
     ///
     ///     task!(task_function).set_weight(3);
     ///
-    ///     async fn task_function(user: &GooseUser) {
+    ///     async fn task_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub fn set_weight(mut self, weight: usize) -> Self {
@@ -1874,16 +1921,19 @@ impl GooseTask {
     ///     let runs_second = task!(second_task_function).set_sequence(5835);
     ///     let runs_last = task!(third_task_function);
     ///
-    ///     async fn first_task_function(user: &GooseUser) {
+    ///     async fn first_task_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/1").await;
+    ///       Ok(())
     ///     }
     ///
-    ///     async fn second_task_function(user: &GooseUser) {
+    ///     async fn second_task_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/2").await;
+    ///       Ok(())
     ///     }
     ///
-    ///     async fn third_task_function(user: &GooseUser) {
+    ///     async fn third_task_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/3").await;
+    ///       Ok(())
     ///     }
     /// ```
     ///
@@ -1898,16 +1948,19 @@ impl GooseTask {
     ///     let runs_second = task!(second_task_function_a).set_sequence(2);
     ///     let also_runs_second = task!(second_task_function_b).set_sequence(2).set_weight(2);
     ///
-    ///     async fn first_task_function(user: &GooseUser) {
+    ///     async fn first_task_function(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/1").await;
+    ///       Ok(())
     ///     }
     ///
-    ///     async fn second_task_function_a(user: &GooseUser) {
+    ///     async fn second_task_function_a(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/2a").await;
+    ///       Ok(())
     ///     }
     ///
-    ///     async fn second_task_function_b(user: &GooseUser) {
+    ///     async fn second_task_function_b(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/2b").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub fn set_sequence(mut self, sequence: usize) -> Self {
@@ -1954,12 +2007,14 @@ mod tests {
     #[test]
     fn goose_task_set() {
         // Simplistic test task functions.
-        async fn test_function_a(user: &GooseUser) {
+        async fn test_function_a(user: &GooseUser) -> Result<(), ()> {
             let _goose = user.get("/a/").await;
+            Ok(())
         }
 
-        async fn test_function_b(user: &GooseUser) {
+        async fn test_function_b(user: &GooseUser) -> Result<(), ()> {
             let _goose = user.get("/b/").await;
+            Ok(())
         }
 
         let mut task_set = taskset!("foo");
@@ -2051,8 +2106,9 @@ mod tests {
     #[test]
     fn goose_task() {
         // Simplistic test task functions.
-        async fn test_function_a(user: &GooseUser) {
+        async fn test_function_a(user: &GooseUser) -> Result<(), ()> {
             let _goose = user.get("/a/");
+            Ok(())
         }
 
         // Initialize task set.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -759,23 +759,15 @@ impl GooseDebug {
         header: Option<&header::HeaderMap>,
         body: Option<&str>,
     ) -> Self {
-        let cloned_request = match request {
-            Some(r) => Some(r.clone()),
-            None => None,
-        };
-        let header_string = match header {
-            Some(h) => Some(format!("{:?}", h)),
-            None => None,
-        };
-        let body_string = match body {
-            Some(b) => Some(b.to_string()),
-            None => None,
-        };
         GooseDebug {
+            // Convert tag from &str to string.
             tag: tag.to_string(),
-            request: cloned_request,
-            header: header_string,
-            body: body_string,
+            // If request is defined, clone it.
+            request: request.map(|r| r.clone()),
+            // If header is defined, convert it to a string.
+            header: header.map(|h| format!("{:?}", h)),
+            // If header is defined, convert from &str to string.
+            body: body.map(|b| b.to_string()),
         }
     }
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1498,6 +1498,9 @@ impl GooseUser {
     /// parameters, `header` and `body`, are optional and used to provide more detail in
     /// logs.
     ///
+    /// This also calls
+    /// [`log_debug`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.log_debug).
+    ///
     /// # Example
     /// ```rust
     ///     use goose::prelude::*;
@@ -1556,6 +1559,10 @@ impl GooseUser {
     /// must include a tag, which is an arbitrary string identifying the debug message.
     /// It may also optionally include references to the GooseRawRequest made, the headers
     /// returned by the server, and the text returned by the server,
+    ///
+    /// Calls to
+    /// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_failure)
+    // automatically invoke `log_debug`.
     ///
     /// To enable the debug log, a load test must be run with the `--debug-log-file=foo`
     /// option set, where `foo` is either a relative or an absolute path of the log file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,7 @@ use serde_json::json;
 use simplelog::*;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashMap};
-use std::error::Error;
+use std::f32;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::{
@@ -322,7 +322,6 @@ use std::sync::{
     Arc,
 };
 use std::time;
-use std::{f32, fmt};
 use structopt::StructOpt;
 use tokio::fs::File;
 use tokio::io::BufWriter;
@@ -347,34 +346,6 @@ lazy_static! {
 
 /// Internal representation of a weighted task list.
 type WeightedGooseTasks = Vec<Vec<usize>>;
-
-/// Goose tasks can return an error.
-pub type GooseTaskResult = Result<(), Box<dyn Error>>;
-
-#[derive(Debug)]
-pub struct GooseTaskError {
-    details: String,
-}
-
-impl GooseTaskError {
-    pub fn new(msg: &str) -> GooseTaskError {
-        GooseTaskError {
-            details: msg.to_string(),
-        }
-    }
-}
-
-impl fmt::Display for GooseTaskError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.details)
-    }
-}
-
-impl Error for GooseTaskError {
-    fn description(&self) -> &str {
-        &self.details
-    }
-}
 
 /// Worker ID to aid in tracing logs when running a Gaggle.
 pub fn get_worker_id() -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,9 @@
 //! ```rust
 //! use goose::prelude::*;
 //!
-//! async fn loadtest_foo(user: &GooseUser) {
+//! async fn loadtest_foo(user: &GooseUser) -> Result<(), ()> {
 //!   let _goose = user.get("/path/to/foo").await;
+//!   Ok(())
 //! }   
 //! ```
 //!
@@ -68,9 +69,10 @@
 //!
 //! use goose::prelude::*;
 //!
-//! async fn loadtest_bar(user: &GooseUser) {
+//! async fn loadtest_bar(user: &GooseUser) -> Result<(), ()> {
 //!   let request_builder = user.goose_get("/path/to/bar").await;
 //!   let _goose = user.goose_send(request_builder.timeout(time::Duration::from_secs(3)), None).await;
+//!   Ok(())
 //! }   
 //! ```
 //!
@@ -99,12 +101,14 @@
 //!     //.set_host("http://dev.local/")
 //!     .execute();
 //!
-//! async fn loadtest_foo(user: &GooseUser) {
+//! async fn loadtest_foo(user: &GooseUser) -> Result<(), ()> {
 //!   let _goose = user.get("/path/to/foo").await;
+//!   Ok(())
 //! }   
 //!
-//! async fn loadtest_bar(user: &GooseUser) {
+//! async fn loadtest_bar(user: &GooseUser) -> Result<(), ()> {
 //!   let _goose = user.get("/path/to/bar").await;
+//!   Ok(())
 //! }   
 //! ```
 //!
@@ -610,12 +614,14 @@ impl GooseAttack {
     ///             .register_task(task!(other_task))
     ///         );
     ///
-    ///     async fn example_task(user: &GooseUser) {
+    ///     async fn example_task(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/foo").await;
+    ///       Ok(())
     ///     }
     ///
-    ///     async fn other_task(user: &GooseUser) {
+    ///     async fn other_task(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/bar").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub fn register_taskset(mut self, mut taskset: GooseTaskSet) -> Self {
@@ -638,8 +644,9 @@ impl GooseAttack {
     ///     GooseAttack::initialize()
     ///         .test_start(task!(setup));
     ///
-    ///     async fn setup(user: &GooseUser) {
+    ///     async fn setup(user: &GooseUser) -> Result<(), ()> {
     ///         // do stuff to set up load test ...
+    ///         Ok(())
     ///     }
     /// ```
     pub fn test_start(mut self, task: GooseTask) -> Self {
@@ -661,8 +668,9 @@ impl GooseAttack {
     ///     GooseAttack::initialize()
     ///         .test_stop(task!(teardown));
     ///
-    ///     async fn teardown(user: &GooseUser) {
+    ///     async fn teardown(user: &GooseUser) -> Result<(), ()> {
     ///         // do stuff to tear down the load test ...
+    ///         Ok(())
     ///     }
     /// ```
     pub fn test_stop(mut self, task: GooseTask) -> Self {
@@ -769,12 +777,14 @@ impl GooseAttack {
     ///         )
     ///         .execute();
     ///
-    ///     async fn example_task(user: &GooseUser) {
+    ///     async fn example_task(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/foo").await;
+    ///       Ok(())
     ///     }
     ///
-    ///     async fn another_example_task(user: &GooseUser) {
+    ///     async fn another_example_task(user: &GooseUser) -> Result<(), ()> {
     ///       let _goose = user.get("/bar").await;
+    ///       Ok(())
     ///     }
     /// ```
     pub fn execute(mut self) {
@@ -1162,7 +1172,7 @@ impl GooseAttack {
                         goose::get_base_url(self.get_configuration_host(), None, self.host.clone());
                     let user = GooseUser::single(base_url, &self.configuration);
                     let function = t.function;
-                    function(&user).await;
+                    let _ = function(&user).await;
                 }
                 // No test_start_task defined, nothing to do.
                 None => (),
@@ -1490,7 +1500,7 @@ impl GooseAttack {
                     // Create a one-time-use user to run the test_stop_task.
                     let user = GooseUser::single(base_url, &self.configuration);
                     let function = t.function;
-                    function(&user).await;
+                    let _ = function(&user).await;
                 }
                 // No test_stop_task defined, nothing to do.
                 None => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! ```rust
 //! use goose::prelude::*;
 //!
-//! async fn loadtest_foo(user: &GooseUser) -> Result<(), ()> {
+//! async fn loadtest_foo(user: &GooseUser) -> GooseTaskResult {
 //!   let _goose = user.get("/path/to/foo").await;
 //!   Ok(())
 //! }   
@@ -69,7 +69,7 @@
 //!
 //! use goose::prelude::*;
 //!
-//! async fn loadtest_bar(user: &GooseUser) -> Result<(), ()> {
+//! async fn loadtest_bar(user: &GooseUser) -> GooseTaskResult {
 //!   let request_builder = user.goose_get("/path/to/bar").await;
 //!   let _goose = user.goose_send(request_builder.timeout(time::Duration::from_secs(3)), None).await;
 //!   Ok(())
@@ -101,12 +101,12 @@
 //!     //.set_host("http://dev.local/")
 //!     .execute();
 //!
-//! async fn loadtest_foo(user: &GooseUser) -> Result<(), ()> {
+//! async fn loadtest_foo(user: &GooseUser) -> GooseTaskResult {
 //!   let _goose = user.get("/path/to/foo").await;
 //!   Ok(())
 //! }   
 //!
-//! async fn loadtest_bar(user: &GooseUser) -> Result<(), ()> {
+//! async fn loadtest_bar(user: &GooseUser) -> GooseTaskResult {
 //!   let _goose = user.get("/path/to/bar").await;
 //!   Ok(())
 //! }   
@@ -346,6 +346,9 @@ lazy_static! {
 
 /// Internal representation of a weighted task list.
 type WeightedGooseTasks = Vec<Vec<usize>>;
+
+/// Goose tasks can return an error.
+pub type GooseTaskResult = Result<(), ()>;
 
 /// Worker ID to aid in tracing logs when running a Gaggle.
 pub fn get_worker_id() -> usize {
@@ -614,12 +617,12 @@ impl GooseAttack {
     ///             .register_task(task!(other_task))
     ///         );
     ///
-    ///     async fn example_task(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn example_task(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/foo").await;
     ///       Ok(())
     ///     }
     ///
-    ///     async fn other_task(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn other_task(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/bar").await;
     ///       Ok(())
     ///     }
@@ -644,7 +647,7 @@ impl GooseAttack {
     ///     GooseAttack::initialize()
     ///         .test_start(task!(setup));
     ///
-    ///     async fn setup(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn setup(user: &GooseUser) -> GooseTaskResult {
     ///         // do stuff to set up load test ...
     ///         Ok(())
     ///     }
@@ -668,7 +671,7 @@ impl GooseAttack {
     ///     GooseAttack::initialize()
     ///         .test_stop(task!(teardown));
     ///
-    ///     async fn teardown(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn teardown(user: &GooseUser) -> GooseTaskResult {
     ///         // do stuff to tear down the load test ...
     ///         Ok(())
     ///     }
@@ -777,12 +780,12 @@ impl GooseAttack {
     ///         )
     ///         .execute();
     ///
-    ///     async fn example_task(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn example_task(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/foo").await;
     ///       Ok(())
     ///     }
     ///
-    ///     async fn another_example_task(user: &GooseUser) -> Result<(), ()> {
+    ///     async fn another_example_task(user: &GooseUser) -> GooseTaskResult {
     ///       let _goose = user.get("/bar").await;
     ///       Ok(())
     ///     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,2 +1,2 @@
 pub use crate::goose::{GooseMethod, GooseTask, GooseTaskSet, GooseUser};
-pub use crate::{task, taskset, GooseAttack};
+pub use crate::{task, taskset, GooseAttack, GooseTaskResult};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,2 +1,4 @@
-pub use crate::goose::{GooseMethod, GooseTask, GooseTaskSet, GooseUser};
-pub use crate::{task, taskset, GooseAttack, GooseTaskError, GooseTaskResult};
+pub use crate::goose::{
+    GooseMethod, GooseTask, GooseTaskError, GooseTaskResult, GooseTaskSet, GooseUser,
+};
+pub use crate::{task, taskset, GooseAttack};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,2 +1,2 @@
 pub use crate::goose::{GooseMethod, GooseTask, GooseTaskSet, GooseUser};
-pub use crate::{task, taskset, GooseAttack, GooseTaskResult};
+pub use crate::{task, taskset, GooseAttack, GooseTaskError, GooseTaskResult};

--- a/src/user.rs
+++ b/src/user.rs
@@ -47,7 +47,7 @@ pub async fn user_main(
                     thread_user.task_request_name = Some(thread_task_name.to_string());
                 }
                 // Invoke the task function.
-                function(&thread_user).await;
+                let _ = function(&thread_user).await;
             }
         }
     }
@@ -98,7 +98,7 @@ pub async fn user_main(
             thread_user.task_request_name = Some(thread_task_name.to_string());
         }
         // Invoke the task function.
-        function(&thread_user).await;
+        let _ = function(&thread_user).await;
 
         // Prepare to sleep for a random value from min_wait to max_wait.
         let wait_time = if thread_user.max_wait > 0 {
@@ -167,7 +167,7 @@ pub async fn user_main(
                     thread_user.task_request_name = Some(thread_task_name.to_string());
                 }
                 // Invoke the task function.
-                function(&thread_user).await;
+                let _ = function(&thread_user).await;
             }
         }
     }

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -10,12 +10,12 @@ const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
 pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get(INDEX_PATH).await;
+    let _goose = user.get(INDEX_PATH).await?;
     Ok(())
 }
 
 pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get(ABOUT_PATH).await;
+    let _goose = user.get(ABOUT_PATH).await?;
     Ok(())
 }
 

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -9,12 +9,14 @@ use goose::prelude::*;
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
-pub async fn get_index(user: &GooseUser) {
+pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(INDEX_PATH).await;
+    Ok(())
 }
 
-pub async fn get_about(user: &GooseUser) {
+pub async fn get_about(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(ABOUT_PATH).await;
+    Ok(())
 }
 
 /// Test test_start alone.

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -9,12 +9,12 @@ use goose::prelude::*;
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
-pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await;
     Ok(())
 }
 
-pub async fn get_about(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(ABOUT_PATH).await;
     Ok(())
 }

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -11,14 +11,15 @@ const ERROR_PATH: &str = "/error";
 const STATS_LOG_FILE: &str = "stats.log";
 const DEBUG_LOG_FILE: &str = "debug.log";
 
-pub async fn get_index(user: &GooseUser) {
+pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(INDEX_PATH).await;
+    Ok(())
 }
 
-pub async fn get_error(user: &GooseUser) {
+pub async fn get_error(user: &GooseUser) -> Result<(), ()> {
     let goose = match user.get(ERROR_PATH).await {
         // Return early if get fails, there's nothing else to do.
-        Err(_) => return,
+        Err(_) => return Err(()),
         // Otherwise unwrap the Result.
         Ok(g) => g,
     };
@@ -34,9 +35,11 @@ pub async fn get_error(user: &GooseUser) {
                     Some(headers),
                     None,
                 );
+                return Err(());
             }
         }
     }
+    Ok(())
 }
 
 fn cleanup_files() {

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -11,12 +11,12 @@ const ERROR_PATH: &str = "/error";
 const STATS_LOG_FILE: &str = "stats.log";
 const DEBUG_LOG_FILE: &str = "debug.log";
 
-pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await;
     Ok(())
 }
 
-pub async fn get_error(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_error(user: &GooseUser) -> GooseTaskResult {
     let goose = match user.get(ERROR_PATH).await {
         // Return early if get fails, there's nothing else to do.
         Err(_) => return Err(()),

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -17,17 +17,17 @@ pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
 }
 
 pub async fn get_error(user: &GooseUser) -> GooseTaskResult {
-    let goose = user.get(ERROR_PATH).await?;
+    let mut goose = user.get(ERROR_PATH).await?;
 
     if let Ok(r) = goose.response {
         let headers = &r.headers().clone();
-        match r.text().await {
-            Ok(_) => {}
-            Err(_) => {
-                let error = "there was an error";
-                user.log_debug(error, Some(goose.request), Some(headers), None);
-                return Err(Box::new(GooseTaskError::new(error)));
-            }
+        if r.text().await.is_err() {
+            return user.set_failure(
+                "there was an error",
+                &mut goose.request,
+                Some(headers),
+                None,
+            );
         }
     }
     Ok(())

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -8,14 +8,14 @@ use goose::prelude::*;
 const LOGIN_PATH: &str = "/login";
 const LOGOUT_PATH: &str = "/logout";
 
-pub async fn login(user: &GooseUser) -> Result<(), ()> {
+pub async fn login(user: &GooseUser) -> GooseTaskResult {
     let request_builder = user.goose_post(LOGIN_PATH).await;
     let params = [("username", "me"), ("password", "s3crET!")];
     let _goose = user.goose_send(request_builder.form(&params), None).await;
     Ok(())
 }
 
-pub async fn logout(user: &GooseUser) -> Result<(), ()> {
+pub async fn logout(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(LOGOUT_PATH).await;
     Ok(())
 }

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -8,14 +8,16 @@ use goose::prelude::*;
 const LOGIN_PATH: &str = "/login";
 const LOGOUT_PATH: &str = "/logout";
 
-pub async fn login(user: &GooseUser) {
+pub async fn login(user: &GooseUser) -> Result<(), ()> {
     let request_builder = user.goose_post(LOGIN_PATH).await;
     let params = [("username", "me"), ("password", "s3crET!")];
     let _goose = user.goose_send(request_builder.form(&params), None).await;
+    Ok(())
 }
 
-pub async fn logout(user: &GooseUser) {
+pub async fn logout(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(LOGOUT_PATH).await;
+    Ok(())
 }
 
 #[test]

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -11,12 +11,12 @@ const LOGOUT_PATH: &str = "/logout";
 pub async fn login(user: &GooseUser) -> GooseTaskResult {
     let request_builder = user.goose_post(LOGIN_PATH).await;
     let params = [("username", "me"), ("password", "s3crET!")];
-    let _goose = user.goose_send(request_builder.form(&params), None).await;
+    let _goose = user.goose_send(request_builder.form(&params), None).await?;
     Ok(())
 }
 
 pub async fn logout(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get(LOGOUT_PATH).await;
+    let _goose = user.get(LOGOUT_PATH).await?;
     Ok(())
 }
 

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -8,12 +8,12 @@ use goose::prelude::*;
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
-pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await;
     Ok(())
 }
 
-pub async fn get_about(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(ABOUT_PATH).await;
     Ok(())
 }

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -9,12 +9,12 @@ const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
 pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get(INDEX_PATH).await;
+    let _goose = user.get(INDEX_PATH).await?;
     Ok(())
 }
 
 pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get(ABOUT_PATH).await;
+    let _goose = user.get(ABOUT_PATH).await?;
     Ok(())
 }
 

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -8,12 +8,14 @@ use goose::prelude::*;
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
-pub async fn get_index(user: &GooseUser) {
+pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(INDEX_PATH).await;
+    Ok(())
 }
 
-pub async fn get_about(user: &GooseUser) {
+pub async fn get_about(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(ABOUT_PATH).await;
+    Ok(())
 }
 
 #[test]

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -55,7 +55,7 @@ pub async fn get_redirect(user: &GooseUser) -> GooseTaskResult {
 
 // Task function, load REDRECT_PATH and follow redirect to new domain.
 pub async fn get_domain_redirect(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get(REDIRECT_PATH).await;
+    let _goose = user.get(REDIRECT_PATH).await?;
     Ok(())
 }
 

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -12,20 +12,22 @@ const REDIRECT3_PATH: &str = "/redirect3";
 const ABOUT_PATH: &str = "/about.php";
 
 // Task function, load INDEX_PATH.
-pub async fn get_index(user: &GooseUser) {
+pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(INDEX_PATH).await;
+    Ok(())
 }
 
 // Task function, load ABOUT PATH
-pub async fn get_about(user: &GooseUser) {
+pub async fn get_about(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(ABOUT_PATH).await;
+    Ok(())
 }
 
 // Task function, load REDRECT_PATH and follow redirects to ABOUT_PATH.
-pub async fn get_redirect(user: &GooseUser) {
+pub async fn get_redirect(user: &GooseUser) -> Result<(), ()> {
     let mut goose = match user.get(REDIRECT_PATH).await {
         // Return early if get fails, there's nothing else to do.
-        Err(_) => return,
+        Err(_) => return Err(()),
         // Otherwise unwrap the Result.
         Ok(g) => g,
     };
@@ -37,19 +39,23 @@ pub async fn get_redirect(user: &GooseUser) {
                 if !html.contains("about page") {
                     eprintln!("about page body wrong");
                     user.set_failure(&mut goose.request);
+                    return Err(());
                 }
             }
             Err(e) => {
                 eprintln!("unexpected error parsing about page: {}", e);
                 user.set_failure(&mut goose.request);
+                return Err(());
             }
         }
     }
+    Ok(())
 }
 
 // Task function, load REDRECT_PATH and follow redirect to new domain.
-pub async fn get_domain_redirect(user: &GooseUser) {
+pub async fn get_domain_redirect(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(REDIRECT_PATH).await;
+    Ok(())
 }
 
 #[test]

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -12,19 +12,19 @@ const REDIRECT3_PATH: &str = "/redirect3";
 const ABOUT_PATH: &str = "/about.php";
 
 // Task function, load INDEX_PATH.
-pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await;
     Ok(())
 }
 
 // Task function, load ABOUT PATH
-pub async fn get_about(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(ABOUT_PATH).await;
     Ok(())
 }
 
 // Task function, load REDRECT_PATH and follow redirects to ABOUT_PATH.
-pub async fn get_redirect(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_redirect(user: &GooseUser) -> GooseTaskResult {
     let mut goose = match user.get(REDIRECT_PATH).await {
         // Return early if get fails, there's nothing else to do.
         Err(_) => return Err(()),
@@ -53,7 +53,7 @@ pub async fn get_redirect(user: &GooseUser) -> Result<(), ()> {
 }
 
 // Task function, load REDRECT_PATH and follow redirect to new domain.
-pub async fn get_domain_redirect(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_domain_redirect(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(REDIRECT_PATH).await;
     Ok(())
 }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -32,17 +32,21 @@ pub async fn get_redirect(user: &GooseUser) -> GooseTaskResult {
             Ok(html) => {
                 // Confirm that we followed redirects and loaded the about page.
                 if !html.contains("about page") {
-                    let error = "about page body wrong";
-                    eprintln!("{}", error);
-                    user.set_failure(&mut goose.request);
-                    return Err(Box::new(GooseTaskError::new(error)));
+                    return user.set_failure(
+                        "about page body wrong",
+                        &mut goose.request,
+                        None,
+                        None,
+                    );
                 }
             }
             Err(e) => {
-                let error = format!("unexpected error parsing about page: {}", e);
-                eprintln!("{}", &error);
-                user.set_failure(&mut goose.request);
-                return Err(Box::new(GooseTaskError::new(&error)));
+                return user.set_failure(
+                    format!("unexpected error parsing about page: {}", e).as_str(),
+                    &mut goose.request,
+                    None,
+                    None,
+                );
             }
         }
     }

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -9,19 +9,19 @@ const INDEX_PATH: &str = "/";
 const SETUP_PATH: &str = "/setup";
 const TEARDOWN_PATH: &str = "/teardown";
 
-pub async fn setup(user: &GooseUser) -> Result<(), ()> {
+pub async fn setup(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.post(SETUP_PATH, "setting up load test").await;
     Ok(())
 }
 
-pub async fn teardown(user: &GooseUser) -> Result<(), ()> {
+pub async fn teardown(user: &GooseUser) -> GooseTaskResult {
     let _goose = user
         .post(TEARDOWN_PATH, "cleaning up after load test")
         .await;
     Ok(())
 }
 
-pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await;
     Ok(())
 }

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -10,19 +10,19 @@ const SETUP_PATH: &str = "/setup";
 const TEARDOWN_PATH: &str = "/teardown";
 
 pub async fn setup(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.post(SETUP_PATH, "setting up load test").await;
+    let _goose = user.post(SETUP_PATH, "setting up load test").await?;
     Ok(())
 }
 
 pub async fn teardown(user: &GooseUser) -> GooseTaskResult {
     let _goose = user
         .post(TEARDOWN_PATH, "cleaning up after load test")
-        .await;
+        .await?;
     Ok(())
 }
 
 pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get(INDEX_PATH).await;
+    let _goose = user.get(INDEX_PATH).await?;
     Ok(())
 }
 

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -9,18 +9,21 @@ const INDEX_PATH: &str = "/";
 const SETUP_PATH: &str = "/setup";
 const TEARDOWN_PATH: &str = "/teardown";
 
-pub async fn setup(user: &GooseUser) {
+pub async fn setup(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.post(SETUP_PATH, "setting up load test").await;
+    Ok(())
 }
 
-pub async fn teardown(user: &GooseUser) {
+pub async fn teardown(user: &GooseUser) -> Result<(), ()> {
     let _goose = user
         .post(TEARDOWN_PATH, "cleaning up after load test")
         .await;
+    Ok(())
 }
 
-pub async fn get_index(user: &GooseUser) {
+pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(INDEX_PATH).await;
+    Ok(())
 }
 
 /// Test test_start alone.

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -9,12 +9,12 @@ const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 const STATS_LOG_FILE: &str = "throttle-stats.log";
 
-pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await;
     Ok(())
 }
 
-pub async fn get_about(user: &GooseUser) -> Result<(), ()> {
+pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(ABOUT_PATH).await;
     Ok(())
 }

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -9,12 +9,14 @@ const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 const STATS_LOG_FILE: &str = "throttle-stats.log";
 
-pub async fn get_index(user: &GooseUser) {
+pub async fn get_index(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(INDEX_PATH).await;
+    Ok(())
 }
 
-pub async fn get_about(user: &GooseUser) {
+pub async fn get_about(user: &GooseUser) -> Result<(), ()> {
     let _goose = user.get(ABOUT_PATH).await;
+    Ok(())
 }
 
 #[test]

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -10,12 +10,12 @@ const ABOUT_PATH: &str = "/about.html";
 const STATS_LOG_FILE: &str = "throttle-stats.log";
 
 pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get(INDEX_PATH).await;
+    let _goose = user.get(INDEX_PATH).await?;
     Ok(())
 }
 
 pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
-    let _goose = user.get(ABOUT_PATH).await;
+    let _goose = user.get(ABOUT_PATH).await?;
     Ok(())
 }
 


### PR DESCRIPTION
Tasks must be converted to return `GooseTaskResult`.

This allows the use of `?` as it supports returning a GooseTaskError:

```rust
pub type GooseTaskResult = Result<(), GooseTaskError>;
```
Currently we define 3 errors:

```rust
/// Definition of all errors Goose Tasks can return.
#[derive(Debug)]
pub enum GooseTaskError {
    /// Contains any possible Reqwest library error.
    Reqwest(reqwest::Error),
    /// The request failed.
    RequestFailed,
    /// The request was canceled (this happens when the throttle is enabled and
    /// the load test finished).
    RequestCanceled,
}
```