### PR TITLE
expose statistics from GooseAttack via GooseStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.9.1-dev
- - expose statistics from load test via `.get_stats()` as `GooseStats`
+ - expose stats from load test via `display_and_get()` and `.get()` as `GooseStats`
 
 ## 0.9.0 July 23, 2020
  - fix code documentation, requests are async and require await

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.9.1-dev
+ - expose statistics from load test via `.get_stats()` as `GooseStats`
 
 ## 0.9.0 July 23, 2020
  - fix code documentation, requests are async and require await

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## 0.9.1-dev
- - expose stats from load test via `display_and_get()` and `.get()` as `GooseStats`
+ - return `GooseStats` from `GooseAttack` `.execute()`
+ - rework as methods of `GooseStats`: `.print()`, `.print_running()`, `print_requests()`,
+   `print_response_times()`, `print_percentiles()`, and `print_status_codes()`
 
 ## 0.9.0 July 23, 2020
  - fix code documentation, requests are async and require await

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -78,7 +78,7 @@ fn main() -> Result<(), GooseError> {
                 ),
         )
         .execute()?
-        .print();
+        .print()?;
 
     Ok(())
 }

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -78,7 +78,7 @@ fn main() -> Result<(), GooseError> {
                 ),
         )
         .execute()?
-        .display();
+        .print();
 
     Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), GooseError> {
                 .register_task(task!(website_about)),
         )
         .execute()?
-        .print();
+        .print()?;
 
     Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), GooseError> {
                 .register_task(task!(website_about)),
         )
         .execute()?
-        .display();
+        .print();
 
     Ok(())
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1825,7 +1825,7 @@ impl GooseUser {
     /// use goose::prelude::*;
     ///
     /// fn main() -> Result<(), GooseError> {
-    ///     GooseAttack::initialize()?
+    ///     let goose_stats = GooseAttack::initialize()?
     ///         .register_taskset(taskset!("LoadtestTasks").set_host("http//foo.example.com/")
     ///             .set_wait_time(0, 3)?
     ///             .register_task(task!(task_foo).set_weight(10)?)

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1825,7 +1825,7 @@ impl GooseUser {
     /// use goose::prelude::*;
     ///
     /// fn main() -> Result<(), GooseError> {
-    ///     let goose_stats = GooseAttack::initialize()?
+    ///     let _goose_stats = GooseAttack::initialize()?
     ///         .register_taskset(taskset!("LoadtestTasks").set_host("http//foo.example.com/")
     ///             .set_wait_time(0, 3)?
     ///             .register_task(task!(task_foo).set_weight(10)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,7 @@ impl GooseAttack {
             run_time: 0,
             users: 0,
             started: None,
-            stats: GooseStats::new(),
+            stats: GooseStats::default(),
         };
         Ok(goose_attack.setup()?)
     }
@@ -524,7 +524,7 @@ impl GooseAttack {
             run_time: 0,
             users: 0,
             started: None,
-            stats: GooseStats::new(),
+            stats: GooseStats::default(),
         }
     }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -214,7 +214,8 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
             {
                 // Reset timer each time we display statistics.
                 running_statistics_timer = time::Instant::now();
-                goose_attack.stats.duration = goose_attack.started.unwrap().elapsed().as_secs() as usize;
+                goose_attack.stats.duration =
+                    goose_attack.started.unwrap().elapsed().as_secs() as usize;
                 goose_attack.stats.print_running();
             }
         } else if canceled.load(Ordering::SeqCst) {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -244,7 +244,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                                 trace!("request_key: {}", request_key);
                                 let merged_request;
                                 if let Some(parent_request) =
-                                    goose_attack.merged_requests.get(&request_key)
+                                    goose_attack.statistics.get(&request_key)
                                 {
                                     merged_request = merge_from_worker(
                                         parent_request,
@@ -256,7 +256,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                                     merged_request = request.clone();
                                 }
                                 goose_attack
-                                    .merged_requests
+                                    .statistics
                                     .insert(request_key.to_string(), merged_request);
                             }
                         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use crate::goose::{
     GooseMethod, GooseTask, GooseTaskError, GooseTaskResult, GooseTaskSet, GooseUser,
 };
-pub use crate::{task, taskset, GooseAttack, GooseError, GooseRequestStats};
+pub use crate::stats::{GooseRequestStats, GooseStats};
+pub use crate::{task, taskset, GooseAttack, GooseError};

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -14,7 +14,7 @@ pub type GooseRequestStats = HashMap<String, GooseRequest>;
 ///
 /// # Example
 /// ```rust,no_run
-///     use goose::prelude::*;
+/// use goose::prelude::*;
 ///
 /// fn main() -> Result<(), GooseError> {
 ///     let goose_stats: GooseStats = GooseAttack::initialize()?
@@ -54,7 +54,7 @@ impl GooseStats {
     ///
     /// # Example
     /// ```rust,no_run
-    ///     use goose::prelude::*;
+    /// use goose::prelude::*;
     ///
     /// fn main() -> Result<(), GooseError> {
     ///     GooseAttack::initialize()?
@@ -459,9 +459,9 @@ impl GooseStats {
                     new_count = *count;
                 }
                 aggregated_status_code_counts.insert(*status_code, new_count);
-                // If the exit_early flag is still true, there are no status codes in
-                // the request stats, so exit early.
             }
+            // If the exit_early flag is still true, there are no status codes in
+            // the request stats, exit.
             if exit_early {
                 return Ok(self);
             }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -3,7 +3,467 @@ use num_format::{Locale, ToFormattedString};
 use std::collections::{BTreeMap, HashMap};
 use std::f32;
 
-use crate::{util, GooseAttack, GooseStats};
+use crate::goose::GooseRequest;
+use crate::util;
+
+/// Goose optionally tracks statistics about requests made during a load test.
+pub type GooseRequestStats = HashMap<String, GooseRequest>;
+
+/// Statistics collected during a Goose load test.
+///
+/// # Example
+/// ```rust,no_run
+///     use goose::prelude::*;
+///
+/// fn main() -> Result<(), GooseError> {
+///     let goose_stats: GooseStats = GooseAttack::initialize()?
+///         .register_taskset(taskset!("ExampleUsers")
+///             .register_task(task!(example_task))
+///         )
+///         .execute()?;
+///
+///     // It is now possible to do something with the statistics collected by Goose.
+///     // For now, we'll just pretty-print the entire object.
+///     println!("{:#?}", goose_stats);
+///
+///     Ok(())
+/// }
+///
+/// async fn example_task(user: &GooseUser) -> GooseTaskResult {
+///     let _goose = user.get("/").await?;
+///
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct GooseStats {
+    /// A hash of the load test, useful to verify if different statistics are from
+    /// the same load test.
+    pub hash: u64,
+    /// How many seconds the load test ran.
+    pub duration: usize,
+    /// Total number of users simulated during this load test.
+    pub users: usize,
+    /// Goose request statistics.
+    pub requests: GooseRequestStats,
+}
+
+impl GooseStats {
+    /// Create a new, empty GooseStats object.
+    pub fn new() -> Self {
+        GooseStats {
+            hash: 0,
+            duration: 0,
+            users: 0,
+            requests: HashMap::new(),
+        }
+    }
+
+    /// Consumes and display all statistics from a completed load test.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    ///     use goose::prelude::*;
+    ///
+    /// fn main() -> Result<(), GooseError> {
+    ///     GooseAttack::initialize()?
+    ///         .register_taskset(taskset!("ExampleUsers")
+    ///             .register_task(task!(example_task))
+    ///         )
+    ///         .execute()?
+    ///         .print();
+    ///
+    ///     Ok(())
+    /// }
+    ///
+    /// async fn example_task(user: &GooseUser) -> GooseTaskResult {
+    ///     let _goose = user.get("/").await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn print(&self) {
+        info!("printing statistics after {} seconds...", self.duration);
+
+        self.print_requests()
+            .print_response_times()
+            .print_percentiles()
+            .print_status_codes();
+    }
+
+    /// Consumes and displays statistics from a running load test.
+    pub fn print_running(&self) {
+        info!(
+            "printing running statistics after {} seconds...",
+            self.duration
+        );
+
+        self.print_requests().print_response_times();
+
+        println!();
+    }
+
+    /// Display a table of requests and fails.
+    pub fn print_requests(&self) -> &GooseStats {
+        // Display stats from merged HashMap
+        println!("------------------------------------------------------------------------------ ");
+        println!(
+            " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
+            "Name", "# reqs", "# fails", "req/s", "fail/s"
+        );
+        println!(" ----------------------------------------------------------------------------- ");
+        let mut aggregate_fail_count = 0;
+        let mut aggregate_total_count = 0;
+        for (request_key, request) in self.requests.iter().sorted() {
+            let total_count = request.success_count + request.fail_count;
+            let fail_percent = if request.fail_count > 0 {
+                request.fail_count as f32 / total_count as f32 * 100.0
+            } else {
+                0.0
+            };
+            // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
+            if fail_percent as usize == 100 || fail_percent as usize == 0 {
+                println!(
+                    " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
+                    util::truncate_string(&request_key, 23),
+                    total_count.to_formatted_string(&Locale::en),
+                    format!(
+                        "{} ({}%)",
+                        request.fail_count.to_formatted_string(&Locale::en),
+                        fail_percent as usize
+                    ),
+                    (total_count / self.duration).to_formatted_string(&Locale::en),
+                    (request.fail_count / self.duration).to_formatted_string(&Locale::en),
+                );
+            } else {
+                println!(
+                    " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
+                    util::truncate_string(&request_key, 23),
+                    total_count.to_formatted_string(&Locale::en),
+                    format!(
+                        "{} ({:.1}%)",
+                        request.fail_count.to_formatted_string(&Locale::en),
+                        fail_percent
+                    ),
+                    (total_count / self.duration).to_formatted_string(&Locale::en),
+                    (request.fail_count / self.duration).to_formatted_string(&Locale::en),
+                );
+            }
+            aggregate_total_count += total_count;
+            aggregate_fail_count += request.fail_count;
+        }
+        if self.requests.len() > 1 {
+            let aggregate_fail_percent = if aggregate_fail_count > 0 {
+                aggregate_fail_count as f32 / aggregate_total_count as f32 * 100.0
+            } else {
+                0.0
+            };
+            println!(
+                " ------------------------+----------------+----------------+--------+--------- "
+            );
+            // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
+            if aggregate_fail_percent as usize == 100 || aggregate_fail_percent as usize == 0 {
+                println!(
+                    " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
+                    "Aggregated",
+                    aggregate_total_count.to_formatted_string(&Locale::en),
+                    format!(
+                        "{} ({}%)",
+                        aggregate_fail_count.to_formatted_string(&Locale::en),
+                        aggregate_fail_percent as usize
+                    ),
+                    (aggregate_total_count / self.duration).to_formatted_string(&Locale::en),
+                    (aggregate_fail_count / self.duration).to_formatted_string(&Locale::en),
+                );
+            } else {
+                println!(
+                    " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
+                    "Aggregated",
+                    aggregate_total_count.to_formatted_string(&Locale::en),
+                    format!(
+                        "{} ({:.1}%)",
+                        aggregate_fail_count.to_formatted_string(&Locale::en),
+                        aggregate_fail_percent
+                    ),
+                    (aggregate_total_count / self.duration).to_formatted_string(&Locale::en),
+                    (aggregate_fail_count / self.duration).to_formatted_string(&Locale::en),
+                );
+            }
+        }
+
+        self
+    }
+
+    // Display a table of response times.
+    pub fn print_response_times(&self) -> &GooseStats {
+        let mut aggregate_response_times: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut aggregate_total_response_time: usize = 0;
+        let mut aggregate_response_time_counter: usize = 0;
+        let mut aggregate_min_response_time: usize = 0;
+        let mut aggregate_max_response_time: usize = 0;
+        println!("-------------------------------------------------------------------------------");
+        println!(
+            " {:<23} | {:<10} | {:<10} | {:<10} | {:<10}",
+            "Name", "Avg (ms)", "Min", "Max", "Median"
+        );
+        println!(" ----------------------------------------------------------------------------- ");
+        for (request_key, request) in self.requests.iter().sorted() {
+            // Iterate over user response times, and merge into global response times.
+            aggregate_response_times =
+                merge_response_times(aggregate_response_times, request.response_times.clone());
+
+            // Increment total response time counter.
+            aggregate_total_response_time += &request.total_response_time;
+
+            // Increment counter tracking individual response times seen.
+            aggregate_response_time_counter += &request.response_time_counter;
+
+            // If user had new fastest response time, update global fastest response time.
+            aggregate_min_response_time =
+                update_min_response_time(aggregate_min_response_time, request.min_response_time);
+
+            // If user had new slowest response time, update global slowest resposne time.
+            aggregate_max_response_time =
+                update_max_response_time(aggregate_max_response_time, request.max_response_time);
+
+            println!(
+                " {:<23} | {:<10.2} | {:<10.2} | {:<10.2} | {:<10.2}",
+                util::truncate_string(&request_key, 23),
+                request.total_response_time / request.response_time_counter,
+                request.min_response_time,
+                request.max_response_time,
+                util::median(
+                    &request.response_times,
+                    request.response_time_counter,
+                    request.min_response_time,
+                    request.max_response_time
+                ),
+            );
+        }
+        if self.requests.len() > 1 {
+            println!(
+                " ------------------------+------------+------------+------------+------------- "
+            );
+            if aggregate_response_time_counter == 0 {
+                aggregate_response_time_counter = 1;
+            }
+            println!(
+                " {:<23} | {:<10.2} | {:<10.2} | {:<10.2} | {:<10.2}",
+                "Aggregated",
+                aggregate_total_response_time / aggregate_response_time_counter,
+                aggregate_min_response_time,
+                aggregate_max_response_time,
+                util::median(
+                    &aggregate_response_times,
+                    aggregate_response_time_counter,
+                    aggregate_min_response_time,
+                    aggregate_max_response_time
+                ),
+            );
+        }
+
+        self
+    }
+
+    // Display slowest response times within several percentiles.
+    pub fn print_percentiles(&self) -> &GooseStats {
+        let mut aggregate_response_times: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut aggregate_total_response_time: usize = 0;
+        let mut aggregate_response_time_counter: usize = 0;
+        let mut aggregate_min_response_time: usize = 0;
+        let mut aggregate_max_response_time: usize = 0;
+        println!("-------------------------------------------------------------------------------");
+        println!(" Slowest page load within specified percentile of requests (in ms):");
+        println!(" ------------------------------------------------------------------------------");
+        println!(
+            " {:<23} | {:<6} | {:<6} | {:<6} | {:<6} | {:<6} | {:6}",
+            "Name", "50%", "75%", "98%", "99%", "99.9%", "99.99%"
+        );
+        println!(" ----------------------------------------------------------------------------- ");
+        for (request_key, request) in self.requests.iter().sorted() {
+            // Iterate over user response times, and merge into global response times.
+            aggregate_response_times =
+                merge_response_times(aggregate_response_times, request.response_times.clone());
+
+            // Increment total response time counter.
+            aggregate_total_response_time += &request.total_response_time;
+
+            // Increment counter tracking individual response times seen.
+            aggregate_response_time_counter += &request.response_time_counter;
+
+            // If user had new fastest response time, update global fastest response time.
+            aggregate_min_response_time =
+                update_min_response_time(aggregate_min_response_time, request.min_response_time);
+
+            // If user had new slowest response time, update global slowest resposne time.
+            aggregate_max_response_time =
+                update_max_response_time(aggregate_max_response_time, request.max_response_time);
+            // Sort response times so we can calculate a mean.
+            println!(
+                " {:<23} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:6.2}",
+                util::truncate_string(&request_key, 23),
+                calculate_response_time_percentile(
+                    &request.response_times,
+                    request.response_time_counter,
+                    request.min_response_time,
+                    request.max_response_time,
+                    0.5
+                ),
+                calculate_response_time_percentile(
+                    &request.response_times,
+                    request.response_time_counter,
+                    request.min_response_time,
+                    request.max_response_time,
+                    0.75
+                ),
+                calculate_response_time_percentile(
+                    &request.response_times,
+                    request.response_time_counter,
+                    request.min_response_time,
+                    request.max_response_time,
+                    0.98
+                ),
+                calculate_response_time_percentile(
+                    &request.response_times,
+                    request.response_time_counter,
+                    request.min_response_time,
+                    request.max_response_time,
+                    0.99
+                ),
+                calculate_response_time_percentile(
+                    &request.response_times,
+                    request.response_time_counter,
+                    request.min_response_time,
+                    request.max_response_time,
+                    0.999
+                ),
+                calculate_response_time_percentile(
+                    &request.response_times,
+                    request.response_time_counter,
+                    request.min_response_time,
+                    request.max_response_time,
+                    0.999
+                ),
+            );
+        }
+        if self.requests.len() > 1 {
+            println!(
+                " ------------------------+--------+--------+--------+--------+--------+------- "
+            );
+            println!(
+                " {:<23} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:6.2}",
+                "Aggregated",
+                calculate_response_time_percentile(
+                    &aggregate_response_times,
+                    aggregate_response_time_counter,
+                    aggregate_min_response_time,
+                    aggregate_max_response_time,
+                    0.5
+                ),
+                calculate_response_time_percentile(
+                    &aggregate_response_times,
+                    aggregate_response_time_counter,
+                    aggregate_min_response_time,
+                    aggregate_max_response_time,
+                    0.75
+                ),
+                calculate_response_time_percentile(
+                    &aggregate_response_times,
+                    aggregate_response_time_counter,
+                    aggregate_min_response_time,
+                    aggregate_max_response_time,
+                    0.98
+                ),
+                calculate_response_time_percentile(
+                    &aggregate_response_times,
+                    aggregate_response_time_counter,
+                    aggregate_min_response_time,
+                    aggregate_max_response_time,
+                    0.99
+                ),
+                calculate_response_time_percentile(
+                    &aggregate_response_times,
+                    aggregate_response_time_counter,
+                    aggregate_min_response_time,
+                    aggregate_max_response_time,
+                    0.999
+                ),
+                calculate_response_time_percentile(
+                    &aggregate_response_times,
+                    aggregate_response_time_counter,
+                    aggregate_min_response_time,
+                    aggregate_max_response_time,
+                    0.9999
+                ),
+            );
+        }
+
+        self
+    }
+
+    // Display a table of response status codes.
+    fn print_status_codes(&self) -> &GooseStats {
+        // @TODO: only display if enabled
+        println!("-------------------------------------------------------------------------------");
+        println!(" {:<23} | {:<25} ", "Name", "Status codes");
+        println!(" ----------------------------------------------------------------------------- ");
+        let mut aggregated_status_code_counts: HashMap<u16, usize> = HashMap::new();
+        for (request_key, request) in self.requests.iter().sorted() {
+            let mut codes: String = "".to_string();
+            for (status_code, count) in &request.status_code_counts {
+                if codes.is_empty() {
+                    codes = format!(
+                        "{} [{}]",
+                        count.to_formatted_string(&Locale::en),
+                        status_code
+                    );
+                } else {
+                    codes = format!(
+                        "{}, {} [{}]",
+                        codes.clone(),
+                        count.to_formatted_string(&Locale::en),
+                        status_code
+                    );
+                }
+                let new_count;
+                if let Some(existing_status_code_count) =
+                    aggregated_status_code_counts.get(&status_code)
+                {
+                    new_count = *existing_status_code_count + *count;
+                } else {
+                    new_count = *count;
+                }
+                aggregated_status_code_counts.insert(*status_code, new_count);
+            }
+            println!(
+                " {:<23} | {:<25}",
+                util::truncate_string(&request_key, 23),
+                codes,
+            );
+        }
+        println!("-------------------------------------------------------------------------------");
+        let mut codes: String = "".to_string();
+        for (status_code, count) in &aggregated_status_code_counts {
+            if codes.is_empty() {
+                codes = format!(
+                    "{} [{}]",
+                    count.to_formatted_string(&Locale::en),
+                    status_code
+                );
+            } else {
+                codes = format!(
+                    "{}, {} [{}]",
+                    codes.clone(),
+                    count.to_formatted_string(&Locale::en),
+                    status_code
+                );
+            }
+        }
+        println!(" {:<23} | {:<25} ", "Aggregated", codes);
+
+        self
+    }
+}
 
 /// A helper function that merges together response times.
 ///
@@ -71,358 +531,6 @@ fn calculate_response_time_percentile(
         }
     }
     0
-}
-
-/// Display a table of requests and fails.
-pub fn print_requests_and_fails(stats: &GooseStats) {
-    debug!("entering print_requests_and_fails");
-    // Display stats from merged HashMap
-    println!("------------------------------------------------------------------------------ ");
-    println!(
-        " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
-        "Name", "# reqs", "# fails", "req/s", "fail/s"
-    );
-    println!(" ----------------------------------------------------------------------------- ");
-    let mut aggregate_fail_count = 0;
-    let mut aggregate_total_count = 0;
-    for (request_key, request) in stats.requests.iter().sorted() {
-        let total_count = request.success_count + request.fail_count;
-        let fail_percent = if request.fail_count > 0 {
-            request.fail_count as f32 / total_count as f32 * 100.0
-        } else {
-            0.0
-        };
-        // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
-        if fail_percent as usize == 100 || fail_percent as usize == 0 {
-            println!(
-                " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
-                util::truncate_string(&request_key, 23),
-                total_count.to_formatted_string(&Locale::en),
-                format!(
-                    "{} ({}%)",
-                    request.fail_count.to_formatted_string(&Locale::en),
-                    fail_percent as usize
-                ),
-                (total_count / stats.duration).to_formatted_string(&Locale::en),
-                (request.fail_count / stats.duration).to_formatted_string(&Locale::en),
-            );
-        } else {
-            println!(
-                " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
-                util::truncate_string(&request_key, 23),
-                total_count.to_formatted_string(&Locale::en),
-                format!(
-                    "{} ({:.1}%)",
-                    request.fail_count.to_formatted_string(&Locale::en),
-                    fail_percent
-                ),
-                (total_count / stats.duration).to_formatted_string(&Locale::en),
-                (request.fail_count / stats.duration).to_formatted_string(&Locale::en),
-            );
-        }
-        aggregate_total_count += total_count;
-        aggregate_fail_count += request.fail_count;
-    }
-    if stats.requests.len() > 1 {
-        let aggregate_fail_percent = if aggregate_fail_count > 0 {
-            aggregate_fail_count as f32 / aggregate_total_count as f32 * 100.0
-        } else {
-            0.0
-        };
-        println!(" ------------------------+----------------+----------------+--------+--------- ");
-        // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
-        if aggregate_fail_percent as usize == 100 || aggregate_fail_percent as usize == 0 {
-            println!(
-                " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
-                "Aggregated",
-                aggregate_total_count.to_formatted_string(&Locale::en),
-                format!(
-                    "{} ({}%)",
-                    aggregate_fail_count.to_formatted_string(&Locale::en),
-                    aggregate_fail_percent as usize
-                ),
-                (aggregate_total_count / stats.duration).to_formatted_string(&Locale::en),
-                (aggregate_fail_count / stats.duration).to_formatted_string(&Locale::en),
-            );
-        } else {
-            println!(
-                " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
-                "Aggregated",
-                aggregate_total_count.to_formatted_string(&Locale::en),
-                format!(
-                    "{} ({:.1}%)",
-                    aggregate_fail_count.to_formatted_string(&Locale::en),
-                    aggregate_fail_percent
-                ),
-                (aggregate_total_count / stats.duration).to_formatted_string(&Locale::en),
-                (aggregate_fail_count / stats.duration).to_formatted_string(&Locale::en),
-            );
-        }
-    }
-}
-
-fn print_response_times(stats: &GooseStats, display_percentiles: bool) {
-    debug!("entering print_response_times");
-    let mut aggregate_response_times: BTreeMap<usize, usize> = BTreeMap::new();
-    let mut aggregate_total_response_time: usize = 0;
-    let mut aggregate_response_time_counter: usize = 0;
-    let mut aggregate_min_response_time: usize = 0;
-    let mut aggregate_max_response_time: usize = 0;
-    println!("-------------------------------------------------------------------------------");
-    println!(
-        " {:<23} | {:<10} | {:<10} | {:<10} | {:<10}",
-        "Name", "Avg (ms)", "Min", "Max", "Median"
-    );
-    println!(" ----------------------------------------------------------------------------- ");
-    for (request_key, request) in stats.requests.iter().sorted() {
-        // Iterate over user response times, and merge into global response times.
-        aggregate_response_times =
-            merge_response_times(aggregate_response_times, request.response_times.clone());
-
-        // Increment total response time counter.
-        aggregate_total_response_time += &request.total_response_time;
-
-        // Increment counter tracking individual response times seen.
-        aggregate_response_time_counter += &request.response_time_counter;
-
-        // If user had new fastest response time, update global fastest response time.
-        aggregate_min_response_time =
-            update_min_response_time(aggregate_min_response_time, request.min_response_time);
-
-        // If user had new slowest response time, update global slowest resposne time.
-        aggregate_max_response_time =
-            update_max_response_time(aggregate_max_response_time, request.max_response_time);
-
-        println!(
-            " {:<23} | {:<10.2} | {:<10.2} | {:<10.2} | {:<10.2}",
-            util::truncate_string(&request_key, 23),
-            request.total_response_time / request.response_time_counter,
-            request.min_response_time,
-            request.max_response_time,
-            util::median(
-                &request.response_times,
-                request.response_time_counter,
-                request.min_response_time,
-                request.max_response_time
-            ),
-        );
-    }
-    if stats.requests.len() > 1 {
-        println!(" ------------------------+------------+------------+------------+------------- ");
-        if aggregate_response_time_counter == 0 {
-            aggregate_response_time_counter = 1;
-        }
-        println!(
-            " {:<23} | {:<10.2} | {:<10.2} | {:<10.2} | {:<10.2}",
-            "Aggregated",
-            aggregate_total_response_time / aggregate_response_time_counter,
-            aggregate_min_response_time,
-            aggregate_max_response_time,
-            util::median(
-                &aggregate_response_times,
-                aggregate_response_time_counter,
-                aggregate_min_response_time,
-                aggregate_max_response_time
-            ),
-        );
-    }
-
-    if display_percentiles {
-        println!("-------------------------------------------------------------------------------");
-        println!(" Slowest page load within specified percentile of requests (in ms):");
-        println!(" ------------------------------------------------------------------------------");
-        println!(
-            " {:<23} | {:<6} | {:<6} | {:<6} | {:<6} | {:<6} | {:6}",
-            "Name", "50%", "75%", "98%", "99%", "99.9%", "99.99%"
-        );
-        println!(" ----------------------------------------------------------------------------- ");
-        for (request_key, request) in stats.requests.iter().sorted() {
-            // Sort response times so we can calculate a mean.
-            println!(
-                " {:<23} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:6.2}",
-                util::truncate_string(&request_key, 23),
-                calculate_response_time_percentile(
-                    &request.response_times,
-                    request.response_time_counter,
-                    request.min_response_time,
-                    request.max_response_time,
-                    0.5
-                ),
-                calculate_response_time_percentile(
-                    &request.response_times,
-                    request.response_time_counter,
-                    request.min_response_time,
-                    request.max_response_time,
-                    0.75
-                ),
-                calculate_response_time_percentile(
-                    &request.response_times,
-                    request.response_time_counter,
-                    request.min_response_time,
-                    request.max_response_time,
-                    0.98
-                ),
-                calculate_response_time_percentile(
-                    &request.response_times,
-                    request.response_time_counter,
-                    request.min_response_time,
-                    request.max_response_time,
-                    0.99
-                ),
-                calculate_response_time_percentile(
-                    &request.response_times,
-                    request.response_time_counter,
-                    request.min_response_time,
-                    request.max_response_time,
-                    0.999
-                ),
-                calculate_response_time_percentile(
-                    &request.response_times,
-                    request.response_time_counter,
-                    request.min_response_time,
-                    request.max_response_time,
-                    0.999
-                ),
-            );
-        }
-        if stats.requests.len() > 1 {
-            println!(
-                " ------------------------+--------+--------+--------+--------+--------+------- "
-            );
-            println!(
-                " {:<23} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:6.2}",
-                "Aggregated",
-                calculate_response_time_percentile(
-                    &aggregate_response_times,
-                    aggregate_response_time_counter,
-                    aggregate_min_response_time,
-                    aggregate_max_response_time,
-                    0.5
-                ),
-                calculate_response_time_percentile(
-                    &aggregate_response_times,
-                    aggregate_response_time_counter,
-                    aggregate_min_response_time,
-                    aggregate_max_response_time,
-                    0.75
-                ),
-                calculate_response_time_percentile(
-                    &aggregate_response_times,
-                    aggregate_response_time_counter,
-                    aggregate_min_response_time,
-                    aggregate_max_response_time,
-                    0.98
-                ),
-                calculate_response_time_percentile(
-                    &aggregate_response_times,
-                    aggregate_response_time_counter,
-                    aggregate_min_response_time,
-                    aggregate_max_response_time,
-                    0.99
-                ),
-                calculate_response_time_percentile(
-                    &aggregate_response_times,
-                    aggregate_response_time_counter,
-                    aggregate_min_response_time,
-                    aggregate_max_response_time,
-                    0.999
-                ),
-                calculate_response_time_percentile(
-                    &aggregate_response_times,
-                    aggregate_response_time_counter,
-                    aggregate_min_response_time,
-                    aggregate_max_response_time,
-                    0.9999
-                ),
-            );
-        }
-    }
-}
-
-fn print_status_codes(stats: &GooseStats) {
-    debug!("entering print_status_codes");
-    println!("-------------------------------------------------------------------------------");
-    println!(" {:<23} | {:<25} ", "Name", "Status codes");
-    println!(" ----------------------------------------------------------------------------- ");
-    let mut aggregated_status_code_counts: HashMap<u16, usize> = HashMap::new();
-    for (request_key, request) in stats.requests.iter().sorted() {
-        let mut codes: String = "".to_string();
-        for (status_code, count) in &request.status_code_counts {
-            if codes.is_empty() {
-                codes = format!(
-                    "{} [{}]",
-                    count.to_formatted_string(&Locale::en),
-                    status_code
-                );
-            } else {
-                codes = format!(
-                    "{}, {} [{}]",
-                    codes.clone(),
-                    count.to_formatted_string(&Locale::en),
-                    status_code
-                );
-            }
-            let new_count;
-            if let Some(existing_status_code_count) =
-                aggregated_status_code_counts.get(&status_code)
-            {
-                new_count = *existing_status_code_count + *count;
-            } else {
-                new_count = *count;
-            }
-            aggregated_status_code_counts.insert(*status_code, new_count);
-        }
-        println!(
-            " {:<23} | {:<25}",
-            util::truncate_string(&request_key, 23),
-            codes,
-        );
-    }
-    println!("-------------------------------------------------------------------------------");
-    let mut codes: String = "".to_string();
-    for (status_code, count) in &aggregated_status_code_counts {
-        if codes.is_empty() {
-            codes = format!(
-                "{} [{}]",
-                count.to_formatted_string(&Locale::en),
-                status_code
-            );
-        } else {
-            codes = format!(
-                "{}, {} [{}]",
-                codes.clone(),
-                count.to_formatted_string(&Locale::en),
-                status_code
-            );
-        }
-    }
-    println!(" {:<23} | {:<25} ", "Aggregated", codes);
-}
-
-/// Display running and ending statistics
-pub fn print_final_stats(stats: &GooseStats) {
-    info!(
-        "printing final statistics after {} seconds...",
-        stats.duration
-    );
-    // 1) print request and fail statistics.
-    print_requests_and_fails(stats);
-    // 2) print respones time statistics, with percentiles
-    print_response_times(stats, true);
-    // 3) print status_codes
-    print_status_codes(stats);
-}
-
-pub fn print_running_stats(goose_attack: &GooseAttack, elapsed: usize) {
-    let stats = GooseAttack::get(goose_attack.clone());
-    if !goose_attack.configuration.worker && !goose_attack.statistics.is_empty() {
-        info!("printing running statistics after {} seconds...", elapsed);
-        // 1) print request and fail statistics.
-        print_requests_and_fails(&stats);
-        // 2) print respones time statistics, without percentiles
-        print_response_times(&stats, false);
-        println!();
-    }
 }
 
 #[cfg(test)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -404,23 +404,23 @@ pub fn print_final_stats(goose_attack: &GooseAttack, elapsed: usize) {
     if !goose_attack.configuration.worker {
         info!("printing final statistics after {} seconds...", elapsed);
         // 1) print request and fail statistics.
-        print_requests_and_fails(&goose_attack.merged_requests, elapsed);
+        print_requests_and_fails(&goose_attack.statistics, elapsed);
         // 2) print respones time statistics, with percentiles
-        print_response_times(&goose_attack.merged_requests, true);
+        print_response_times(&goose_attack.statistics, true);
         // 3) print status_codes
         if goose_attack.configuration.status_codes {
-            print_status_codes(&goose_attack.merged_requests);
+            print_status_codes(&goose_attack.statistics);
         }
     }
 }
 
 pub fn print_running_stats(goose_attack: &GooseAttack, elapsed: usize) {
-    if !goose_attack.configuration.worker && !goose_attack.merged_requests.is_empty() {
+    if !goose_attack.configuration.worker && !goose_attack.statistics.is_empty() {
         info!("printing running statistics after {} seconds...", elapsed);
         // 1) print request and fail statistics.
-        print_requests_and_fails(&goose_attack.merged_requests, elapsed);
+        print_requests_and_fails(&goose_attack.statistics, elapsed);
         // 2) print respones time statistics, without percentiles
-        print_response_times(&goose_attack.merged_requests, false);
+        print_response_times(&goose_attack.statistics, false);
         println!();
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -36,7 +36,7 @@ pub type GooseRequestStats = HashMap<String, GooseRequest>;
 ///     Ok(())
 /// }
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct GooseStats {
     /// A hash of the load test, useful to verify if different statistics are from
     /// the same load test.
@@ -50,16 +50,6 @@ pub struct GooseStats {
 }
 
 impl GooseStats {
-    /// Create a new, empty GooseStats object.
-    pub fn new() -> Self {
-        GooseStats {
-            hash: 0,
-            duration: 0,
-            users: 0,
-            requests: HashMap::new(),
-        }
-    }
-
     /// Consumes and display all statistics from a completed load test.
     ///
     /// # Example
@@ -109,7 +99,7 @@ impl GooseStats {
     /// Display a table of requests and fails.
     pub fn print_requests(&self) -> &GooseStats {
         // If there's nothing to display, exit immediately.
-        if self.requests.len() == 0 {
+        if self.requests.is_empty() {
             return self;
         }
 
@@ -205,7 +195,7 @@ impl GooseStats {
     // Display a table of response times.
     pub fn print_response_times(&self) -> &GooseStats {
         // If there's nothing to display, exit immediately.
-        if self.requests.len() == 0 {
+        if self.requests.is_empty() {
             return self;
         }
 
@@ -281,7 +271,7 @@ impl GooseStats {
     // Display slowest response times within several percentiles.
     pub fn print_percentiles(&self) -> &GooseStats {
         // If there's nothing to display, exit immediately.
-        if self.requests.len() == 0 {
+        if self.requests.is_empty() {
             return self;
         }
 
@@ -422,7 +412,7 @@ impl GooseStats {
     // Display a table of response status codes.
     pub fn print_status_codes(&self) -> Result<&GooseStats> {
         // If there's nothing to display, exit immediately.
-        if self.requests.len() == 0 {
+        if self.requests.is_empty() {
             return Ok(self);
         }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -69,11 +69,11 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     // "Fake" request for manager to validate this worker's load test hash.
     requests.insert(
         "load_test_hash".to_string(),
-        GooseRequest::new("none", GooseMethod::GET, goose_attack.task_sets_hash),
+        GooseRequest::new("none", GooseMethod::GET, goose_attack.stats.hash),
     );
     debug!(
         "sending load test hash to manager: {}",
-        goose_attack.task_sets_hash
+        goose_attack.stats.hash
     );
     push_stats_to_manager(&manager, &requests, false);
 
@@ -129,7 +129,7 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
                 initializer.min_wait,
                 initializer.max_wait,
                 &initializer.config,
-                goose_attack.task_sets_hash,
+                goose_attack.stats.hash,
             )
             .map_err(|error| eprintln!("{:?} worker_id({})", error, get_worker_id()))
             .expect("failed to create socket");

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -45,7 +45,7 @@ fn test_gaggle() {
         master_configuration.manager = true;
         master_configuration.expect_workers = 1;
         master_configuration.run_time = "3".to_string();
-        let _goose_attack = crate::GooseAttack::initialize_with_config(master_configuration)
+        let _goose_stats = crate::GooseAttack::initialize_with_config(master_configuration)
             .setup()
             .unwrap()
             .register_taskset(taskset!("User1").register_task(task!(get_index)))
@@ -61,7 +61,7 @@ fn test_gaggle() {
         configuration.users = None;
         configuration.no_stats = false;
         configuration.run_time = "".to_string();
-        let _goose_attack = crate::GooseAttack::initialize_with_config(configuration)
+        let _goose_stats = crate::GooseAttack::initialize_with_config(configuration)
             .setup()
             .unwrap()
             .register_taskset(taskset!("User1").register_task(task!(get_index)))

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -55,7 +55,7 @@ fn test_stat_logs_json() {
     let mut config = common::build_configuration(&server);
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.no_stats = false;
-    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -89,7 +89,7 @@ fn test_stat_logs_csv() {
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.stats_log_format = "csv".to_string();
     config.no_stats = false;
-    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -123,7 +123,7 @@ fn test_stat_logs_raw() {
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.stats_log_format = "raw".to_string();
     config.no_stats = false;
-    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -161,7 +161,7 @@ fn test_debug_logs_raw() {
     let mut config = common::build_configuration(&server);
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
     config.debug_log_format = "raw".to_string();
-    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(
@@ -203,7 +203,7 @@ fn test_debug_logs_json() {
 
     let mut config = common::build_configuration(&server);
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
-    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(
@@ -248,7 +248,7 @@ fn test_stats_and_debug_logs() {
     config.stats_log_format = "raw".to_string();
     config.no_stats = false;
     config.debug_log_file = DEBUG_LOG_FILE.to_string();
-    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -35,7 +35,7 @@ fn test_no_normal_tasks() {
         .return_status(200)
         .create_on(&server);
 
-    let _goose_attack =
+    let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server))
             .setup()
             .unwrap()

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -50,7 +50,7 @@ fn test_single_taskset() {
         )
         .execute()
         .unwrap()
-        .get_stats();
+        .get();
 
     // Confirm that we loaded the mock endpoints.
     assert!(index.times_called() > 0);
@@ -61,14 +61,8 @@ fn test_single_taskset() {
     let difference = about.times_called() as i32 - one_third_index as i32;
     assert!(difference >= -2 && difference <= 2);
 
-    let index_stats = stats
-        .statistics
-        .get(&format!("GET {}", INDEX_PATH))
-        .unwrap();
-    let about_stats = stats
-        .statistics
-        .get(&format!("GET {}", ABOUT_PATH))
-        .unwrap();
+    let index_stats = stats.requests.get(&format!("GET {}", INDEX_PATH)).unwrap();
+    let about_stats = stats.requests.get(&format!("GET {}", ABOUT_PATH)).unwrap();
 
     // Confirm that the path and method are correct in the statistics.
     assert!(index_stats.path == INDEX_PATH);
@@ -125,7 +119,7 @@ fn test_single_taskset_empty_config_host() {
         .set_host(&host)
         .execute()
         .unwrap()
-        .get_stats();
+        .get();
 
     // Confirm that we loaded the mock endpoints.
     assert!(index.times_called() > 0);
@@ -139,7 +133,7 @@ fn test_single_taskset_empty_config_host() {
     // Confirm that Goose and the server saw the same number of page loads.
     assert!(
         stats
-            .statistics
+            .requests
             .get(&format!("GET {}", INDEX_PATH))
             .unwrap()
             .response_time_counter
@@ -147,7 +141,7 @@ fn test_single_taskset_empty_config_host() {
     );
     assert!(
         stats
-            .statistics
+            .requests
             .get(&format!("GET {}", ABOUT_PATH))
             .unwrap()
             .response_time_counter

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -41,6 +41,9 @@ fn test_single_taskset() {
 
     let mut config = common::build_configuration(&server);
     config.no_stats = false;
+    // Start users in .5 seconds.
+    config.users = Some(2);
+    config.hatch_rate = 4;
     let goose_attack = crate::GooseAttack::initialize_with_config(config.clone())
         .setup()
         .unwrap()
@@ -93,10 +96,19 @@ fn test_single_taskset() {
     assert!(goose_attack.configuration.users.unwrap() == config.users.unwrap());
     assert!(goose_attack.users == config.users.unwrap());
     assert!(goose_attack.users == goose_attack.active_users);
+    assert!(goose_attack.weighted_users.len() == config.users.unwrap());
+
+    // Verify that Goose correctly shares 1 task_set among all users.
+    assert!(goose_attack.task_sets.len() == 1);
+    assert!(goose_attack.test_start_task.is_none());
+    assert!(goose_attack.test_stop_task.is_none());
 
     // Verify Goose properly tracks time.
     assert!(before < goose_attack.started.unwrap());
     assert!(after > goose_attack.started.unwrap());
+    assert!(before < goose_attack.weighted_users[0].started);
+    assert!(before < goose_attack.weighted_users[1].started);
+    assert!(after > goose_attack.weighted_users[1].started);
 }
 
 #[test]

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -95,7 +95,7 @@ fn test_redirect() {
         .return_body("<HTML><BODY>about page</BODY></HTML>")
         .create_on(&server1);
 
-    let _goose_attack =
+    let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server1))
             .setup()
             .unwrap()
@@ -161,7 +161,7 @@ fn test_domain_redirect() {
         .return_status(200)
         .create_on(&server2);
 
-    let _goose_attack =
+    let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server1))
             .setup()
             .unwrap()
@@ -226,7 +226,7 @@ fn test_sticky_domain_redirect() {
     // Enable sticky_follow option.
     let mut configuration = common::build_configuration(&server1);
     configuration.sticky_follow = true;
-    let _goose_attack = crate::GooseAttack::initialize_with_config(configuration)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(configuration)
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -47,7 +47,7 @@ fn test_start() {
         .return_status(200)
         .create_on(&server);
 
-    let _goose_attack =
+    let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server))
             .setup()
             .unwrap()
@@ -89,7 +89,7 @@ fn test_stop() {
         .return_status(200)
         .create_on(&server);
 
-    let _goose_attack =
+    let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server))
             .setup()
             .unwrap()
@@ -135,7 +135,7 @@ fn test_setup_teardown() {
     configuration.users = Some(5);
     configuration.hatch_rate = 5;
 
-    let _goose_attack = crate::GooseAttack::initialize_with_config(configuration)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(configuration)
         .setup()
         .unwrap()
         .test_start(task!(setup))

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -51,7 +51,7 @@ fn test_throttle() {
     config.hatch_rate = users;
     // Run for a few seconds to be sure throttle really works.
     config.run_time = run_time.to_string();
-    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(
@@ -93,7 +93,7 @@ fn test_throttle() {
     // Start all users in half a second.
     config.hatch_rate = users;
     config.run_time = run_time.to_string();
-    let _goose_attack = crate::GooseAttack::initialize_with_config(config)
+    let _goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(


### PR DESCRIPTION
 - return `GooseStats` from `GooseAttack.execute()`, a public sub-object contained within `GooseAttack`
 - move `GooseStats` to `mod.stats` and rework functions as methods
 - consume and display statistics with `goose_stats.print()`
 - other methods: `.print_running()`, `.print_requests()`, `.print_response_times()`, `.print_percentiles()` and `.print_status_codes()`
 - add test coverage to validate `GooseStats` fields are public
 - add test coverage to validate that Goose statistics match server statistics

Fixes #115 