### PR TITLE
remove `exit(1)`, instead return error on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
  - properly support setting host when registering task set 
  - rename `response` wrapper to `goose`, so we end up with `goose.request` and `goose.response`
  - add `--throttle-requests` to optionally limit the maximum requests per second (api change)
+ - introduce `GooseError` and `GooseTaskError`
  - change task function signature, tasks must return a `GooseTaskResult`
- - introduce `GooseTaskError`
- - change `GooseAttack.execute()` to return `Result<GooseAttack, GooseError>`
- - introduce `GooseAttack.display_stats()` which consumes the execute Result and displays statistics
+ - change `GooseAttack` method signatures where an error is possible
+ - where possible, passs error up the stack instead of calling `exit(1)`
+ - introduce `GooseAttack.display()` which consumes the load test state and displays statistics
 
 ## 0.8.2 July 2, 2020
  - `client.log_debug()` will write debug logs to file when specified with `--debug-log-file=`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
  - add `--throttle-requests` to optionally limit the maximum requests per second (api change)
  - change task function signature, tasks must return a `GooseTaskResult`
  - introduce `GooseTaskError`
+ - change `GooseAttack.execute()` to return `Result<GooseAttack, GooseError>`
+ - introduce `GooseAttack.display_stats()` which consumes the execute Result and displays statistics
 
 ## 0.8.2 July 2, 2020
  - `client.log_debug()` will write debug logs to file when specified with `--debug-log-file=`

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ will return a `GooseError` on failure. This is helpful as several of `GooseAttac
 methods can fail, returning an error. In our example, `initialize()` and `execute()`
 each may fail. The `?` that follows the method's name tells our program to exit and
 return an error on failure, otherwise continue on. The `display()` method consumes
-the everything returned by `GooseAttack` and prints a summary if statistics are
-enabled. The final line, `Ok(())` returns the empty result expected on success.
+everything returned by `GooseAttack` and prints a summary if statistics are enabled.
+The final line, `Ok(())` returns the empty result expected on success.
 
 And that's it, you've created your first load test! Let's run it and see what
 happens.

--- a/README.md
+++ b/README.md
@@ -80,19 +80,30 @@ async fn loadtest_index(user: &GooseUser) -> GooseTaskResult {
 }
 ```
 
-Finally, edit the `main()` function, setting a return type so we can use `?` to unwrap
-results, and replacing the hello world text as follows:
+Finally, edit the `main()` function, setting a return type and replacing the hello
+world text as follows:
 
 ```rust
 fn main() -> Result<(), GooseError> {
-    GooseAttack::initialize()
+    GooseAttack::initialize()?
         .register_taskset(taskset!("LoadtestTasks")
             .register_task(task!(loadtest_index))
         )
         .execute()?
-        .display_stats();
+        .display();
+    
+    Ok(())
 }
 ```
+
+If you're new to Rust, `main()`'s return type of `Result<(), GooseError>` may look
+strange. It essentially says that `main` will return nothing (`()`) on success, and
+will return a `GooseError` on failure. This is helpful as several of `GooseAttack`'s
+methods can fail, returning an error. In our example, `initialize()` and `execute()`
+each may fail. The `?` that follows the method's name tells our program to exit and
+return an error on failure, otherwise continue on. The `display()` method consumes
+the everything returned by `GooseAttack` and prints a summary if statistics are
+enabled. The final line, `Ok(())` returns the empty result expected on success.
 
 And that's it, you've created your first load test! Let's run it and see what
 happens.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ fn main() {
         .register_taskset(taskset!("LoadtestTasks")
             .register_task(task!(loadtest_index))
         )
-        .execute();
+        .execute()?
+        .display_stats();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ async fn loadtest_index(user: &GooseUser) -> GooseTaskResult {
 }
 ```
 
-Finally, edit the `main()` function, removing the hello world text and replacing
-it as follows:
+Finally, edit the `main()` function, setting a return type so we can use `?` to unwrap
+results, and replacing the hello world text as follows:
 
 ```rust
-fn main() {
+fn main() -> Result<(), GooseError> {
     GooseAttack::initialize()
         .register_taskset(taskset!("LoadtestTasks")
             .register_task(task!(loadtest_index))

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -78,7 +78,7 @@ fn main() -> Result<(), GooseError> {
                 ),
         )
         .execute()?
-        .display_stats();
+        .display();
 
     Ok(())
 }
@@ -128,6 +128,7 @@ async fn drupal_loadtest_front_page(user: &GooseUser) -> GooseTaskResult {
             );
         }
     }
+
     Ok(())
 }
 
@@ -135,6 +136,7 @@ async fn drupal_loadtest_front_page(user: &GooseUser) -> GooseTaskResult {
 async fn drupal_loadtest_node_page(user: &GooseUser) -> GooseTaskResult {
     let nid = rand::thread_rng().gen_range(1, 10_000);
     let _goose = user.get(format!("/node/{}", &nid).as_str()).await?;
+
     Ok(())
 }
 
@@ -142,6 +144,7 @@ async fn drupal_loadtest_node_page(user: &GooseUser) -> GooseTaskResult {
 async fn drupal_loadtest_profile_page(user: &GooseUser) -> GooseTaskResult {
     let uid = rand::thread_rng().gen_range(2, 5_001);
     let _goose = user.get(format!("/user/{}", &uid).as_str()).await?;
+
     Ok(())
 }
 
@@ -180,7 +183,7 @@ async fn drupal_loadtest_login(user: &GooseUser) -> GooseTaskResult {
                         ("form_id", "user_login"),
                         ("op", "Log+in"),
                     ];
-                    let request_builder = user.goose_post("/user").await;
+                    let request_builder = user.goose_post("/user").await?;
                     let _goose = user.goose_send(request_builder.form(&params), None).await;
                     // @TODO: verify that we actually logged in.
                 }
@@ -208,6 +211,7 @@ async fn drupal_loadtest_login(user: &GooseUser) -> GooseTaskResult {
             );
         }
     }
+
     Ok(())
 }
 
@@ -296,7 +300,7 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
                     ];
 
                     // Post the comment.
-                    let request_builder = user.goose_post(&comment_path).await;
+                    let request_builder = user.goose_post(&comment_path).await?;
                     let mut goose = user.goose_send(request_builder.form(&params), None).await?;
 
                     // Verify that the comment posted.
@@ -373,5 +377,6 @@ async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
             );
         }
     }
+
     Ok(())
 }

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -28,7 +28,7 @@ use rand::Rng;
 use regex::Regex;
 
 fn main() -> Result<(), GooseError> {
-    GooseAttack::initialize()
+    GooseAttack::initialize()?
         .register_taskset(
             taskset!("AnonBrowsingUser")
                 .set_weight(4)

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -31,26 +31,26 @@ fn main() -> Result<(), GooseError> {
     GooseAttack::initialize()?
         .register_taskset(
             taskset!("AnonBrowsingUser")
-                .set_weight(4)
+                .set_weight(4)?
                 .register_task(
                     task!(drupal_loadtest_front_page)
-                        .set_weight(15)
+                        .set_weight(15)?
                         .set_name("(Anon) front page"),
                 )
                 .register_task(
                     task!(drupal_loadtest_node_page)
-                        .set_weight(10)
+                        .set_weight(10)?
                         .set_name("(Anon) node page"),
                 )
                 .register_task(
                     task!(drupal_loadtest_profile_page)
-                        .set_weight(3)
+                        .set_weight(3)?
                         .set_name("(Anon) user page"),
                 ),
         )
         .register_taskset(
             taskset!("AuthBrowsingUser")
-                .set_weight(1)
+                .set_weight(1)?
                 .register_task(
                     task!(drupal_loadtest_login)
                         .set_on_start()
@@ -58,22 +58,22 @@ fn main() -> Result<(), GooseError> {
                 )
                 .register_task(
                     task!(drupal_loadtest_front_page)
-                        .set_weight(15)
+                        .set_weight(15)?
                         .set_name("(Auth) front page"),
                 )
                 .register_task(
                     task!(drupal_loadtest_node_page)
-                        .set_weight(10)
+                        .set_weight(10)?
                         .set_name("(Auth) node page"),
                 )
                 .register_task(
                     task!(drupal_loadtest_profile_page)
-                        .set_weight(3)
+                        .set_weight(3)?
                         .set_name("(Auth) user page"),
                 )
                 .register_task(
                     task!(drupal_loadtest_post_comment)
-                        .set_weight(3)
+                        .set_weight(3)?
                         .set_name("(Auth) comment form"),
                 ),
         )

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -27,7 +27,7 @@ use goose::prelude::*;
 use rand::Rng;
 use regex::Regex;
 
-fn main() {
+fn main() -> Result<(), GooseError> {
     GooseAttack::initialize()
         .register_taskset(
             taskset!("AnonBrowsingUser")
@@ -77,7 +77,10 @@ fn main() {
                         .set_name("(Auth) comment form"),
                 ),
         )
-        .execute();
+        .execute()?
+        .display_stats();
+
+    Ok(())
 }
 
 /// View the front page.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -19,7 +19,7 @@
 
 use goose::prelude::*;
 
-fn main() {
+fn main() -> Result<(), GooseError> {
     GooseAttack::initialize()
         // In this example, we only create a single taskset, named "WebsiteUser".
         .register_taskset(
@@ -32,7 +32,10 @@ fn main() {
                 .register_task(task!(website_index))
                 .register_task(task!(website_about)),
         )
-        .execute();
+        .execute()?
+        .display_stats();
+
+    Ok(())
 }
 
 /// Demonstrates how to log in when a user starts. We flag this task as an

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -20,7 +20,7 @@
 use goose::prelude::*;
 
 fn main() -> Result<(), GooseError> {
-    GooseAttack::initialize()
+    GooseAttack::initialize()?
         // In this example, we only create a single taskset, named "WebsiteUser".
         .register_taskset(
             taskset!("WebsiteUser")

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), GooseError> {
         .register_taskset(
             taskset!("WebsiteUser")
                 // After each task runs, sleep randomly from 5 to 15 seconds.
-                .set_wait_time(5, 15)
+                .set_wait_time(5, 15)?
                 // This task only runs one time when the user first starts.
                 .register_task(task!(website_login).set_on_start())
                 // These next two tasks run repeatedly as long as the load test is running.
@@ -33,7 +33,7 @@ fn main() -> Result<(), GooseError> {
                 .register_task(task!(website_about)),
         )
         .execute()?
-        .display_stats();
+        .display();
 
     Ok(())
 }
@@ -42,21 +42,24 @@ fn main() -> Result<(), GooseError> {
 /// on_start task when registering it above. This means it only runs one time
 /// per user, when the user thread first starts.
 async fn website_login(user: &GooseUser) -> GooseTaskResult {
-    let request_builder = user.goose_post("/login").await;
+    let request_builder = user.goose_post("/login").await?;
     // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
     let _goose = user.goose_send(request_builder.form(&params), None).await?;
+
     Ok(())
 }
 
 /// A very simple task that simply loads the front page.
 async fn website_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get("/").await?;
+
     Ok(())
 }
 
 /// A very simple task that simply loads the about page.
 async fn website_about(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get("/about/").await?;
+
     Ok(())
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1748,27 +1748,30 @@ impl GooseUser {
     /// ```rust,no_run
     /// use goose::prelude::*;
     ///
-    /// GooseAttack::initialize()
-    ///     .register_taskset(taskset!("LoadtestTasks").set_host("http//foo.example.com/")
-    ///         .set_wait_time(0, 3)
-    ///         .register_task(task!(task_foo).set_weight(10))
-    ///         .register_task(task!(task_bar))
-    ///     )
-    ///     .execute();
+    /// fn main() -> Result<(), GooseError> {
+    ///     GooseAttack::initialize()?
+    ///         .register_taskset(taskset!("LoadtestTasks").set_host("http//foo.example.com/")
+    ///             .set_wait_time(0, 3)
+    ///             .register_task(task!(task_foo).set_weight(10))
+    ///             .register_task(task!(task_bar))
+    ///         )
+    ///         .execute()?;
+    ///     Ok(())
+    /// }
     ///
-    ///     async fn task_foo(user: &GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/").await?;
-    ///       Ok(())
-    ///     }
+    /// async fn task_foo(user: &GooseUser) -> GooseTaskResult {
+    ///     let _goose = user.get("/").await?;
+    ///     Ok(())
+    /// }
     ///
-    ///     async fn task_bar(user: &GooseUser) -> GooseTaskResult {
-    ///       // Before this task runs, all requests are being made against
-    ///       // http://foo.example.com, after this task runs all subsequent
-    ///       // requests are made against http://bar.example.com/.
-    ///       user.set_base_url("http://bar.example.com/");
-    ///       let _goose = user.get("/").await?;
-    ///       Ok(())
-    ///     }
+    /// async fn task_bar(user: &GooseUser) -> GooseTaskResult {
+    ///     // Before this task runs, all requests are being made against
+    ///     // http://foo.example.com, after this task runs all subsequent
+    ///     // requests are made against http://bar.example.com/.
+    ///     user.set_base_url("http://bar.example.com/");
+    ///     let _goose = user.get("/").await?;
+    ///     Ok(())
+    /// }
     /// ```
     pub async fn set_base_url(&self, host: &str) {
         match Url::parse(host) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -850,7 +850,7 @@ impl GooseAttack {
     /// use goose::prelude::*;
     ///
     /// fn main() -> Result<(), GooseError> {
-    ///     let _stats = GooseAttack::initialize()?
+    ///     let _goose_attack = GooseAttack::initialize()?
     ///         .register_taskset(taskset!("ExampleTasks")
     ///             .register_task(task!(example_task).set_weight(2)?)
     ///             .register_task(task!(another_example_task).set_weight(3)?)
@@ -1113,7 +1113,7 @@ impl GooseAttack {
     ///     use goose::prelude::*;
     ///
     /// fn main() -> Result<(), GooseError> {
-    ///     let _stats = GooseAttack::initialize()?
+    ///     let _goose_attack = GooseAttack::initialize()?
     ///         .register_taskset(taskset!("ExampleTasks")
     ///             .register_task(task!(example_task).set_weight(2)?)
     ///             .register_task(task!(another_example_task).set_weight(3)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,10 +362,10 @@ pub struct Socket {}
 /// Goose optionally tracks statistics about requests made during a load test.
 pub type GooseRequestStats = HashMap<String, GooseRequest>;
 
-/// Definition of all errors Goose Tasks can return.
+/// Definition of all errors Goose can return.
 #[derive(Debug)]
 pub enum GooseError {
-    /// Contains any possible Reqwest library error.
+    /// Contains any possible GooseTask error.
     GooseTask(GooseTaskError),
 }
 
@@ -1221,8 +1221,6 @@ impl GooseAttack {
             socket
         );
 
-        let started = self.started.unwrap();
-
         // Initilize per-user states.
         if !self.configuration.worker {
             // First run global test_start_task, if defined.
@@ -1258,8 +1256,8 @@ impl GooseAttack {
         ) = mpsc::unbounded_channel();
         // Spawn users, each with their own weighted task_set.
         for mut thread_user in self.weighted_users.clone() {
-            // Stop launching threads if the run_timer has expired.
-            if util::timer_expired(started, self.run_time) {
+            // Stop launching threads if the run_timer has expired, unwrap is safe as we only get here if we started.
+            if util::timer_expired(self.started.unwrap(), self.run_time) {
                 break;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,11 +92,11 @@
 //!         .register_taskset(taskset!("LoadtestTasks")
 //!             .set_wait_time(0, 3)
 //!             // Register the foo task, assigning it a weight of 10.
-//!             .register_task(task!(loadtest_foo).set_weight(10))
+//!             .register_task(task!(loadtest_foo).set_weight(10)?)
 //!             // Register the bar task, assigning it a weight of 2 (so it
 //!             // runs 1/5 as often as bar). Apply a task name which shows up
 //!             // in statistics.
-//!             .register_task(task!(loadtest_bar).set_name("bar").set_weight(2))
+//!             .register_task(task!(loadtest_bar).set_name("bar").set_weight(2)?)
 //!         )
 //!         // You could also set a default host here, for example:
 //!         //.set_host("http://dev.local/")
@@ -377,6 +377,7 @@ pub enum GooseError {
     NoTaskSets,
     InvalidOption,
     InvalidHost,
+    InvalidWeight,
     FeatureNotEnabled,
     Io(io::Error),
 }
@@ -388,6 +389,7 @@ impl fmt::Display for GooseError {
             GooseError::NoTaskSets => write!(f, "No task sets defined."),
             GooseError::InvalidOption => write!(f, "Invalid option specified."),
             GooseError::InvalidHost => write!(f, "Host is not in valid format."),
+            GooseError::InvalidWeight => write!(f, "Invalid weight specified."),
             GooseError::FeatureNotEnabled => write!(f, "Compile time feature not enabled."),
             GooseError::Io(ref err) => err.fmt(f),
         }
@@ -841,8 +843,8 @@ impl GooseAttack {
     /// fn main() -> Result<(), GooseError> {
     ///     let _stats = GooseAttack::initialize()?
     ///         .register_taskset(taskset!("ExampleTasks")
-    ///             .register_task(task!(example_task).set_weight(2))
-    ///             .register_task(task!(another_example_task).set_weight(3))
+    ///             .register_task(task!(example_task).set_weight(2)?)
+    ///             .register_task(task!(another_example_task).set_weight(3)?)
     ///         )
     ///         .execute()?;
     ///
@@ -1104,8 +1106,8 @@ impl GooseAttack {
     /// fn main() -> Result<(), GooseError> {
     ///     let _stats = GooseAttack::initialize()?
     ///         .register_taskset(taskset!("ExampleTasks")
-    ///             .register_task(task!(example_task).set_weight(2))
-    ///             .register_task(task!(another_example_task).set_weight(3))
+    ///             .register_task(task!(example_task).set_weight(2)?)
+    ///             .register_task(task!(another_example_task).set_weight(3)?)
     ///         )
     ///         .execute()?
     ///         .display_stats();

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
 pub use crate::goose::{
     GooseMethod, GooseTask, GooseTaskError, GooseTaskResult, GooseTaskSet, GooseUser,
 };
-pub use crate::{task, taskset, GooseAttack};
+pub use crate::{task, taskset, GooseAttack, GooseError, GooseRequestStats};

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -3,8 +3,7 @@ use num_format::{Locale, ToFormattedString};
 use std::collections::{BTreeMap, HashMap};
 use std::f32;
 
-use crate::goose::GooseRequest;
-use crate::{util, GooseAttack};
+use crate::{util, GooseAttack, GooseRequestStats};
 
 /// A helper function that merges together response times.
 ///
@@ -75,7 +74,7 @@ fn calculate_response_time_percentile(
 }
 
 /// Display a table of requests and fails.
-pub fn print_requests_and_fails(requests: &HashMap<String, GooseRequest>, elapsed: usize) {
+pub fn print_requests_and_fails(requests: &GooseRequestStats, elapsed: usize) {
     debug!("entering print_requests_and_fails");
     // Display stats from merged HashMap
     println!("------------------------------------------------------------------------------ ");
@@ -162,7 +161,7 @@ pub fn print_requests_and_fails(requests: &HashMap<String, GooseRequest>, elapse
     }
 }
 
-fn print_response_times(requests: &HashMap<String, GooseRequest>, display_percentiles: bool) {
+fn print_response_times(requests: &GooseRequestStats, display_percentiles: bool) {
     debug!("entering print_response_times");
     let mut aggregate_response_times: BTreeMap<usize, usize> = BTreeMap::new();
     let mut aggregate_total_response_time: usize = 0;
@@ -340,7 +339,7 @@ fn print_response_times(requests: &HashMap<String, GooseRequest>, display_percen
     }
 }
 
-fn print_status_codes(requests: &HashMap<String, GooseRequest>) {
+fn print_status_codes(requests: &GooseRequestStats) {
     debug!("entering print_status_codes");
     println!("-------------------------------------------------------------------------------");
     println!(" {:<23} | {:<25} ", "Name", "Status codes");

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -211,7 +211,6 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     }
 
     // Worker is officially starting the load test.
-    let started = time::Instant::now();
     info!(
         "[{}] entering gaggle mode, starting load test",
         get_worker_id()
@@ -219,6 +218,7 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     let sleep_duration = time::Duration::from_secs_f32(hatch_rate.unwrap());
 
     let mut worker_goose_attack = GooseAttack::initialize_with_config(config.clone());
+    worker_goose_attack.started = Some(time::Instant::now());
     worker_goose_attack.task_sets = goose_attack.task_sets.clone();
     if config.run_time != "" {
         worker_goose_attack.run_time = util::parse_timespan(&config.run_time);
@@ -233,7 +233,7 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     worker_goose_attack.weighted_users = weighted_users;
     worker_goose_attack.configuration.worker = true;
     worker_goose_attack
-        .launch_users(started, sleep_duration, Some(manager))
+        .launch_users(sleep_duration, Some(manager))
         .await
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -232,9 +232,16 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     }
     worker_goose_attack.weighted_users = weighted_users;
     worker_goose_attack.configuration.worker = true;
-    worker_goose_attack
+    match worker_goose_attack
         .launch_users(sleep_duration, Some(manager))
         .await
+    {
+        Ok(w) => w,
+        Err(e) => {
+            error!("[{}] failed to launch GooseAttack: {}", get_worker_id(), e);
+            std::process::exit(1);
+        }
+    }
 }
 
 pub fn push_stats_to_manager(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -133,14 +133,20 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
             if worker_id == 0 {
                 worker_id = initializer.worker_id;
             }
-            let user = GooseUser::new(
+            let user = match GooseUser::new(
                 initializer.task_sets_index,
                 Url::parse(&initializer.base_url).unwrap(),
                 initializer.min_wait,
                 initializer.max_wait,
                 &initializer.config,
                 goose_attack.task_sets_hash,
-            );
+            ) {
+                Ok(u) => u,
+                Err(e) => {
+                    error!("[{}] failed to create GooseUser: {}", get_worker_id(), e);
+                    std::process::exit(1);
+                }
+            };
             weighted_users.push(user);
             if hatch_rate == None {
                 hatch_rate = Some(

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -38,9 +38,11 @@ fn test_gaggle() {
         master_configuration.run_time = "3".to_string();
         let _stats = crate::GooseAttack::initialize_with_config(master_configuration)
             .setup()
+            .unwrap()
             .register_taskset(taskset!("User1").register_task(task!(get_index)))
             .register_taskset(taskset!("User2").register_task(task!(get_about)))
-            .execute();
+            .execute()
+            .unwrap();
     });
 
     // Start worker instance of the load test.
@@ -52,9 +54,11 @@ fn test_gaggle() {
         configuration.run_time = "".to_string();
         let _stats = crate::GooseAttack::initialize_with_config(configuration)
             .setup()
+            .unwrap()
             .register_taskset(taskset!("User1").register_task(task!(get_index)))
             .register_taskset(taskset!("User2").register_task(task!(get_about)))
-            .execute();
+            .execute()
+            .unwrap();
     });
 
     // Wait for the load test to finish.

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -36,7 +36,7 @@ fn test_gaggle() {
         master_configuration.manager = true;
         master_configuration.expect_workers = 1;
         master_configuration.run_time = "3".to_string();
-        let _stats = crate::GooseAttack::initialize_with_config(master_configuration)
+        let _goose_attack = crate::GooseAttack::initialize_with_config(master_configuration)
             .setup()
             .unwrap()
             .register_taskset(taskset!("User1").register_task(task!(get_index)))
@@ -52,7 +52,7 @@ fn test_gaggle() {
         configuration.users = None;
         configuration.no_stats = false;
         configuration.run_time = "".to_string();
-        let _stats = crate::GooseAttack::initialize_with_config(configuration)
+        let _goose_attack = crate::GooseAttack::initialize_with_config(configuration)
             .setup()
             .unwrap()
             .register_taskset(taskset!("User1").register_task(task!(get_index)))

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -36,7 +36,7 @@ fn test_gaggle() {
         master_configuration.manager = true;
         master_configuration.expect_workers = 1;
         master_configuration.run_time = "3".to_string();
-        crate::GooseAttack::initialize_with_config(master_configuration)
+        let _stats = crate::GooseAttack::initialize_with_config(master_configuration)
             .setup()
             .register_taskset(taskset!("User1").register_task(task!(get_index)))
             .register_taskset(taskset!("User2").register_task(task!(get_about)))
@@ -50,7 +50,7 @@ fn test_gaggle() {
         configuration.users = None;
         configuration.no_stats = false;
         configuration.run_time = "".to_string();
-        crate::GooseAttack::initialize_with_config(configuration)
+        let _stats = crate::GooseAttack::initialize_with_config(configuration)
             .setup()
             .register_taskset(taskset!("User1").register_task(task!(get_index)))
             .register_taskset(taskset!("User2").register_task(task!(get_about)))

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -48,7 +48,7 @@ fn test_stat_logs_json() {
     let mut config = common::build_configuration();
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.no_stats = false;
-    let _stats = crate::GooseAttack::initialize_with_config(config)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -78,7 +78,7 @@ fn test_stat_logs_csv() {
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.stats_log_format = "csv".to_string();
     config.no_stats = false;
-    let _stats = crate::GooseAttack::initialize_with_config(config)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -108,7 +108,7 @@ fn test_stat_logs_raw() {
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.stats_log_format = "raw".to_string();
     config.no_stats = false;
-    let _stats = crate::GooseAttack::initialize_with_config(config)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -138,7 +138,7 @@ fn test_debug_logs_raw() {
     let mut config = common::build_configuration();
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
     config.debug_log_format = "raw".to_string();
-    let _stats = crate::GooseAttack::initialize_with_config(config)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(
@@ -173,7 +173,7 @@ fn test_debug_logs_json() {
 
     let mut config = common::build_configuration();
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
-    let _stats = crate::GooseAttack::initialize_with_config(config)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(
@@ -211,7 +211,7 @@ fn test_stats_and_debug_logs() {
     config.stats_log_format = "raw".to_string();
     config.no_stats = false;
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
-    let _stats = crate::GooseAttack::initialize_with_config(config)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -50,8 +50,10 @@ fn test_stat_logs_json() {
     config.no_stats = false;
     let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
+        .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
 
@@ -78,8 +80,10 @@ fn test_stat_logs_csv() {
     config.no_stats = false;
     let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
+        .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
 
@@ -106,8 +110,10 @@ fn test_stat_logs_raw() {
     config.no_stats = false;
     let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
+        .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
 
@@ -134,12 +140,14 @@ fn test_debug_logs_raw() {
     config.debug_log_format = "raw".to_string();
     let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 .register_task(task!(get_index))
                 .register_task(task!(get_error)),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_error = mock_error.times_called();
@@ -167,12 +175,14 @@ fn test_debug_logs_json() {
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
     let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 .register_task(task!(get_index))
                 .register_task(task!(get_error)),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_error = mock_error.times_called();
@@ -203,12 +213,14 @@ fn test_stats_and_debug_logs() {
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
     let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 .register_task(task!(get_index))
                 .register_task(task!(get_error)),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_error = mock_error.times_called();

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -48,7 +48,7 @@ fn test_stat_logs_json() {
     let mut config = common::build_configuration();
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.no_stats = false;
-    crate::GooseAttack::initialize_with_config(config)
+    let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
         .execute();
@@ -76,7 +76,7 @@ fn test_stat_logs_csv() {
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.stats_log_format = "csv".to_string();
     config.no_stats = false;
-    crate::GooseAttack::initialize_with_config(config)
+    let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
         .execute();
@@ -104,7 +104,7 @@ fn test_stat_logs_raw() {
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.stats_log_format = "raw".to_string();
     config.no_stats = false;
-    crate::GooseAttack::initialize_with_config(config)
+    let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
         .execute();
@@ -132,7 +132,7 @@ fn test_debug_logs_raw() {
     let mut config = common::build_configuration();
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
     config.debug_log_format = "raw".to_string();
-    crate::GooseAttack::initialize_with_config(config)
+    let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(
             taskset!("LoadTest")
@@ -165,7 +165,7 @@ fn test_debug_logs_json() {
 
     let mut config = common::build_configuration();
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
-    crate::GooseAttack::initialize_with_config(config)
+    let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(
             taskset!("LoadTest")
@@ -201,7 +201,7 @@ fn test_stats_and_debug_logs() {
     config.stats_log_format = "raw".to_string();
     config.no_stats = false;
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
-    crate::GooseAttack::initialize_with_config(config)
+    let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(
             taskset!("LoadTest")

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -28,12 +28,14 @@ fn test_no_normal_tasks() {
 
     let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 .register_task(task!(login).set_on_start())
                 .register_task(task!(logout).set_on_stop()),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_login = mock_login.times_called();
     let called_logout = mock_logout.times_called();

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -9,7 +9,7 @@ const LOGIN_PATH: &str = "/login";
 const LOGOUT_PATH: &str = "/logout";
 
 pub async fn login(user: &GooseUser) -> GooseTaskResult {
-    let request_builder = user.goose_post(LOGIN_PATH).await;
+    let request_builder = user.goose_post(LOGIN_PATH).await?;
     let params = [("username", "me"), ("password", "s3crET!")];
     let _goose = user.goose_send(request_builder.form(&params), None).await?;
     Ok(())

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -26,7 +26,7 @@ fn test_no_normal_tasks() {
     let mock_login = mock(POST, LOGIN_PATH).return_status(200).create();
     let mock_logout = mock(GET, LOGOUT_PATH).return_status(200).create();
 
-    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _goose_attack = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -26,7 +26,7 @@ fn test_no_normal_tasks() {
     let mock_login = mock(POST, LOGIN_PATH).return_status(200).create();
     let mock_logout = mock(GET, LOGOUT_PATH).return_status(200).create();
 
-    crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .register_taskset(
             taskset!("LoadTest")

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -32,8 +32,8 @@ fn test_single_taskset() {
         .unwrap()
         .register_taskset(
             taskset!("LoadTest")
-                .register_task(task!(get_index).set_weight(9))
-                .register_task(task!(get_about).set_weight(3)),
+                .register_task(task!(get_index).set_weight(9).unwrap())
+                .register_task(task!(get_about).set_weight(3).unwrap()),
         )
         .execute()
         .unwrap();
@@ -68,8 +68,8 @@ fn test_single_taskset_empty_config_host() {
         .unwrap()
         .register_taskset(
             taskset!("LoadTest")
-                .register_task(task!(get_index).set_weight(9))
-                .register_task(task!(get_about).set_weight(3)),
+                .register_task(task!(get_index).set_weight(9).unwrap())
+                .register_task(task!(get_about).set_weight(3).unwrap()),
         )
         .set_host(&host)
         .execute()

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -27,7 +27,7 @@ fn test_single_taskset() {
         .return_body("<HTML><BODY>about page</BODY></HTML>")
         .create();
 
-    crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .register_taskset(
             taskset!("LoadTest")
@@ -61,7 +61,7 @@ fn test_single_taskset_empty_config_host() {
     let mut config = common::build_configuration();
     // this will leave an empty string in config.host
     let host = std::mem::take(&mut config.host);
-    crate::GooseAttack::initialize_with_config(config)
+    let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(
             taskset!("LoadTest")

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -27,7 +27,7 @@ fn test_single_taskset() {
         .return_body("<HTML><BODY>about page</BODY></HTML>")
         .create();
 
-    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _goose_attack = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .unwrap()
         .register_taskset(
@@ -63,7 +63,7 @@ fn test_single_taskset_empty_config_host() {
     let mut config = common::build_configuration();
     // this will leave an empty string in config.host
     let host = std::mem::take(&mut config.host);
-    let _stats = crate::GooseAttack::initialize_with_config(config)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -29,12 +29,14 @@ fn test_single_taskset() {
 
     let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 .register_task(task!(get_index).set_weight(9))
                 .register_task(task!(get_about).set_weight(3)),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_about = mock_about.times_called();
@@ -63,13 +65,15 @@ fn test_single_taskset_empty_config_host() {
     let host = std::mem::take(&mut config.host);
     let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 .register_task(task!(get_index).set_weight(9))
                 .register_task(task!(get_about).set_weight(3)),
         )
         .set_host(&host)
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_about = mock_about.times_called();

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -85,7 +85,7 @@ fn test_redirect() {
         .return_body("<HTML><BODY>about page</BODY></HTML>")
         .create();
 
-    crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .register_taskset(
             taskset!("LoadTest")
@@ -144,7 +144,7 @@ fn test_domain_redirect() {
         .expect(0)
         .create();
 
-    crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .register_taskset(
             taskset!("LoadTest")
@@ -200,7 +200,7 @@ fn test_sticky_domain_redirect() {
     // Enable sticky_follow option.
     let mut configuration = common::build_configuration();
     configuration.sticky_follow = true;
-    crate::GooseAttack::initialize_with_config(configuration)
+    let _stats = crate::GooseAttack::initialize_with_config(configuration)
         .setup()
         .register_taskset(
             taskset!("LoadTest")

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -87,6 +87,7 @@ fn test_redirect() {
 
     let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 // Load index directly.
@@ -95,7 +96,8 @@ fn test_redirect() {
                 // redirect3 path, redirect to about.
                 .register_task(task!(get_redirect)),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_redirect = mock_redirect.times_called();
@@ -146,6 +148,7 @@ fn test_domain_redirect() {
 
     let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 // First load redirect, takes this request only to another domain.
@@ -155,7 +158,8 @@ fn test_domain_redirect() {
                 // Load about directly, always on original domain.
                 .register_task(task!(get_about)),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_about = mock_about.times_called();
@@ -202,6 +206,7 @@ fn test_sticky_domain_redirect() {
     configuration.sticky_follow = true;
     let _stats = crate::GooseAttack::initialize_with_config(configuration)
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 // First load redirect, due to stick_follow the load test stays on the
@@ -212,7 +217,8 @@ fn test_sticky_domain_redirect() {
                 // Due to sticky follow, we should always load the alternative about.
                 .register_task(task!(get_about)),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_about = mock_about.times_called();

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -85,7 +85,7 @@ fn test_redirect() {
         .return_body("<HTML><BODY>about page</BODY></HTML>")
         .create();
 
-    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _goose_attack = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .unwrap()
         .register_taskset(
@@ -146,7 +146,7 @@ fn test_domain_redirect() {
         .expect(0)
         .create();
 
-    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _goose_attack = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .unwrap()
         .register_taskset(
@@ -204,7 +204,7 @@ fn test_sticky_domain_redirect() {
     // Enable sticky_follow option.
     let mut configuration = common::build_configuration();
     configuration.sticky_follow = true;
-    let _stats = crate::GooseAttack::initialize_with_config(configuration)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(configuration)
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -34,7 +34,7 @@ fn test_start() {
     let mock_teardown = mock(POST, TEARDOWN_PATH).return_status(205).create();
     let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
 
-    crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .test_start(task!(setup))
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
@@ -62,7 +62,7 @@ fn test_stop() {
     let mock_teardown = mock(POST, TEARDOWN_PATH).return_status(205).create();
     let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
 
-    crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .test_stop(task!(teardown))
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
@@ -94,7 +94,7 @@ fn test_setup_teardown() {
     configuration.users = Some(5);
     configuration.hatch_rate = 5;
 
-    crate::GooseAttack::initialize_with_config(configuration)
+    let _stats = crate::GooseAttack::initialize_with_config(configuration)
         .setup()
         .test_start(task!(setup))
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -36,9 +36,11 @@ fn test_start() {
 
     let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
+        .unwrap()
         .test_start(task!(setup))
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_setup = mock_setup.times_called();
     let called_index = mock_index.times_called();
@@ -64,9 +66,11 @@ fn test_stop() {
 
     let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
+        .unwrap()
         .test_stop(task!(teardown))
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_setup = mock_setup.times_called();
     let called_index = mock_index.times_called();
@@ -96,10 +100,12 @@ fn test_setup_teardown() {
 
     let _stats = crate::GooseAttack::initialize_with_config(configuration)
         .setup()
+        .unwrap()
         .test_start(task!(setup))
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
         .test_stop(task!(teardown))
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_setup = mock_setup.times_called();
     let called_index = mock_index.times_called();

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -38,7 +38,9 @@ fn test_start() {
         .setup()
         .unwrap()
         .test_start(task!(setup))
-        .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
+        .register_taskset(
+            taskset!("LoadTest").register_task(task!(get_index).set_weight(9).unwrap()),
+        )
         .execute()
         .unwrap();
 
@@ -68,7 +70,9 @@ fn test_stop() {
         .setup()
         .unwrap()
         .test_stop(task!(teardown))
-        .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
+        .register_taskset(
+            taskset!("LoadTest").register_task(task!(get_index).set_weight(9).unwrap()),
+        )
         .execute()
         .unwrap();
 
@@ -102,7 +106,9 @@ fn test_setup_teardown() {
         .setup()
         .unwrap()
         .test_start(task!(setup))
-        .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9)))
+        .register_taskset(
+            taskset!("LoadTest").register_task(task!(get_index).set_weight(9).unwrap()),
+        )
         .test_stop(task!(teardown))
         .execute()
         .unwrap();

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -34,7 +34,7 @@ fn test_start() {
     let mock_teardown = mock(POST, TEARDOWN_PATH).return_status(205).create();
     let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
 
-    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _goose_attack = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .unwrap()
         .test_start(task!(setup))
@@ -66,7 +66,7 @@ fn test_stop() {
     let mock_teardown = mock(POST, TEARDOWN_PATH).return_status(205).create();
     let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
 
-    let _stats = crate::GooseAttack::initialize_with_config(common::build_configuration())
+    let _goose_attack = crate::GooseAttack::initialize_with_config(common::build_configuration())
         .setup()
         .unwrap()
         .test_stop(task!(teardown))
@@ -102,7 +102,7 @@ fn test_setup_teardown() {
     configuration.users = Some(5);
     configuration.hatch_rate = 5;
 
-    let _stats = crate::GooseAttack::initialize_with_config(configuration)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(configuration)
         .setup()
         .unwrap()
         .test_start(task!(setup))

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -42,7 +42,7 @@ fn test_throttle() {
     config.hatch_rate = users;
     // Run for a few seconds to be sure throttle really works.
     config.run_time = run_time.to_string();
-    let _stats = crate::GooseAttack::initialize_with_config(config)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(
@@ -84,7 +84,7 @@ fn test_throttle() {
     // Start all users in half a second.
     config.hatch_rate = users;
     config.run_time = run_time.to_string();
-    let _stats = crate::GooseAttack::initialize_with_config(config)
+    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -42,7 +42,7 @@ fn test_throttle() {
     config.hatch_rate = users;
     // Run for a few seconds to be sure throttle really works.
     config.run_time = run_time.to_string();
-    crate::GooseAttack::initialize_with_config(config)
+    let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(
             taskset!("LoadTest")
@@ -82,7 +82,7 @@ fn test_throttle() {
     // Start all users in half a second.
     config.hatch_rate = users;
     config.run_time = run_time.to_string();
-    crate::GooseAttack::initialize_with_config(config)
+    let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .register_taskset(
             taskset!("LoadTest")

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -44,12 +44,14 @@ fn test_throttle() {
     config.run_time = run_time.to_string();
     let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 .register_task(task!(get_about))
                 .register_task(task!(get_index)),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_about = mock_about.times_called();
@@ -84,12 +86,14 @@ fn test_throttle() {
     config.run_time = run_time.to_string();
     let _stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
+        .unwrap()
         .register_taskset(
             taskset!("LoadTest")
                 .register_task(task!(get_about))
                 .register_task(task!(get_index)),
         )
-        .execute();
+        .execute()
+        .unwrap();
 
     let called_index = mock_index.times_called();
     let called_about = mock_about.times_called();


### PR DESCRIPTION
- Return a `Result` from all `GooseAttack` methods that can fail.
- Remove all unnecessary `exit(1)` calls from code, to simplify integrating Goose with other applications.
  - This included adding several new `GooseTaskError` types
- Update documentation briefly explaining the use of `Result<>`, `?` and `Ok(())`.

Note: This PR required a considerable number of document tests be rewritten for tests to pass. In order to simplify this process and avoid accidental errors I standardized coding style in all affected comments. Comments for functions that were not affected by this PR will be standardized in a follow up PR.

Fixes #109
