### PR TITLE
add more detail to errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  - change `GooseAttack` method signatures where an error is possible
  - where possible, passs error up the stack instead of calling `exit(1)`
  - introduce `GooseAttack.display()` which consumes the load test state and displays statistics
+ - `panic!()` on unexpected errors instead of `exit(1)`
 
 ## 0.8.2 July 2, 2020
  - `client.log_debug()` will write debug logs to file when specified with `--debug-log-file=`

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $ cargo run
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 3.56s
      Running `target/debug/loadtest`
-12:09:56 [ERROR] Host must be defined globally or per-TaskSet. No host defined for LoadtestTasks.
+Error: InvalidOption { option: "--host", value: "", detail: Some("host must be defined via --host, GooseAttack.set_host() or GooseTaskSet.set_host() (no host defined for WebsiteUser)") }
 ```
 
 Goose is unable to run, as it doesn't know the domain you want to load test. So,

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -537,11 +537,11 @@ impl GooseTaskSet {
             max_wait
         );
         if min_wait > max_wait {
-            error!(
-                "min_wait({}) can't be larger than max_wait({})",
-                min_wait, max_wait
-            );
-            return Err(GooseError::InvalidWaitTime);
+            return Err(GooseError::InvalidWaitTime {
+                min_wait,
+                max_wait,
+                detail: Some("min_wait can not be larger than max_wait".to_string()),
+            });
         }
         self.min_wait = min_wait;
         self.max_wait = max_wait;

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -488,9 +488,11 @@ impl GooseTaskSet {
     /// ```
     pub fn set_weight(mut self, weight: usize) -> Result<Self, GooseError> {
         trace!("{} set_weight: {}", self.name, weight);
-        if weight < 1 {
-            error!("{} weight of {} not allowed", self.name, weight);
-            return Err(GooseError::InvalidWeight);
+        if weight == 0 {
+            return Err(GooseError::InvalidWeight {
+                weight,
+                detail: Some("weight of 0 not allowed".to_string()),
+            });
         } else {
             self.weight = weight;
         }
@@ -2031,9 +2033,11 @@ impl GooseTask {
             self.tasks_index,
             weight
         );
-        if weight < 1 {
-            error!("{} weight of {} not allowed", self.name, weight);
-            return Err(GooseError::InvalidWeight);
+        if weight == 0 {
+            return Err(GooseError::InvalidWeight {
+                weight,
+                detail: Some("weight of 0 not allowed".to_string()),
+            });
         } else {
             self.weight = weight;
         }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -493,9 +493,9 @@ impl GooseTaskSet {
                 weight,
                 detail: Some("weight of 0 not allowed".to_string()),
             });
-        } else {
-            self.weight = weight;
         }
+        self.weight = weight;
+
         Ok(self)
     }
 
@@ -1881,7 +1881,16 @@ pub fn get_base_url(
                 None => {
                     // Host is required, if we get here it's safe to unwrap this variable.
                     let default_host = default_host.unwrap();
-                    Ok(Url::parse(&default_host).map_err(|parse_error| GooseError::InvalidHost { host: default_host.to_string(), detail: Some("failure parsing host specified globally with GooseAttack.set_host()".to_string()), parse_error })?)
+                    Ok(
+                        Url::parse(&default_host).map_err(|parse_error| GooseError::InvalidHost {
+                            host: default_host.to_string(),
+                            detail: Some(
+                                "failure parsing host specified globally with GooseAttack.set_host()"
+                                    .to_string(),
+                            ),
+                            parse_error,
+                        })?,
+                    )
                 }
             }
         }
@@ -2038,9 +2047,9 @@ impl GooseTask {
                 weight,
                 detail: Some("weight of 0 not allowed".to_string()),
             });
-        } else {
-            self.weight = weight;
         }
+        self.weight = weight;
+
         Ok(self)
     }
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1858,7 +1858,7 @@ pub fn get_base_url(
         Some(host) => Ok(
             Url::parse(&host).map_err(|parse_error| GooseError::InvalidHost {
                 host,
-                detail: Some("Failure parsing host specified with --host".to_string()),
+                detail: Some("failure parsing host specified with --host".to_string()),
                 parse_error,
             })?,
         ),
@@ -1870,7 +1870,7 @@ pub fn get_base_url(
                         Url::parse(&host).map_err(|parse_error| GooseError::InvalidHost {
                             host,
                             detail: Some(
-                                "Failure parsing host specified with GooseTaskSet.set_host()"
+                                "failure parsing host specified with GooseTaskSet.set_host()"
                                     .to_string(),
                             ),
                             parse_error,
@@ -1881,7 +1881,7 @@ pub fn get_base_url(
                 None => {
                     // Host is required, if we get here it's safe to unwrap this variable.
                     let default_host = default_host.unwrap();
-                    Ok(Url::parse(&default_host).map_err(|parse_error| GooseError::InvalidHost { host: default_host.to_string(), detail: Some("Failure parsing host specified globally with GooseAttack.set_host()".to_string()), parse_error })?)
+                    Ok(Url::parse(&default_host).map_err(|parse_error| GooseError::InvalidHost { host: default_host.to_string(), detail: Some("failure parsing host specified globally with GooseAttack.set_host()".to_string()), parse_error })?)
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,11 @@ pub enum GooseError {
         parse_error: url::ParseError,
     },
     InvalidOption,
-    InvalidWaitTime,
+    InvalidWaitTime {
+        min_wait: usize,
+        max_wait: usize,
+        detail: Option<String>,
+    },
     InvalidWeight,
     NoTaskSets,
 }
@@ -396,7 +400,7 @@ impl fmt::Display for GooseError {
             GooseError::FeatureNotEnabled { .. } => write!(f, "Compile time feature not enabled."),
             GooseError::InvalidHost { .. } => write!(f, "Unable to parse host"),
             GooseError::InvalidOption => write!(f, "Invalid option."),
-            GooseError::InvalidWaitTime => write!(f, "Invalid wait time specified."),
+            GooseError::InvalidWaitTime { .. } => write!(f, "Invalid wait time specified."),
             GooseError::InvalidWeight => write!(f, "Invalid weight specified."),
             GooseError::NoTaskSets => write!(f, "No task sets defined."),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,7 +392,9 @@ pub enum GooseError {
         weight: usize,
         detail: Option<String>,
     },
-    NoTaskSets,
+    NoTaskSets {
+        detail: Option<String>,
+    },
 }
 
 impl fmt::Display for GooseError {
@@ -405,7 +407,7 @@ impl fmt::Display for GooseError {
             GooseError::InvalidOption => write!(f, "Invalid option."),
             GooseError::InvalidWaitTime { .. } => write!(f, "Invalid wait time specified."),
             GooseError::InvalidWeight { .. } => write!(f, "Invalid weight specified."),
-            GooseError::NoTaskSets => write!(f, "No task sets defined."),
+            GooseError::NoTaskSets { .. } => write!(f, "No task sets defined."),
         }
     }
 }
@@ -889,8 +891,9 @@ impl GooseAttack {
     pub fn execute(mut self) -> Result<GooseAttack, GooseError> {
         // At least one task set is required.
         if self.task_sets.is_empty() {
-            error!("No task sets defined.");
-            return Err(GooseError::NoTaskSets);
+            return Err(GooseError::NoTaskSets {
+                detail: Some("no task sets defined".to_string()),
+            });
         }
 
         if self.configuration.list {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,7 +388,10 @@ pub enum GooseError {
         max_wait: usize,
         detail: Option<String>,
     },
-    InvalidWeight,
+    InvalidWeight {
+        weight: usize,
+        detail: Option<String>,
+    },
     NoTaskSets,
 }
 
@@ -401,7 +404,7 @@ impl fmt::Display for GooseError {
             GooseError::InvalidHost { .. } => write!(f, "Unable to parse host"),
             GooseError::InvalidOption => write!(f, "Invalid option."),
             GooseError::InvalidWaitTime { .. } => write!(f, "Invalid wait time specified."),
-            GooseError::InvalidWeight => write!(f, "Invalid weight specified."),
+            GooseError::InvalidWeight { .. } => write!(f, "Invalid weight specified."),
             GooseError::NoTaskSets => write!(f, "No task sets defined."),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,34 +367,51 @@ pub struct Socket {}
 /// Goose optionally tracks statistics about requests made during a load test.
 pub type GooseRequestStats = HashMap<String, GooseRequest>;
 
-/// Definition of all errors Goose can return.
+/// Definition of all errors a GooseAttack can return.
 #[derive(Debug)]
 pub enum GooseError {
+    /// Contains an io::Error.
     Io(io::Error),
+    /// Contains a reqwest::Error.
     Reqwest(reqwest::Error),
+    /// Failed attempt to use code that requires a compile-time feature be enabled. The missing
+    /// feature is named in `.feature`. An optional explanation may be found in `.detail`.
     FeatureNotEnabled {
         feature: String,
         detail: Option<String>,
     },
+    /// Failed to parse hostname. The invalid hostname that caused this error is found in
+    /// `.host`. An optional explanation may be found in `.detail`. The lower level
+    /// `url::ParseError` is contained in `.parse_error`.
     InvalidHost {
         host: String,
         detail: Option<String>,
         parse_error: url::ParseError,
     },
+    /// Invalid option or value specified, may only be invalid in context. The invalid option
+    /// is found in `.option`, while the invalid value is found in `.value`. An optional
+    /// explanation providing context may be found in `.detail`.
     InvalidOption {
         option: String,
         value: String,
         detail: Option<String>,
     },
+    /// Invalid wait time specified. The minimum wait time and maximum wait time are found in
+    /// `.min_wait` and `.max_wait` respectively. An optional explanation providing context may
+    /// be found in `.detail`.
     InvalidWaitTime {
         min_wait: usize,
         max_wait: usize,
         detail: Option<String>,
     },
+    /// Invalid weight specified. The invalid weight value is found in `.weight`. An optional
+    // explanation providing context may be found in `.detail`.
     InvalidWeight {
         weight: usize,
         detail: Option<String>,
     },
+    /// `GooseAttack` has no `GooseTaskSet` defined. An optional explanation may be found in
+    /// `.detail`.
     NoTaskSets {
         detail: Option<String>,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,7 +628,7 @@ impl GooseAttack {
             if self.configuration.stats_log_file.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: "--stats-log-format".to_string(),
-                    value: self.configuration.stats_log_format.to_string(),
+                    value: self.configuration.stats_log_format,
                     detail: Some(
                         "--stats-log-file must be enabled when setting --stats-log-format."
                             .to_string(),
@@ -641,7 +641,7 @@ impl GooseAttack {
             if !options.contains(&self.configuration.stats_log_format.as_str()) {
                 return Err(GooseError::InvalidOption {
                     option: "--stats-log-format".to_string(),
-                    value: self.configuration.stats_log_format.to_string(),
+                    value: self.configuration.stats_log_format,
                     detail: Some(format!(
                         "--stats-log-format must be set to one of: {}.",
                         options.join(", ")
@@ -655,7 +655,7 @@ impl GooseAttack {
             if self.configuration.debug_log_file.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: "--debug-log-format".to_string(),
-                    value: self.configuration.debug_log_format.to_string(),
+                    value: self.configuration.debug_log_format,
                     detail: Some(
                         "--debug-log-file must be enabled when setting --debug-log-format."
                             .to_string(),
@@ -668,7 +668,7 @@ impl GooseAttack {
             if !options.contains(&self.configuration.debug_log_format.as_str()) {
                 return Err(GooseError::InvalidOption {
                     option: "--debug-log-format".to_string(),
-                    value: self.configuration.debug_log_format.to_string(),
+                    value: self.configuration.debug_log_format,
                     detail: Some(format!(
                         "--debug-log-format must be set to one of: {}.",
                         options.join(", ")
@@ -1001,7 +1001,7 @@ impl GooseAttack {
             if !self.configuration.debug_log_file.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: "--debug-log-file".to_string(),
-                    value: self.configuration.debug_log_file.to_string(),
+                    value: self.configuration.debug_log_file,
                     detail: Some(
                         "--debug-log-file can only be enabled in stand-alone or worker mode"
                             .to_string(),
@@ -1065,7 +1065,7 @@ impl GooseAttack {
             if !self.configuration.host.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: "--host".to_string(),
-                    value: self.configuration.host.to_string(),
+                    value: self.configuration.host,
                     detail: Some("--host is only available to the manager".to_string()),
                 });
             }
@@ -1073,7 +1073,7 @@ impl GooseAttack {
             if self.configuration.manager_bind_host != "0.0.0.0" {
                 return Err(GooseError::InvalidOption {
                     option: "--manager-bind-host".to_string(),
-                    value: self.configuration.manager_bind_host.to_string(),
+                    value: self.configuration.manager_bind_host,
                     detail: Some(
                         "--manager-bind-host is only available to the manager".to_string(),
                     ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -706,9 +706,8 @@ impl GooseAttack {
                             value: self.users.to_string(),
                             detail: Some("at least 1 user is required.".to_string()),
                         });
-                    } else {
-                        0
                     }
+                    0
                 } else {
                     if self.configuration.worker {
                         return Err(GooseError::InvalidOption {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,16 +403,7 @@ pub enum GooseError {
 
 impl fmt::Display for GooseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            GooseError::Io(ref err) => err.fmt(f),
-            GooseError::Reqwest(ref err) => err.fmt(f),
-            GooseError::FeatureNotEnabled { .. } => write!(f, "Compile time feature not enabled."),
-            GooseError::InvalidHost { .. } => write!(f, "Unable to parse host"),
-            GooseError::InvalidOption { .. } => write!(f, "Invalid option."),
-            GooseError::InvalidWaitTime { .. } => write!(f, "Invalid wait time specified."),
-            GooseError::InvalidWeight { .. } => write!(f, "Invalid weight specified."),
-            GooseError::NoTaskSets { .. } => write!(f, "No task sets defined."),
-        }
+        fmt::Display::fmt(&self, f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,9 +412,7 @@ pub enum GooseError {
     },
     /// `GooseAttack` has no `GooseTaskSet` defined. An optional explanation may be found in
     /// `.detail`.
-    NoTaskSets {
-        detail: Option<String>,
-    },
+    NoTaskSets { detail: Option<String> },
 }
 
 // Define how to display errors.
@@ -430,14 +428,10 @@ impl std::error::Error for GooseError {
         match *self {
             GooseError::Io(ref source) => Some(source),
             GooseError::Reqwest(ref source) => Some(source),
-            GooseError::FeatureNotEnabled { .. } => None,
             GooseError::InvalidHost {
                 ref parse_error, ..
             } => Some(parse_error),
-            GooseError::InvalidOption { .. } => None,
-            GooseError::InvalidWaitTime { .. } => None,
-            GooseError::InvalidWeight { .. } => None,
-            GooseError::NoTaskSets { .. } => None,
+            _ => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,10 @@ pub type GooseRequestStats = HashMap<String, GooseRequest>;
 pub enum GooseError {
     Io(io::Error),
     Reqwest(reqwest::Error),
-    FeatureNotEnabled,
+    FeatureNotEnabled {
+        feature: String,
+        detail: Option<String>,
+    },
     InvalidHost {
         host: String,
         detail: Option<String>,
@@ -390,7 +393,7 @@ impl fmt::Display for GooseError {
         match *self {
             GooseError::Io(ref err) => err.fmt(f),
             GooseError::Reqwest(ref err) => err.fmt(f),
-            GooseError::FeatureNotEnabled => write!(f, "Compile time feature not enabled."),
+            GooseError::FeatureNotEnabled { .. } => write!(f, "Compile time feature not enabled."),
             GooseError::InvalidHost { .. } => write!(f, "Unable to parse host"),
             GooseError::InvalidOption => write!(f, "Invalid option."),
             GooseError::InvalidWaitTime => write!(f, "Invalid wait time specified."),
@@ -1081,10 +1084,7 @@ impl GooseAttack {
 
             #[cfg(not(feature = "gaggle"))]
             {
-                error!(
-                    "goose must be recompiled with `--features gaggle` to start in manager mode"
-                );
-                return Err(GooseError::FeatureNotEnabled);
+                return Err(GooseError::FeatureNotEnabled { feature: "gaggle".to_string(), detail: Some("goose must be recompiled with `--features gaggle` to start in manager mode".to_string()) });
             }
         }
         // Start goose in worker mode.
@@ -1097,8 +1097,13 @@ impl GooseAttack {
 
             #[cfg(not(feature = "gaggle"))]
             {
-                error!("goose must be recompiled with `--features gaggle` to start in worker mode");
-                return Err(GooseError::FeatureNotEnabled);
+                return Err(GooseError::FeatureNotEnabled {
+                    feature: "gaggle".to_string(),
+                    detail: Some(
+                        "goose must be recompiled with `--features gaggle` to start in worker mode"
+                            .to_string(),
+                    ),
+                });
             }
         }
         // Start goose in single-process mode.

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -25,11 +25,10 @@ pub async fn logger_main(
                 Some(BufWriter::new(f))
             }
             Err(e) => {
-                error!(
+                panic!(
                     "failed to create debug_log_file ({}): {}",
                     configuration.debug_log_file, e
                 );
-                std::process::exit(1);
             }
         }
     }


### PR DESCRIPTION
The goal of this PR is to make errors more rich, allowing application developers the option of what they want to display. In our examples, `main()` returns the errors so they are simply displayed.

 - enriched `GooseError::InvalidHost`, for example:
   ```
   $ cargo run --example drupal_loadtest -- --host=foo
       Finished dev [unoptimized + debuginfo] target(s) in 0.08s
        Running `target/debug/examples/drupal_loadtest --host=foo`
   Error: InvalidHost { host: "foo", detail: Some("Failure parsing host specified with --host"), parse_error: RelativeUrlWithoutBase }
   ```
 - enriched `GooseError::FeatureNotEnabled`, for example:
   ```
   $ cargo run --example drupal_loadtest -- --worker
       Finished dev [unoptimized + debuginfo] target(s) in 0.08s
        Running `target/debug/examples/drupal_loadtest --worker`
   Error: FeatureNotEnabled { feature: "gaggle", detail: Some("goose must be recompiled with `--features gaggle` to start in worker mode") }
   ```

 - enriched `GooseError::InvalidWaitTime`, for example:
   ```
        Running `target/debug/examples/drupal_loadtest`
   Error: InvalidWaitTime { min_wait: 5, max_wait: 1, detail: Some("min_wait can not be larger than max_wait") }

   ```

 - enriched `GooseError::InvalidWeight`, for example:
```
        Running `target/debug/examples/drupal_loadtest`
   Error: InvalidWeight { weight: 0, detail: Some("weight of 0 not allowed") }
```

 - enriched `GooseError::NoTaskSets`
   ```
        Running `target/debug/examples/drupal_loadtest`
   Error: NoTaskSets { detail: Some("no task sets defined") }
   ```

- enriched `GooseError::InvalidOption`
   ```
   $ cargo run --example drupal_loadtest -- --host https://127.0.0.1/ --expect-workers=10
       Finished dev [unoptimized + debuginfo] target(s) in 0.08s
        Running `target/debug/examples/drupal_loadtest --host 'https://127.0.0.1/' --expect-workers=10`
   Error: InvalidOption { option: "--expect-workers", value: "10", detail: Some("--expect-workers is only available when running in manager mode") }
   ```