### PR TITLE
default to resetting stats, display spawn stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.9.2-dev
+ - default to resetting statistics, disable with `--no-reset-stats`, display spawning statistics before resetting
 
 ## 0.9.1 Aug 1, 2020
  - return `GooseStats` from `GooseAttack` `.execute()`
@@ -9,7 +10,6 @@
  - display `GooseStats` with fmt::Display (ie `print!("{}", goose_stats);`)
  - make it possible to pass a closure to GooseTask::new
  - fix display of `GooseError` and `GooseTaskError`
- - default to resetting statistics, disable with `--no-reset-stats`, display spawning statistics before resetting
 
 ## 0.9.0 July 23, 2020
  - fix code documentation, requests are async and require await

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - display `GooseStats` with fmt::Display (ie `print!("{}", goose_stats);`)
  - make it possible to pass a closure to GooseTask::new
  - fix display of `GooseError` and `GooseTaskError`
+ - default to resetting statistics, disable with `--no-reset-stats`, display spawning statistcs before resetting
 
 ## 0.9.0 July 23, 2020
  - fix code documentation, requests are async and require await

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
  - display `GooseStats` with fmt::Display (ie `print!("{}", goose_stats);`)
  - make it possible to pass a closure to GooseTask::new
  - fix display of `GooseError` and `GooseTaskError`
- - default to resetting statistics, disable with `--no-reset-stats`, display spawning statistcs before resetting
+ - default to resetting statistics, disable with `--no-reset-stats`, display spawning statistics before resetting
 
 ## 0.9.0 July 23, 2020
  - fix code documentation, requests are async and require await

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ $ cargo run --release --example simple -- --host http://apache.fosciana -v -u102
 18:43:25 [ INFO] launching user 1024 from WebsiteUser...
 18:43:25 [ INFO] launched 1024 users...
 
-All 1024 users hatched, resetting statistics (disable with —no-reset-stats)
+All 1024 users hatched, resetting statistics (disable with --no-reset-stats)
 
 18:53:26 [ INFO] stopping after 600 seconds...
 18:53:26 [ INFO] waiting for users to exit
@@ -473,7 +473,7 @@ and the test will stop on all servers.
 * `--worker`: starts a Goose process in worker mode. How many workers are in a given Gaggle is defined by the `--expect-workers` option, documented below.
 * `--no-hash-check`: tells Goose to ignore if the load test applications don't match between worker(s) and manager. Not recommended.
 
-The `--no-stats`, `--only-summary`, `--no-reset-stats`, `--status-codes`, and `--no-hash-check` flags must be set on the manager. Workers inheret these flags from the manager
+The `--no-stats`, `--only-summary`, `--no-reset-stats`, `--status-codes`, and `--no-hash-check` flags must be set on the manager. Workers inherit these flags from the manager
 
 ### Goose Run-time Options
 
@@ -482,7 +482,7 @@ The `--no-stats`, `--only-summary`, `--no-reset-stats`, `--status-codes`, and `-
 * `--manager-host <manager-host>`: configures the host that the worker will talk to the manager on. By default, a Goose worker will connect to the localhost, or `127.0.0.1`. In a distributed load test, this must be set to the IP of the Goose manager.
 * `--manager-port <manager-port>`: configures the port that a worker will talk to the manager on. By default, a Goose worker will connect to port `5115`.
 
-The `--users`, `--hatch-rate`, `--host`, and `--run-time` options must be set on the manager. Workers inheret these options from the manager.
+The `--users`, `--hatch-rate`, `--host`, and `--run-time` options must be set on the manager. Workers inherit these options from the manager.
 
 The `--throttle-requests` option must be configured on each worker, and can be set to a different value
 on each worker if desired.

--- a/README.md
+++ b/README.md
@@ -184,19 +184,19 @@ USAGE:
     simple [FLAGS] [OPTIONS]
 
 FLAGS:
-    -h, --help             Prints help information
-    -l, --list             Shows list of all possible Goose tasks and exits
-    -g, --log-level        Log level (-g, -gg, -ggg, etc.)
-        --manager          Enables manager mode
-        --no-hash-check    Ignore worker load test checksum
-        --no-stats         Don't print stats in the console
-        --only-summary     Only prints summary stats
-        --reset-stats      Resets statistics once hatching has been completed
-        --status-codes     Includes status code counts in console stats
-        --sticky-follow    User follows redirect of base_url with subsequent requests
-    -V, --version          Prints version information
-    -v, --verbose          Debug level (-v, -vv, -vvv, etc.)
-        --worker           Enables worker mode
+    -h, --help              Prints help information
+    -l, --list              Shows list of all possible Goose tasks and exits
+    -g, --log-level         Log level (-g, -gg, -ggg, etc.)
+        --manager           Enables manager mode
+        --no-hash-check     Ignore worker load test checksum
+        --no-reset-stats    Resets statistics once hatching has been completed
+        --no-stats          Don't print stats in the console
+        --only-summary      Only prints summary stats
+        --status-codes      Includes status code counts in console stats
+        --sticky-follow     User follows redirect of base_url with subsequent requests
+    -V, --version           Prints version information
+    -v, --verbose           Debug level (-v, -vv, -vvv, etc.)
+        --worker            Enables worker mode
 
 OPTIONS:
     -d, --debug-log-file <debug-log-file>          Debug log file name [default: ]
@@ -260,6 +260,9 @@ $ cargo run --release --example simple -- --host http://apache.fosciana -v -u102
 18:43:25 [ INFO] launching user 1023 from WebsiteUser...
 18:43:25 [ INFO] launching user 1024 from WebsiteUser...
 18:43:25 [ INFO] launched 1024 users...
+
+All 1024 users hatched, resetting statistics (disable with —no-reset-stats)
+
 18:53:26 [ INFO] stopping after 600 seconds...
 18:53:26 [ INFO] waiting for users to exit
 ------------------------------------------------------------------------------ 
@@ -470,7 +473,7 @@ and the test will stop on all servers.
 * `--worker`: starts a Goose process in worker mode. How many workers are in a given Gaggle is defined by the `--expect-workers` option, documented below.
 * `--no-hash-check`: tells Goose to ignore if the load test applications don't match between worker(s) and manager. Not recommended.
 
-The `--no-stats`, `--only-summary`, `--reset-stats`, `--status-codes`, and `--no-hash-check` flags must be set on the manager. Workers inheret these flags from the manager
+The `--no-stats`, `--only-summary`, `--no-reset-stats`, `--status-codes`, and `--no-hash-check` flags must be set on the manager. Workers inheret these flags from the manager
 
 ### Goose Run-time Options
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1679,11 +1679,11 @@ impl GooseAttack {
 
                         if self.stats.users < self.users {
                             println!(
-                                "{} of {} users hatched, timer expired, resetting statistics (disable with —no-reset-stats).\n", self.stats.users, self.users
+                                "{} of {} users hatched, timer expired, resetting statistics (disable with --no-reset-stats).\n", self.stats.users, self.users
                             );
                         } else {
                             println!(
-                                "All {} users hatched, resetting statistics (disable with —no-reset-stats).\n", self.stats.users
+                                "All {} users hatched, resetting statistics (disable with --no-reset-stats).\n", self.stats.users
                             );
                         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1138,6 +1138,14 @@ impl GooseAttack {
                 });
             }
 
+            if self.configuration.no_reset_stats {
+                return Err(GooseError::InvalidOption {
+                    option: "--no-reset-stats".to_string(),
+                    value: self.configuration.no_reset_stats.to_string(),
+                    detail: Some("--no-reset-stats is only available to the manager".to_string()),
+                });
+            }
+
             if self.configuration.no_hash_check {
                 return Err(GooseError::InvalidOption {
                     option: "--no-hash-check".to_string(),
@@ -1682,15 +1690,13 @@ impl GooseAttack {
                         self.stats.requests = HashMap::new();
                         // Restart the timer now that all threads are launched.
                         self.started = Some(time::Instant::now());
+                    } else if self.stats.users < self.users {
+                        println!(
+                            "{} of {} users hatched, timer expired\n",
+                            self.stats.users, self.users
+                        );
                     } else {
-                        if self.stats.users < self.users {
-                            println!(
-                                "{} of {} users hatched, timer expired\n",
-                                self.stats.users, self.users
-                            );
-                        } else {
-                            println!("All {} users hatched\n", self.stats.users);
-                        }
+                        println!("All {} users hatched\n", self.stats.users);
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1679,11 +1679,11 @@ impl GooseAttack {
 
                         if self.stats.users < self.users {
                             println!(
-                                "{} of {} users hatched, timer expired, resetting statistics (disable with —no-reset-stats)\n", self.stats.users, self.users
+                                "{} of {} users hatched, timer expired, resetting statistics (disable with —no-reset-stats).\n", self.stats.users, self.users
                             );
                         } else {
                             println!(
-                                "All {} users hatched, resetting statistics (disable with —no-reset-stats)\n", self.stats.users
+                                "All {} users hatched, resetting statistics (disable with —no-reset-stats).\n", self.stats.users
                             );
                         }
 
@@ -1692,11 +1692,11 @@ impl GooseAttack {
                         self.started = Some(time::Instant::now());
                     } else if self.stats.users < self.users {
                         println!(
-                            "{} of {} users hatched, timer expired\n",
+                            "{} of {} users hatched, timer expired.\n",
                             self.stats.users, self.users
                         );
                     } else {
-                        println!("All {} users hatched\n", self.stats.users);
+                        println!("All {} users hatched.\n", self.stats.users);
                     }
                 }
             }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -177,6 +177,15 @@ impl GooseStats {
                 fmt,
                 " ------------------------+----------------+----------------+--------+--------- "
             )?;
+            let req_s;
+            let fail_s;
+            if self.duration == 0 {
+                req_s = 0.to_formatted_string(&Locale::en);
+                fail_s = 0.to_formatted_string(&Locale::en);
+            } else {
+                req_s = (aggregate_total_count / self.duration).to_formatted_string(&Locale::en);
+                fail_s = (aggregate_fail_count / self.duration).to_formatted_string(&Locale::en);
+            }
             // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
             if aggregate_fail_percent as usize == 100 || aggregate_fail_percent as usize == 0 {
                 writeln!(
@@ -189,8 +198,8 @@ impl GooseStats {
                         aggregate_fail_count.to_formatted_string(&Locale::en),
                         aggregate_fail_percent as usize
                     ),
-                    (aggregate_total_count / self.duration).to_formatted_string(&Locale::en),
-                    (aggregate_fail_count / self.duration).to_formatted_string(&Locale::en),
+                    req_s,
+                    fail_s,
                 )?;
             } else {
                 writeln!(
@@ -203,8 +212,8 @@ impl GooseStats {
                         aggregate_fail_count.to_formatted_string(&Locale::en),
                         aggregate_fail_percent
                     ),
-                    (aggregate_total_count / self.duration).to_formatted_string(&Locale::en),
-                    (aggregate_fail_count / self.duration).to_formatted_string(&Locale::en),
+                    req_s,
+                    fail_s,
                 )?;
             }
         }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -125,6 +125,15 @@ impl GooseStats {
             } else {
                 0.0
             };
+            let req_s;
+            let fail_s;
+            if self.duration == 0 {
+                req_s = 0.to_formatted_string(&Locale::en);
+                fail_s = 0.to_formatted_string(&Locale::en);
+            } else {
+                req_s = (total_count / self.duration).to_formatted_string(&Locale::en);
+                fail_s = (request.fail_count / self.duration).to_formatted_string(&Locale::en);
+            }
             // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
             if fail_percent as usize == 100 || fail_percent as usize == 0 {
                 writeln!(
@@ -137,8 +146,8 @@ impl GooseStats {
                         request.fail_count.to_formatted_string(&Locale::en),
                         fail_percent as usize
                     ),
-                    (total_count / self.duration).to_formatted_string(&Locale::en),
-                    (request.fail_count / self.duration).to_formatted_string(&Locale::en),
+                    req_s,
+                    fail_s,
                 )?;
             } else {
                 writeln!(
@@ -151,8 +160,8 @@ impl GooseStats {
                         request.fail_count.to_formatted_string(&Locale::en),
                         fail_percent
                     ),
-                    (total_count / self.duration).to_formatted_string(&Locale::en),
-                    (request.fail_count / self.duration).to_formatted_string(&Locale::en),
+                    req_s,
+                    fail_s,
                 )?;
             }
             aggregate_total_count += total_count;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -13,7 +13,7 @@ pub fn build_configuration(server: &MockServer) -> GooseConfiguration {
         no_stats: true,
         status_codes: false,
         only_summary: false,
-        reset_stats: false,
+        no_reset_stats: false,
         list: false,
         verbose: 0,
         log_level: 0,

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -40,7 +40,7 @@ fn cleanup_files(stats_log_file: &str, debug_log_file: &str) {
 }
 
 #[test]
-fn test_stat_logs_json() {
+fn test_stats_logs_json() {
     const STATS_LOG_FILE: &str = "stats-json.log";
     const DEBUG_LOG_FILE: &str = "debug-json.log";
 
@@ -55,7 +55,7 @@ fn test_stat_logs_json() {
     let mut config = common::build_configuration(&server);
     config.stats_log_file = STATS_LOG_FILE.to_string();
     config.no_stats = false;
-    let _goose_stats = crate::GooseAttack::initialize_with_config(config)
+    let goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -65,6 +65,9 @@ fn test_stat_logs_json() {
     // Confirm that we loaded the mock endpoints.
     assert!(index.times_called() > 0);
 
+    // Confirm that the test duration was correct.
+    assert!(goose_stats.duration == 1);
+
     // Confirm only the stats log file exists.
     assert!(std::path::Path::new(STATS_LOG_FILE).exists());
     assert!(!std::path::Path::new(DEBUG_LOG_FILE).exists());
@@ -73,7 +76,7 @@ fn test_stat_logs_json() {
 }
 
 #[test]
-fn test_stat_logs_csv() {
+fn test_stats_logs_csv() {
     const STATS_LOG_FILE: &str = "stats-csv.log";
     const DEBUG_LOG_FILE: &str = "debug-csv.log";
 
@@ -107,7 +110,7 @@ fn test_stat_logs_csv() {
 }
 
 #[test]
-fn test_stat_logs_raw() {
+fn test_stats_logs_raw() {
     const STATS_LOG_FILE: &str = "stats-raw.log";
     const DEBUG_LOG_FILE: &str = "debug-raw.log";
 

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -42,6 +42,7 @@ fn test_single_taskset() {
     config.users = Some(2);
     config.hatch_rate = 4;
     config.status_codes = true;
+    config.no_reset_stats = true;
     let goose_stats = crate::GooseAttack::initialize_with_config(config.clone())
         .setup()
         .unwrap()
@@ -115,6 +116,7 @@ fn test_single_taskset_empty_config_host() {
     let host = std::mem::take(&mut config.host);
     // Enable statistics to confirm Goose and web server agree.
     config.no_stats = false;
+    config.no_reset_stats = true;
     let goose_stats = crate::GooseAttack::initialize_with_config(config)
         .setup()
         .unwrap()
@@ -191,6 +193,7 @@ fn test_single_taskset_closure() {
     config.users = Some(test_endpoints.len());
     config.hatch_rate = 2 * test_endpoints.len();
     config.status_codes = true;
+    config.no_reset_stats = true;
 
     // Setup mock endpoints.
     let mut mock_endpoints = Vec::with_capacity(test_endpoints.len());

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -298,3 +298,77 @@ fn test_single_taskset_closure() {
     // Verify that Goose started the correct number of users.
     assert!(goose_stats.users == config.users.unwrap());
 }
+
+#[test]
+// Load test with a single task set containing two weighted tasks. Validate
+// weighting and statistics after resetting stats.
+fn test_single_taskset_reset_stats() {
+    let server = MockServer::start();
+
+    let index = Mock::new()
+        .expect_method(GET)
+        .expect_path(INDEX_PATH)
+        .return_status(200)
+        .create_on(&server);
+    let about = Mock::new()
+        .expect_method(GET)
+        .expect_path(ABOUT_PATH)
+        .return_status(200)
+        .create_on(&server);
+
+    let mut config = common::build_configuration(&server);
+    config.no_stats = false;
+    // Start users in .5 seconds.
+    config.users = Some(2);
+    config.hatch_rate = 4;
+    config.status_codes = true;
+    let goose_stats = crate::GooseAttack::initialize_with_config(config.clone())
+        .setup()
+        .unwrap()
+        .register_taskset(
+            taskset!("LoadTest")
+                .register_task(task!(get_index).set_weight(9).unwrap())
+                .register_task(task!(get_about).set_weight(3).unwrap()),
+        )
+        .execute()
+        .unwrap();
+
+    // Confirm that we loaded the mock endpoints.
+    assert!(index.times_called() > 0);
+    assert!(about.times_called() > 0);
+
+    // Confirm that we loaded the index roughly three times as much as the about page.
+    let one_third_index = index.times_called() / 3;
+    let difference = about.times_called() as i32 - one_third_index as i32;
+    assert!(difference >= -2 && difference <= 2);
+
+    let index_stats = goose_stats
+        .requests
+        .get(&format!("GET {}", INDEX_PATH))
+        .unwrap();
+    let about_stats = goose_stats
+        .requests
+        .get(&format!("GET {}", ABOUT_PATH))
+        .unwrap();
+
+    // Confirm that the path and method are correct in the statistics.
+    assert!(index_stats.path == INDEX_PATH);
+    assert!(index_stats.method == GooseMethod::GET);
+    assert!(about_stats.path == ABOUT_PATH);
+    assert!(about_stats.method == GooseMethod::GET);
+
+    // Confirm that Goose saw fewer page loads than the server, as the statistics
+    // were reset after .5 seconds.
+    let status_code: u16 = 200;
+    assert!(index_stats.response_time_counter < index.times_called());
+    assert!(index_stats.status_code_counts[&status_code] < index.times_called());
+    assert!(index_stats.success_count < index.times_called());
+    assert!(index_stats.fail_count == 0);
+    assert!(about_stats.response_time_counter < about.times_called());
+    assert!(about_stats.status_code_counts[&status_code] < about.times_called());
+    assert!(about_stats.success_count < about.times_called());
+    assert!(about_stats.fail_count == 0);
+
+    // Verify that Goose started the correct number of users.
+    assert!(goose_stats.users == config.users.unwrap());
+}


### PR DESCRIPTION
 - change default, renaming `--reset-stats` to `--no-reset-stats`
 - display spawn stats if resetting statistics
 - modify message if spawning exits early do to `--run-time` expiring
 - document in README
 - fix #106 

Example with `--run_time` expiring:

```bash
$ cargo run --example simple -- --host http://apache.fosciana/ -t5
   Compiling goose v0.9.1-dev (/home/jandrews/devel/rust/goose)
    Finished dev [unoptimized + debuginfo] target(s) in 3.60s
     Running `target/debug/examples/simple --host 'http://apache.fosciana/' -t5`
------------------------------------------------------------------------------ 
 Name                    | # reqs         | # fails        | req/s  | fail/s
 ----------------------------------------------------------------------------- 
 GET /                   | 5              | 0 (0%)         | 1      | 0    
 POST /login             | 5              | 5 (100%)       | 1      | 1    
 ------------------------+----------------+----------------+--------+--------- 
 Aggregated              | 10             | 5 (50.0%)      | 2      | 1    
-------------------------------------------------------------------------------
 Name                    | Avg (ms)   | Min        | Max        | Median    
 ----------------------------------------------------------------------------- 
 GET /                   | 3          | 3          | 4          | 4         
 POST /login             | 18         | 18         | 20         | 19        
 ------------------------+------------+------------+------------+------------- 
 Aggregated              | 11         | 3          | 20         | 4         

5 of 8 users hatched, timer expired, resetting statistics (disable with —no-reset-stats).

------------------------------------------------------------------------------ 
 Name                    | # reqs         | # fails        | req/s  | fail/s
 ----------------------------------------------------------------------------- 
 GET /about/             | 1              | 1 (100%)       | 0      | 0    
-------------------------------------------------------------------------------
 Name                    | Avg (ms)   | Min        | Max        | Median    
 ----------------------------------------------------------------------------- 
 GET /about/             | 16         | 16         | 16         | 16        
-------------------------------------------------------------------------------
 Slowest page load within specified percentile of requests (in ms):
 ------------------------------------------------------------------------------
 Name                    | 50%    | 75%    | 98%    | 99%    | 99.9%  | 99.99%
 ----------------------------------------------------------------------------- 
 GET /about/             | 16     | 16     | 16     | 16     | 16     |     16
```

Now with `--no-reset-stats` also enabled:

```bash
$ cargo run --example simple -- --host http://apache.fosciana/ -t5 --no-reset-stats
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/examples/simple --host 'http://apache.fosciana/' -t5 --no-reset-stats`
5 of 8 users hatched, timer expired.

------------------------------------------------------------------------------ 
 Name                    | # reqs         | # fails        | req/s  | fail/s
 ----------------------------------------------------------------------------- 
 GET /                   | 5              | 0 (0%)         | 1      | 0    
 POST /login             | 5              | 5 (100%)       | 1      | 1    
 ------------------------+----------------+----------------+--------+--------- 
 Aggregated              | 10             | 5 (50.0%)      | 2      | 1    
-------------------------------------------------------------------------------
 Name                    | Avg (ms)   | Min        | Max        | Median    
 ----------------------------------------------------------------------------- 
 GET /                   | 4          | 2          | 5          | 5         
 POST /login             | 17         | 15         | 21         | 17        
 ------------------------+------------+------------+------------+------------- 
 Aggregated              | 11         | 2          | 21         | 5         
-------------------------------------------------------------------------------
 Slowest page load within specified percentile of requests (in ms):
 ------------------------------------------------------------------------------
 Name                    | 50%    | 75%    | 98%    | 99%    | 99.9%  | 99.99%
 ----------------------------------------------------------------------------- 
 GET /                   | 5      | 5      | 5      | 5      | 5      |      5
 POST /login             | 17     | 20     | 21     | 21     | 21     |     21
 ------------------------+--------+--------+--------+--------+--------+------- 
 Aggregated              | 5      | 17     | 21     | 21     | 21     |     21
```

Longer run time:

```bash
$ cargo run --example simple -- --host http://apache.fosciana/ -t30
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/examples/simple --host 'http://apache.fosciana/' -t30`
------------------------------------------------------------------------------ 
 Name                    | # reqs         | # fails        | req/s  | fail/s
 ----------------------------------------------------------------------------- 
 GET /                   | 8              | 0 (0%)         | 1      | 0    
 POST /login             | 8              | 8 (100%)       | 1      | 1    
 ------------------------+----------------+----------------+--------+--------- 
 Aggregated              | 16             | 8 (50.0%)      | 2      | 1    
-------------------------------------------------------------------------------
 Name                    | Avg (ms)   | Min        | Max        | Median    
 ----------------------------------------------------------------------------- 
 GET /                   | 4          | 3          | 9          | 4         
 POST /login             | 20         | 18         | 25         | 20        
 ------------------------+------------+------------+------------+------------- 
 Aggregated              | 12         | 3          | 25         | 9         

All 8 users hatched, resetting statistics (disable with —no-reset-stats).

------------------------------------------------------------------------------ 
 Name                    | # reqs         | # fails        | req/s  | fail/s
 ----------------------------------------------------------------------------- 
 GET /                   | 1              | 0 (0%)         | 0      | 0    
 GET /about/             | 9              | 9 (100%)       | 0      | 0    
 ------------------------+----------------+----------------+--------+--------- 
 Aggregated              | 10             | 9 (90.0%)      | 0      | 0    
-------------------------------------------------------------------------------
 Name                    | Avg (ms)   | Min        | Max        | Median    
 ----------------------------------------------------------------------------- 
 GET /                   | 12         | 12         | 12         | 12        
 GET /about/             | 19         | 10         | 80         | 12        
 ------------------------+------------+------------+------------+------------- 
 Aggregated              | 18         | 10         | 80         | 12        

------------------------------------------------------------------------------ 
 Name                    | # reqs         | # fails        | req/s  | fail/s
 ----------------------------------------------------------------------------- 
 GET /                   | 8              | 0 (0%)         | 0      | 0    
 GET /about/             | 14             | 14 (100%)      | 0      | 0    
 ------------------------+----------------+----------------+--------+--------- 
 Aggregated              | 22             | 14 (63.6%)     | 0      | 0    
-------------------------------------------------------------------------------
 Name                    | Avg (ms)   | Min        | Max        | Median    
 ----------------------------------------------------------------------------- 
 GET /                   | 11         | 10         | 13         | 11        
 GET /about/             | 16         | 10         | 80         | 11        
 ------------------------+------------+------------+------------+------------- 
 Aggregated              | 14         | 10         | 80         | 11        
-------------------------------------------------------------------------------
 Slowest page load within specified percentile of requests (in ms):
 ------------------------------------------------------------------------------
 Name                    | 50%    | 75%    | 98%    | 99%    | 99.9%  | 99.99%
 ----------------------------------------------------------------------------- 
 GET /                   | 11     | 12     | 13     | 13     | 13     |     13
 GET /about/             | 11     | 13     | 80     | 80     | 80     |     80
 ------------------------+--------+--------+--------+--------+--------+------- 
 Aggregated              | 11     | 12     | 80     | 80     | 80     |     80
```
Again, but with `--no-reset-stats` enabled:

```bash
$ cargo run --example simple -- --host http://apache.fosciana/ -t30 --no-reset-stats
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/examples/simple --host 'http://apache.fosciana/' -t30 --no-reset-stats`
All 8 users hatched.

------------------------------------------------------------------------------ 
 Name                    | # reqs         | # fails        | req/s  | fail/s
 ----------------------------------------------------------------------------- 
 GET /                   | 9              | 0 (0%)         | 0      | 0    
 GET /about/             | 10             | 10 (100%)      | 0      | 0    
 POST /login             | 8              | 8 (100%)       | 0      | 0    
 ------------------------+----------------+----------------+--------+--------- 
 Aggregated              | 27             | 18 (66.7%)     | 1      | 0    
-------------------------------------------------------------------------------
 Name                    | Avg (ms)   | Min        | Max        | Median    
 ----------------------------------------------------------------------------- 
 GET /                   | 4          | 2          | 10         | 3         
 GET /about/             | 12         | 11         | 16         | 11        
 POST /login             | 21         | 17         | 30         | 20        
 ------------------------+------------+------------+------------+------------- 
 Aggregated              | 12         | 2          | 30         | 11        

------------------------------------------------------------------------------ 
 Name                    | # reqs         | # fails        | req/s  | fail/s
 ----------------------------------------------------------------------------- 
 GET /                   | 11             | 0 (0%)         | 0      | 0    
 GET /about/             | 15             | 15 (100%)      | 0      | 0    
 POST /login             | 8              | 8 (100%)       | 0      | 0    
 ------------------------+----------------+----------------+--------+--------- 
 Aggregated              | 34             | 23 (67.6%)     | 1      | 0    
-------------------------------------------------------------------------------
 Name                    | Avg (ms)   | Min        | Max        | Median    
 ----------------------------------------------------------------------------- 
 GET /                   | 5          | 2          | 13         | 4         
 GET /about/             | 12         | 11         | 16         | 12        
 POST /login             | 21         | 17         | 30         | 20        
 ------------------------+------------+------------+------------+------------- 
 Aggregated              | 12         | 2          | 30         | 12        
-------------------------------------------------------------------------------
 Slowest page load within specified percentile of requests (in ms):
 ------------------------------------------------------------------------------
 Name                    | 50%    | 75%    | 98%    | 99%    | 99.9%  | 99.99%
 ----------------------------------------------------------------------------- 
 GET /                   | 4      | 4      | 13     | 13     | 13     |     13
 GET /about/             | 12     | 13     | 16     | 16     | 16     |     16
 POST /login             | 20     | 21     | 30     | 30     | 30     |     30
 ------------------------+--------+--------+--------+--------+--------+------- 
 Aggregated              | 12     | 16     | 23     | 30     | 30     |     30
```

