### PR TITLE
disable gaggle test if feature isn't enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.9.2-dev
  - default to resetting statistics, disable with `--no-reset-stats`, display spawning statistics before resetting
+ - only run gaggle integration tests when feature is enabled
 
 ## 0.9.1 Aug 1, 2020
  - return `GooseStats` from `GooseAttack` `.execute()`

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -21,6 +21,7 @@ pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
 
 /// Test test_start alone.
 #[test]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
 fn test_gaggle() {
     let server = MockServer::start();
 


### PR DESCRIPTION
Only run gaggle tests if the feature is enabled.

Performed web-searches and found https://stackoverflow.com/questions/48583049/run-additional-tests-by-using-a-feature-flag-to-cargo-test to implement.

Fix #121 

With the feature not enabled:
```
$ cargo test gaggle
     Running target/debug/deps/gaggle-a993cbffbecd509a

running 1 test
test test_gaggle ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out

```

With all features enabled:
```
$ cargo test gaggle --all-features
     Running target/debug/deps/gaggle-451ba72b6f1f2257

running 1 test
test test_gaggle ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

```

And with just the `gaggle` feature enabled:
```
$ cargo test gaggle --features gaggle
     Running target/debug/deps/gaggle-774a13f7bc2ee5f3

running 1 test
test test_gaggle ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
