### PR TITLE
upgrade httpmock, two mock frameworks no longer needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,4 @@ gaggle = ["nng"]
 rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
-httpmock = "0.3"
-mockito = "0.25"
+httpmock = "0.4"

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,10 +1,12 @@
+use httpmock::MockServer;
+
 use goose::GooseConfiguration;
 
-pub fn build_configuration() -> GooseConfiguration {
+pub fn build_configuration(server: &MockServer) -> GooseConfiguration {
     // Manually specify configuration for test, normally this is provided as
     // CLI options.
     GooseConfiguration {
-        host: "http://127.0.0.1:5000".to_string(),
+        host: server.url("/").to_string(),
         users: Some(1),
         hatch_rate: 1,
         run_time: "1".to_string(),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -6,7 +6,7 @@ pub fn build_configuration(server: &MockServer) -> GooseConfiguration {
     // Manually specify configuration for test, normally this is provided as
     // CLI options.
     GooseConfiguration {
-        host: server.url("/").to_string(),
+        host: server.url("/"),
         users: Some(1),
         hatch_rate: 1,
         run_time: "1".to_string(),

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -1,5 +1,5 @@
 use httpmock::Method::GET;
-use httpmock::{mock, with_mock_server};
+use httpmock::{Mock, MockServer};
 
 mod common;
 
@@ -20,18 +20,27 @@ pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
 }
 
 #[test]
-#[with_mock_server]
 fn test_throttle() {
     use std::io::{self, BufRead};
 
-    let mock_index = mock(GET, INDEX_PATH).return_status(200).create();
-    let mock_about = mock(GET, ABOUT_PATH).return_status(200).create();
+    let server = MockServer::start();
+
+    let index = Mock::new()
+        .expect_method(GET)
+        .expect_path(INDEX_PATH)
+        .return_status(200)
+        .create_on(&server);
+    let about = Mock::new()
+        .expect_method(GET)
+        .expect_path(ABOUT_PATH)
+        .return_status(200)
+        .create_on(&server);
 
     let mut throttle_requests = 25;
     let users = 5;
     let run_time = 3;
 
-    let mut config = common::build_configuration();
+    let mut config = common::build_configuration(&server);
     // Record all requests so we can confirm throttle is working.
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.no_stats = false;
@@ -53,12 +62,9 @@ fn test_throttle() {
         .execute()
         .unwrap();
 
-    let called_index = mock_index.times_called();
-    let called_about = mock_about.times_called();
-
     // Confirm that we loaded the mock endpoints.
-    assert_ne!(called_index, 0);
-    assert_ne!(called_about, 0);
+    assert!(index.times_called() > 0);
+    assert!(about.times_called() > 0);
 
     let test1_lines: usize;
     if let Ok(stats_log) = std::fs::File::open(std::path::Path::new(STATS_LOG_FILE)) {
@@ -74,7 +80,7 @@ fn test_throttle() {
     // and confirm the throttle is actually working.
     throttle_requests *= 5;
 
-    let mut config = common::build_configuration();
+    let mut config = common::build_configuration(&server);
     // Record all requests so we can confirm throttle is working.
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.no_stats = false;
@@ -95,12 +101,9 @@ fn test_throttle() {
         .execute()
         .unwrap();
 
-    let called_index = mock_index.times_called();
-    let called_about = mock_about.times_called();
-
     // Confirm that we loaded the mock endpoints.
-    assert_ne!(called_index, 0);
-    assert_ne!(called_about, 0);
+    assert!(index.times_called() > 0);
+    assert!(about.times_called() > 0);
 
     let lines: usize;
     if let Ok(stats_log) = std::fs::File::open(std::path::Path::new(STATS_LOG_FILE)) {

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -76,6 +76,9 @@ fn test_throttle() {
     // Requests are made while GooseUsers are hatched, and then for run_time seconds.
     assert!(test1_lines <= (run_time + 1) * throttle_requests);
 
+    // Cleanup log file.
+    std::fs::remove_file(STATS_LOG_FILE).expect("failed to delete stats log file");
+
     // Increase the throttle and run a second load test, so we can compare the difference
     // and confirm the throttle is actually working.
     throttle_requests *= 5;
@@ -116,4 +119,9 @@ fn test_throttle() {
     assert!(lines <= (run_time + 1) * throttle_requests);
     // Verify the second load test generated more than 4x the load of the first test.
     assert!(lines > test1_lines * 4);
+    // Verify the second load test generated less than 6x the load of the first test.
+    assert!(lines < test1_lines * 6);
+
+    // Cleanup log file.
+    std::fs::remove_file(STATS_LOG_FILE).expect("failed to delete stats log file");
 }


### PR DESCRIPTION
- upgrade to httpmock 4.x
- remove mockito
- rework tests to use a dynamic server port
- rework tests to support parallel execution -- this is a nice performance boost when running tests
- consistently use `assert!()` as `assert_eq!()` and `assert_ne!()` are confusing when reading/debugging tests

Fixes #111 