### PR TITLE
[POC] bench GooseUser creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,8 @@ rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 httpmock = "0.4"
+criterion = "0.3"
+
+[[bench]]
+name = "create_clients"
+harness = false

--- a/benches/create_clients.rs
+++ b/benches/create_clients.rs
@@ -1,0 +1,60 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use goose::prelude::*;
+use goose::GooseConfiguration;
+
+async fn task_a(user: &GooseUser) -> GooseTaskResult {
+    let _goose = user.get("/a").await?;
+
+    Ok(())
+}
+
+async fn task_b(user: &GooseUser) -> GooseTaskResult {
+    let _goose = user.get("/b").await?;
+
+    Ok(())
+}
+
+fn create_clients_benchmark(c: &mut Criterion) {
+    let config = GooseConfiguration {
+        host: "http://localhost/".to_string(),
+        users: Some(10),
+        hatch_rate: 1,
+        run_time: "".to_string(),
+        no_stats: true,
+        status_codes: false,
+        only_summary: false,
+        no_reset_stats: true,
+        list: false,
+        verbose: 0,
+        log_level: 0,
+        log_file: "goose.log".to_string(),
+        stats_log_file: "".to_string(),
+        stats_log_format: "json".to_string(),
+        debug_log_file: "".to_string(),
+        debug_log_format: "json".to_string(),
+        throttle_requests: None,
+        sticky_follow: false,
+        manager: false,
+        no_hash_check: false,
+        expect_workers: 0,
+        manager_bind_host: "0.0.0.0".to_string(),
+        manager_bind_port: 5115,
+        worker: false,
+        manager_host: "127.0.0.1".to_string(),
+        manager_port: 5115,
+    };
+    let mut goose_attack = GooseAttack::initialize_with_config(config)
+        .setup()
+        .unwrap()
+        .register_taskset(
+            taskset!("foo")
+                .register_task(task!(task_a))
+                .register_task(task!(task_b)),
+        );
+    c.bench_function("create 10 clients", |b| {
+        b.iter(|| goose_attack.weight_task_set_users())
+    });
+}
+
+criterion_group!(benches, create_clients_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -884,7 +884,7 @@ impl GooseAttack {
     }
 
     /// Allocate a vector of weighted GooseUser.
-    fn weight_task_set_users(&mut self) -> Result<Vec<GooseUser>, GooseError> {
+    pub fn weight_task_set_users(&mut self) -> Result<Vec<GooseUser>, GooseError> {
         trace!("weight_task_set_users");
 
         let mut u: usize = 0;


### PR DESCRIPTION
Testing out the usefulness of micro-benchmarking Goose, fixing #104. The first issue is that Rust's built-in benchmarking support is an unstable-only feature at this time.

So instead I tried using Criterion.rs. With this initial test, it doesn't seem especially useful. I also had to make a function public to expose it to the test.

Example of running the benchmark:
```
     Running target/release/deps/create_clients-666a1151355ed1df
Gnuplot not found, using plotters backend
Benchmarking create 10 clients: Collecting 100 samples in estimated 9.1393 s (20                                                                                create 10 clients       time:   [44.713 ms 44.996 ms 45.297 ms]
                        change: [-2.2595% -1.4565% -0.6129%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

```

Running the same test again, with no changes:
```
     Running target/release/deps/create_clients-666a1151355ed1df
Gnuplot not found, using plotters backend
Benchmarking create 10 clients: Collecting 100 samples in estimated 9.7184 s (20                                                                                create 10 clients       time:   [47.002 ms 47.490 ms 48.031 ms]
                        change: [+4.1617% +5.5423% +6.7862%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```

And running it a third time:
```
     Running target/release/deps/create_clients-666a1151355ed1df
Gnuplot not found, using plotters backend
Benchmarking create 10 clients: Collecting 100 samples in estimated 9.2752 s (20                                                                                create 10 clients       time:   [45.312 ms 45.566 ms 45.841 ms]
                        change: [-6.3916% -4.9278% -3.6065%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
```

I will re-test next week on a dedicated VM to see if this prevents these fluctuations.