### PR TITLE
Remove no longer needed .clone()

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -38,7 +38,7 @@ pub async fn user_main(
             for task_index in &sequence {
                 // Determine which task we're going to run next.
                 let thread_task_name = &thread_task_set.tasks[*task_index].name;
-                let function = &thread_task_set.tasks[*task_index].function.clone();
+                let function = &thread_task_set.tasks[*task_index].function;
                 debug!(
                     "launching on_start {} task from {}",
                     thread_task_name, thread_task_set.name
@@ -88,7 +88,7 @@ pub async fn user_main(
         let thread_weighted_task =
             thread_user.weighted_tasks[weighted_bucket][weighted_bucket_position];
         let thread_task_name = &thread_task_set.tasks[thread_weighted_task].name;
-        let function = &thread_task_set.tasks[thread_weighted_task].function.clone();
+        let function = &thread_task_set.tasks[thread_weighted_task].function;
         debug!(
             "launching {} task from {}",
             thread_task_name, thread_task_set.name
@@ -158,7 +158,7 @@ pub async fn user_main(
             for task_index in &sequence {
                 // Determine which task we're going to run next.
                 let thread_task_name = &thread_task_set.tasks[*task_index].name;
-                let function = &thread_task_set.tasks[*task_index].function.clone();
+                let function = &thread_task_set.tasks[*task_index].function;
                 debug!(
                     "launching on_stop {} task from {}",
                     thread_task_name, thread_task_set.name


### PR DESCRIPTION
Not sure what changed, but a recent refactor made the clone unnecessary now.

Maybe the time-drift change? Or the derive Clone on the containing struct?

(I had wanted to try if instead of cloning, pinning would have been enough)