### PR TITLE
release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.9.1-dev
+## 0.9.1 Aug 1, 2020
  - return `GooseStats` from `GooseAttack` `.execute()`
  - rework as methods of `GooseStats`: `.print()`, `.print_running()`, `fmt_requests()`,
    `fmt_response_times()`, `fmt_percentiles()`, and `fmt_status_codes()`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.9.1-dev"
+version = "0.9.1"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1762,7 +1762,7 @@ impl GooseUser {
     ///
     /// By default, Goose configures two options when building a Reqwest client. The first
     /// configures Goose to report itself as the user agent requesting web pages (ie
-    /// `goose/0.9.0`). The second option configures Reqwest to store cookies, which is
+    /// `goose/0.9.1`). The second option configures Reqwest to store cookies, which is
     /// generally necessary if you aim to simulate logged in users.
     ///
     /// # Default configuration:


### PR DESCRIPTION
## 0.9.1 Aug 1, 2020
 - return `GooseStats` from `GooseAttack` `.execute()`
 - rework as methods of `GooseStats`: `.print()`, `.print_running()`, `fmt_requests()`,
   `fmt_response_times()`, `fmt_percentiles()`, and `fmt_status_codes()`
 - display `GooseStats` with fmt::Display (ie `print!("{}", goose_stats);`)
 - make it possible to pass a closure to GooseTask::new
 - fix display of `GooseError` and `GooseTaskError`
