### PR TITLE
subtract overhead to avoid time drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.2-dev
  - default to resetting statistics, disable with `--no-reset-stats`, display spawning statistics before resetting
  - only run gaggle integration tests when feature is enabled
+ - prevent time-drift when launching users and throttling requests
 
 ## 0.9.1 Aug 1, 2020
  - return `GooseStats` from `GooseAttack` `.execute()`

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,6 +1,8 @@
 use tokio::sync::mpsc::Receiver;
 use tokio::time;
 
+use crate::util;
+
 /// This throttle thread limits the maximum number of requests that can be made across
 /// all GooseUser threads. When enabled, GooseUser threads must add a token to the
 /// bounded channel before making a request, and this thread limits how frequently
@@ -36,9 +38,10 @@ pub async fn throttle_main(
         tokens_per_duration, sleep_duration
     );
 
-    // Update throttle_started after each delay. This is used to prevent a time
-    // drift due to the time it takes to remove tokens from the throttle_receiver.
-    let mut throttle_started = time::Instant::now();
+    // One or more token gets removed from the throttle_receiver bucket at regular
+    // intervals. The throttle_drift variable tracks how much time is spent on
+    // everything else, and is subtracted from the time spent sleeping.
+    let mut throttle_drift = tokio::time::Instant::now();
 
     // Loop and remove tokens from channel at controlled rate until load test ends.
     loop {
@@ -46,10 +49,7 @@ pub async fn throttle_main(
             "throttle removing {} token(s) from channel",
             tokens_per_duration
         );
-        time::delay_for(sleep_duration - throttle_started.elapsed()).await;
-
-        // Update throttle_started after each delay.
-        throttle_started = time::Instant::now();
+        throttle_drift = util::sleep_minus_drift(sleep_duration, throttle_drift).await;
 
         // A message will be received when the load test is over.
         if parent_receiver.try_recv().is_ok() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -46,6 +46,20 @@ pub fn parse_timespan(time_str: &str) -> usize {
     }
 }
 
+/// Sleep for a specified duration, minus an time spent doing other things.
+pub async fn sleep_minus_drift(
+    duration: tokio::time::Duration,
+    drift: tokio::time::Instant,
+) -> tokio::time::Instant {
+    let elapsed = drift.elapsed();
+    if (duration - elapsed).as_nanos() > 0 {
+        tokio::time::delay_for(duration - elapsed).await;
+    } else {
+        warn!("sleep_minus_drift: drift was greater than or equal to duration, not sleeping");
+    }
+    tokio::time::Instant::now()
+}
+
 /// Calculate the greatest commond divisor using binary GCD (or Stein's) algorithm.
 /// More detail: https://en.wikipedia.org/wiki/Binary_GCD_algorithm
 pub fn gcd(u: usize, v: usize) -> usize {


### PR DESCRIPTION
In smaller load tests the drift is barely perceptible. But in larger tests the drift becomes more pronounced. This PR subtracts the drift from delays in two loops: launching users, and throttling requests.

Fixes #102 