### PR TITLE
Implement fmt::display for GooseStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 0.9.1-dev
  - return `GooseStats` from `GooseAttack` `.execute()`
- - rework as methods of `GooseStats`: `.print()`, `.print_running()`, `print_requests()`,
-   `print_response_times()`, `print_percentiles()`, and `print_status_codes()`
+ - rework as methods of `GooseStats`: `.print()`, `.print_running()`, `fmt_requests()`,
+   `fmt_response_times()`, `fmt_percentiles()`, and `fmt_status_codes()`
+ - display `GooseStats` with fmt::Display (ie `print!("{}", goose_stats);`)
 
 ## 0.9.0 July 23, 2020
  - fix code documentation, requests are async and require await

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -78,7 +78,7 @@ fn main() -> Result<(), GooseError> {
                 ),
         )
         .execute()?
-        .print()?;
+        .print();
 
     Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), GooseError> {
                 .register_task(task!(website_about)),
         )
         .execute()?
-        .print()?;
+        .print();
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1522,6 +1522,9 @@ impl GooseAttack {
             info!("launched {} users...", self.stats.users);
         }
 
+        // Only display status codes if enabled.
+        self.stats.display_status_codes = self.configuration.status_codes;
+
         // Track whether or not we've (optionally) reset the statistics after all users started.
         let mut statistics_reset: bool = false;
 
@@ -1777,6 +1780,8 @@ impl GooseAttack {
             );
             let _ = file.flush().await;
         };
+        // Only display percentile once the load test is finished.
+        self.stats.display_percentile = true;
 
         Ok(self)
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use num_format::{Locale, ToFormattedString};
 use std::collections::{BTreeMap, HashMap};
+use std::io::{Result, Write};
 use std::{f32, fmt, str};
-use std::io::{Write, Result};
 
 use crate::goose::GooseRequest;
 use crate::util;
@@ -94,8 +94,8 @@ impl GooseStats {
         println!("{}", self);
     }
 
-    /// Display a table of requests and fails.
-    pub fn print_requests(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
+    /// Prepares a table of requests and fails.
+    pub fn fmt_requests(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
         // If there's nothing to display, exit immediately.
         if self.requests.is_empty() {
             return Ok(self);
@@ -202,8 +202,8 @@ impl GooseStats {
         Ok(self)
     }
 
-    // Display a table of response times.
-    pub fn print_response_times(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
+    // Prepares a table of response times.
+    pub fn fmt_response_times(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
         // If there's nothing to display, exit immediately.
         if self.requests.is_empty() {
             return Ok(self);
@@ -288,8 +288,8 @@ impl GooseStats {
         Ok(self)
     }
 
-    // Display slowest response times within several percentiles.
-    pub fn print_percentiles(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
+    // Prepares a table of slowest response times within several percentiles.
+    pub fn fmt_percentiles(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
         // If there's nothing to display, exit immediately.
         if !self.display_percentile {
             return Ok(self);
@@ -445,8 +445,8 @@ impl GooseStats {
         Ok(self)
     }
 
-    // Display a table of response status codes.
-    pub fn print_status_codes(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
+    // Prepares a table of response status codes.
+    pub fn fmt_status_codes(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
         // If there's nothing to display, exit immediately.
         if !self.display_status_codes {
             return Ok(self);
@@ -531,12 +531,20 @@ impl fmt::Display for GooseStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut buffer = Vec::new();
 
-        self.print_requests(&mut buffer).expect("unexpected formatting error");
-        self.print_response_times(&mut buffer).expect("unexpected formatting error");
-        self.print_percentiles(&mut buffer).expect("unexpected formatting error");
-        self.print_status_codes(&mut buffer).expect("unexpected formatting error");
+        self.fmt_requests(&mut buffer)
+            .expect("unexpected formatting error");
+        self.fmt_response_times(&mut buffer)
+            .expect("unexpected formatting error");
+        self.fmt_percentiles(&mut buffer)
+            .expect("unexpected formatting error");
+        self.fmt_status_codes(&mut buffer)
+            .expect("unexpected formatting error");
 
-        write!(f, "{}", str::from_utf8(&buffer).expect("unexpected formatting error"))
+        write!(
+            f,
+            "{}",
+            str::from_utf8(&buffer).expect("unexpected formatting error")
+        )
     }
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -46,9 +46,11 @@ pub struct GooseStats {
     pub users: usize,
     /// Goose request statistics.
     pub requests: GooseRequestStats,
-    /// Flag indicating whether or not to display percentile.
+    /// Flag indicating whether or not to display percentile. Because we're deriving Default,
+    /// this defaults to false.
     pub display_percentile: bool,
-    /// Flag indicating whether or not to display status_codes.
+    /// Flag indicating whether or not to display status_codes. Because we're deriving Default,
+    /// this defaults to false.
     pub display_status_codes: bool,
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -532,18 +532,24 @@ impl fmt::Display for GooseStats {
         let mut buffer = Vec::new();
 
         self.fmt_requests(&mut buffer)
+            .map_err(|error| eprintln!("{:?}", error))
             .expect("unexpected formatting error");
         self.fmt_response_times(&mut buffer)
+            .map_err(|error| eprintln!("{:?}", error))
             .expect("unexpected formatting error");
         self.fmt_percentiles(&mut buffer)
+            .map_err(|error| eprintln!("{:?}", error))
             .expect("unexpected formatting error");
         self.fmt_status_codes(&mut buffer)
+            .map_err(|error| eprintln!("{:?}", error))
             .expect("unexpected formatting error");
 
         write!(
             f,
             "{}",
-            str::from_utf8(&buffer).expect("unexpected formatting error")
+            str::from_utf8(&buffer)
+                .map_err(|error| eprintln!("{:?}", error))
+                .expect("unexpected formatting error")
         )
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -96,7 +96,7 @@ impl GooseStats {
     }
 
     /// Optionally prepares a table of requests and fails.
-    pub fn fmt_requests(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn fmt_requests(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         // If there's nothing to display, exit immediately.
         if self.requests.is_empty() {
             return Ok(());
@@ -104,16 +104,16 @@ impl GooseStats {
 
         // Display stats from merged HashMap
         writeln!(
-            f,
+            fmt,
             "------------------------------------------------------------------------------ "
         )?;
         writeln!(
-            f,
+            fmt,
             " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
             "Name", "# reqs", "# fails", "req/s", "fail/s"
         )?;
         writeln!(
-            f,
+            fmt,
             " ----------------------------------------------------------------------------- "
         )?;
         let mut aggregate_fail_count = 0;
@@ -128,7 +128,7 @@ impl GooseStats {
             // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
             if fail_percent as usize == 100 || fail_percent as usize == 0 {
                 writeln!(
-                    f,
+                    fmt,
                     " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
                     util::truncate_string(&request_key, 23),
                     total_count.to_formatted_string(&Locale::en),
@@ -142,7 +142,7 @@ impl GooseStats {
                 )?;
             } else {
                 writeln!(
-                    f,
+                    fmt,
                     " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
                     util::truncate_string(&request_key, 23),
                     total_count.to_formatted_string(&Locale::en),
@@ -165,13 +165,13 @@ impl GooseStats {
                 0.0
             };
             writeln!(
-                f,
+                fmt,
                 " ------------------------+----------------+----------------+--------+--------- "
             )?;
             // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
             if aggregate_fail_percent as usize == 100 || aggregate_fail_percent as usize == 0 {
                 writeln!(
-                    f,
+                    fmt,
                     " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
                     "Aggregated",
                     aggregate_total_count.to_formatted_string(&Locale::en),
@@ -185,7 +185,7 @@ impl GooseStats {
                 )?;
             } else {
                 writeln!(
-                    f,
+                    fmt,
                     " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
                     "Aggregated",
                     aggregate_total_count.to_formatted_string(&Locale::en),
@@ -204,7 +204,7 @@ impl GooseStats {
     }
 
     // Optionally prepares a table of response times.
-    pub fn fmt_response_times(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn fmt_response_times(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         // If there's nothing to display, exit immediately.
         if self.requests.is_empty() {
             return Ok(());
@@ -216,16 +216,16 @@ impl GooseStats {
         let mut aggregate_min_response_time: usize = 0;
         let mut aggregate_max_response_time: usize = 0;
         writeln!(
-            f,
+            fmt,
             "-------------------------------------------------------------------------------"
         )?;
         writeln!(
-            f,
+            fmt,
             " {:<23} | {:<10} | {:<10} | {:<10} | {:<10}",
             "Name", "Avg (ms)", "Min", "Max", "Median"
         )?;
         writeln!(
-            f,
+            fmt,
             " ----------------------------------------------------------------------------- "
         )?;
         for (request_key, request) in self.requests.iter().sorted() {
@@ -248,7 +248,7 @@ impl GooseStats {
                 update_max_response_time(aggregate_max_response_time, request.max_response_time);
 
             writeln!(
-                f,
+                fmt,
                 " {:<23} | {:<10.2} | {:<10.2} | {:<10.2} | {:<10.2}",
                 util::truncate_string(&request_key, 23),
                 request.total_response_time / request.response_time_counter,
@@ -264,14 +264,14 @@ impl GooseStats {
         }
         if self.requests.len() > 1 {
             writeln!(
-                f,
+                fmt,
                 " ------------------------+------------+------------+------------+------------- "
             )?;
             if aggregate_response_time_counter == 0 {
                 aggregate_response_time_counter = 1;
             }
             writeln!(
-                f,
+                fmt,
                 " {:<23} | {:<10.2} | {:<10.2} | {:<10.2} | {:<10.2}",
                 "Aggregated",
                 aggregate_total_response_time / aggregate_response_time_counter,
@@ -290,7 +290,7 @@ impl GooseStats {
     }
 
     // Optionallyl prepares a table of slowest response times within several percentiles.
-    pub fn fmt_percentiles(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn fmt_percentiles(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         // If there's nothing to display, exit immediately.
         if !self.display_percentile {
             return Ok(());
@@ -302,24 +302,24 @@ impl GooseStats {
         let mut aggregate_min_response_time: usize = 0;
         let mut aggregate_max_response_time: usize = 0;
         writeln!(
-            f,
+            fmt,
             "-------------------------------------------------------------------------------"
         )?;
         writeln!(
-            f,
+            fmt,
             " Slowest page load within specified percentile of requests (in ms):"
         )?;
         writeln!(
-            f,
+            fmt,
             " ------------------------------------------------------------------------------"
         )?;
         writeln!(
-            f,
+            fmt,
             " {:<23} | {:<6} | {:<6} | {:<6} | {:<6} | {:<6} | {:6}",
             "Name", "50%", "75%", "98%", "99%", "99.9%", "99.99%"
         )?;
         writeln!(
-            f,
+            fmt,
             " ----------------------------------------------------------------------------- "
         )?;
         for (request_key, request) in self.requests.iter().sorted() {
@@ -342,7 +342,7 @@ impl GooseStats {
                 update_max_response_time(aggregate_max_response_time, request.max_response_time);
             // Sort response times so we can calculate a mean.
             writeln!(
-                f,
+                fmt,
                 " {:<23} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:6.2}",
                 util::truncate_string(&request_key, 23),
                 calculate_response_time_percentile(
@@ -391,11 +391,11 @@ impl GooseStats {
         }
         if self.requests.len() > 1 {
             writeln!(
-                f,
+                fmt,
                 " ------------------------+--------+--------+--------+--------+--------+------- "
             )?;
             writeln!(
-                f,
+                fmt,
                 " {:<23} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:6.2}",
                 "Aggregated",
                 calculate_response_time_percentile(
@@ -447,19 +447,19 @@ impl GooseStats {
     }
 
     // Optionally prepares a table of response status codes.
-    pub fn fmt_status_codes(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn fmt_status_codes(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         // If there's nothing to display, exit immediately.
         if !self.display_status_codes {
             return Ok(());
         }
 
         writeln!(
-            f,
+            fmt,
             "-------------------------------------------------------------------------------"
         )?;
-        writeln!(f, " {:<23} | {:<25} ", "Name", "Status codes")?;
+        writeln!(fmt, " {:<23} | {:<25} ", "Name", "Status codes")?;
         writeln!(
-            f,
+            fmt,
             " ----------------------------------------------------------------------------- "
         )?;
         let mut aggregated_status_code_counts: HashMap<u16, usize> = HashMap::new();
@@ -492,14 +492,14 @@ impl GooseStats {
             }
 
             writeln!(
-                f,
+                fmt,
                 " {:<23} | {:<25}",
                 util::truncate_string(&request_key, 23),
                 codes,
             )?;
         }
         writeln!(
-            f,
+            fmt,
             "-------------------------------------------------------------------------------"
         )?;
         let mut codes: String = "".to_string();
@@ -519,20 +519,20 @@ impl GooseStats {
                 );
             }
         }
-        writeln!(f, " {:<23} | {:<25} ", "Aggregated", codes)?;
+        writeln!(fmt, " {:<23} | {:<25} ", "Aggregated", codes)?;
 
         Ok(())
     }
 }
 
 impl fmt::Display for GooseStats {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         // Formats from zero to four tables of data, depending on what data is contained
         // and which contained flags are set.
-        self.fmt_requests(f)?;
-        self.fmt_response_times(f)?;
-        self.fmt_percentiles(f)?;
-        self.fmt_status_codes(f)
+        self.fmt_requests(fmt)?;
+        self.fmt_response_times(fmt)?;
+        self.fmt_percentiles(fmt)?;
+        self.fmt_status_codes(fmt)
     }
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,8 +1,7 @@
 use itertools::Itertools;
 use num_format::{Locale, ToFormattedString};
 use std::collections::{BTreeMap, HashMap};
-use std::io::{Result, Write};
-use std::{f32, fmt, str};
+use std::{f32, fmt};
 
 use crate::goose::GooseRequest;
 use crate::util;
@@ -90,29 +89,29 @@ impl GooseStats {
             self.duration
         );
 
-        // Include a blank line after running statistics.
+        // Include a blank line after printing running statistics.
         println!("{}", self);
     }
 
-    /// Prepares a table of requests and fails.
-    pub fn fmt_requests(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
+    /// Optionally prepares a table of requests and fails.
+    pub fn fmt_requests(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // If there's nothing to display, exit immediately.
         if self.requests.is_empty() {
-            return Ok(self);
+            return Ok(());
         }
 
         // Display stats from merged HashMap
         writeln!(
-            buffer,
+            f,
             "------------------------------------------------------------------------------ "
         )?;
         writeln!(
-            buffer,
+            f,
             " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
             "Name", "# reqs", "# fails", "req/s", "fail/s"
         )?;
         writeln!(
-            buffer,
+            f,
             " ----------------------------------------------------------------------------- "
         )?;
         let mut aggregate_fail_count = 0;
@@ -127,7 +126,7 @@ impl GooseStats {
             // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
             if fail_percent as usize == 100 || fail_percent as usize == 0 {
                 writeln!(
-                    buffer,
+                    f,
                     " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
                     util::truncate_string(&request_key, 23),
                     total_count.to_formatted_string(&Locale::en),
@@ -141,7 +140,7 @@ impl GooseStats {
                 )?;
             } else {
                 writeln!(
-                    buffer,
+                    f,
                     " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
                     util::truncate_string(&request_key, 23),
                     total_count.to_formatted_string(&Locale::en),
@@ -164,13 +163,13 @@ impl GooseStats {
                 0.0
             };
             writeln!(
-                buffer,
+                f,
                 " ------------------------+----------------+----------------+--------+--------- "
             )?;
             // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
             if aggregate_fail_percent as usize == 100 || aggregate_fail_percent as usize == 0 {
                 writeln!(
-                    buffer,
+                    f,
                     " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
                     "Aggregated",
                     aggregate_total_count.to_formatted_string(&Locale::en),
@@ -184,7 +183,7 @@ impl GooseStats {
                 )?;
             } else {
                 writeln!(
-                    buffer,
+                    f,
                     " {:<23} | {:<14} | {:<14} | {:<6} | {:<5}",
                     "Aggregated",
                     aggregate_total_count.to_formatted_string(&Locale::en),
@@ -199,14 +198,14 @@ impl GooseStats {
             }
         }
 
-        Ok(self)
+        Ok(())
     }
 
-    // Prepares a table of response times.
-    pub fn fmt_response_times(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
+    // Optionally prepares a table of response times.
+    pub fn fmt_response_times(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // If there's nothing to display, exit immediately.
         if self.requests.is_empty() {
-            return Ok(self);
+            return Ok(());
         }
 
         let mut aggregate_response_times: BTreeMap<usize, usize> = BTreeMap::new();
@@ -215,16 +214,16 @@ impl GooseStats {
         let mut aggregate_min_response_time: usize = 0;
         let mut aggregate_max_response_time: usize = 0;
         writeln!(
-            buffer,
+            f,
             "-------------------------------------------------------------------------------"
         )?;
         writeln!(
-            buffer,
+            f,
             " {:<23} | {:<10} | {:<10} | {:<10} | {:<10}",
             "Name", "Avg (ms)", "Min", "Max", "Median"
         )?;
         writeln!(
-            buffer,
+            f,
             " ----------------------------------------------------------------------------- "
         )?;
         for (request_key, request) in self.requests.iter().sorted() {
@@ -247,7 +246,7 @@ impl GooseStats {
                 update_max_response_time(aggregate_max_response_time, request.max_response_time);
 
             writeln!(
-                buffer,
+                f,
                 " {:<23} | {:<10.2} | {:<10.2} | {:<10.2} | {:<10.2}",
                 util::truncate_string(&request_key, 23),
                 request.total_response_time / request.response_time_counter,
@@ -263,14 +262,14 @@ impl GooseStats {
         }
         if self.requests.len() > 1 {
             writeln!(
-                buffer,
+                f,
                 " ------------------------+------------+------------+------------+------------- "
             )?;
             if aggregate_response_time_counter == 0 {
                 aggregate_response_time_counter = 1;
             }
             writeln!(
-                buffer,
+                f,
                 " {:<23} | {:<10.2} | {:<10.2} | {:<10.2} | {:<10.2}",
                 "Aggregated",
                 aggregate_total_response_time / aggregate_response_time_counter,
@@ -285,14 +284,14 @@ impl GooseStats {
             )?;
         }
 
-        Ok(self)
+        Ok(())
     }
 
-    // Prepares a table of slowest response times within several percentiles.
-    pub fn fmt_percentiles(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
+    // Optionallyl prepares a table of slowest response times within several percentiles.
+    pub fn fmt_percentiles(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // If there's nothing to display, exit immediately.
         if !self.display_percentile {
-            return Ok(self);
+            return Ok(());
         }
 
         let mut aggregate_response_times: BTreeMap<usize, usize> = BTreeMap::new();
@@ -301,24 +300,24 @@ impl GooseStats {
         let mut aggregate_min_response_time: usize = 0;
         let mut aggregate_max_response_time: usize = 0;
         writeln!(
-            buffer,
+            f,
             "-------------------------------------------------------------------------------"
         )?;
         writeln!(
-            buffer,
+            f,
             " Slowest page load within specified percentile of requests (in ms):"
         )?;
         writeln!(
-            buffer,
+            f,
             " ------------------------------------------------------------------------------"
         )?;
         writeln!(
-            buffer,
+            f,
             " {:<23} | {:<6} | {:<6} | {:<6} | {:<6} | {:<6} | {:6}",
             "Name", "50%", "75%", "98%", "99%", "99.9%", "99.99%"
         )?;
         writeln!(
-            buffer,
+            f,
             " ----------------------------------------------------------------------------- "
         )?;
         for (request_key, request) in self.requests.iter().sorted() {
@@ -341,7 +340,7 @@ impl GooseStats {
                 update_max_response_time(aggregate_max_response_time, request.max_response_time);
             // Sort response times so we can calculate a mean.
             writeln!(
-                buffer,
+                f,
                 " {:<23} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:6.2}",
                 util::truncate_string(&request_key, 23),
                 calculate_response_time_percentile(
@@ -390,11 +389,11 @@ impl GooseStats {
         }
         if self.requests.len() > 1 {
             writeln!(
-                buffer,
+                f,
                 " ------------------------+--------+--------+--------+--------+--------+------- "
             )?;
             writeln!(
-                buffer,
+                f,
                 " {:<23} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:<6.2} | {:6.2}",
                 "Aggregated",
                 calculate_response_time_percentile(
@@ -442,26 +441,23 @@ impl GooseStats {
             )?;
         }
 
-        Ok(self)
+        Ok(())
     }
 
-    // Prepares a table of response status codes.
-    pub fn fmt_status_codes(&self, buffer: &mut Vec<u8>) -> Result<&GooseStats> {
+    // Optionally prepares a table of response status codes.
+    pub fn fmt_status_codes(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // If there's nothing to display, exit immediately.
         if !self.display_status_codes {
-            return Ok(self);
+            return Ok(());
         }
 
-        // Write to buffer, we may be tracking requests but not status codes. If during
-        // processing it's found that there's no status codes in the requests, we exit
-        // early.
         writeln!(
-            buffer,
+            f,
             "-------------------------------------------------------------------------------"
         )?;
-        writeln!(buffer, " {:<23} | {:<25} ", "Name", "Status codes")?;
+        writeln!(f, " {:<23} | {:<25} ", "Name", "Status codes")?;
         writeln!(
-            buffer,
+            f,
             " ----------------------------------------------------------------------------- "
         )?;
         let mut aggregated_status_code_counts: HashMap<u16, usize> = HashMap::new();
@@ -494,14 +490,14 @@ impl GooseStats {
             }
 
             writeln!(
-                buffer,
+                f,
                 " {:<23} | {:<25}",
                 util::truncate_string(&request_key, 23),
                 codes,
             )?;
         }
         writeln!(
-            buffer,
+            f,
             "-------------------------------------------------------------------------------"
         )?;
         let mut codes: String = "".to_string();
@@ -521,36 +517,20 @@ impl GooseStats {
                 );
             }
         }
-        writeln!(buffer, " {:<23} | {:<25} ", "Aggregated", codes)?;
+        writeln!(f, " {:<23} | {:<25} ", "Aggregated", codes)?;
 
-        Ok(self)
+        Ok(())
     }
 }
 
 impl fmt::Display for GooseStats {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut buffer = Vec::new();
-
-        self.fmt_requests(&mut buffer)
-            .map_err(|error| eprintln!("{:?}", error))
-            .expect("unexpected formatting error");
-        self.fmt_response_times(&mut buffer)
-            .map_err(|error| eprintln!("{:?}", error))
-            .expect("unexpected formatting error");
-        self.fmt_percentiles(&mut buffer)
-            .map_err(|error| eprintln!("{:?}", error))
-            .expect("unexpected formatting error");
-        self.fmt_status_codes(&mut buffer)
-            .map_err(|error| eprintln!("{:?}", error))
-            .expect("unexpected formatting error");
-
-        write!(
-            f,
-            "{}",
-            str::from_utf8(&buffer)
-                .map_err(|error| eprintln!("{:?}", error))
-                .expect("unexpected formatting error")
-        )
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Formats from zero to four tables of data, depending on what data is contained
+        // and which contained flags are set.
+        self.fmt_requests(f)?;
+        self.fmt_response_times(f)?;
+        self.fmt_percentiles(f)?;
+        self.fmt_status_codes(f)
     }
 }
 


### PR DESCRIPTION
This is a followup on #116.

 - implement `fmt::Display` allowing us to simply `print!("{}", goose_stats);`
 - rename methods: `.fmt_requests()`, `.fmt_response_times()`, `.fmt_percentiles()` and `.fmt_status_codes()`