### PR TITLE
update prelude documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  - replace `structopt` with `gumdrop`
     o restructured help page to logically group related options
     o rewrote/simplified configuration descriptions to fit standard console width
+ - update prelude documentation
 
 ## 0.9.1 Aug 1, 2020
  - return `GooseStats` from `GooseAttack` `.execute()`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,12 @@
 //! necessary for your load test, so you don't need to manually add them:
 //!
 //! ```rust
-//! use goose::{GooseAttack, task, taskset};
-//! use goose::goose::{GooseTaskSet, GooseUser, GooseTask};
+//! use goose::goose::{
+//!     GooseMethod, GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet,
+//!     GooseUser,
+//! };
+//! use goose::metrics::{GooseMetrics, GooseRequestMetrics};
+//! use goose::{task, taskset, GooseAttack, GooseError};
 //! ```
 //!
 //! Below your `main` function (which currently is the default `Hello, world!`), add

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //!     GooseMethod, GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet,
 //!     GooseUser,
 //! };
-//! use goose::metrics::{GooseMetrics, GooseRequestMetrics};
+//! use goose::metrics::GooseMetrics;
 //! use goose::{task, taskset, GooseAttack, GooseError};
 //! ```
 //!
@@ -308,7 +308,7 @@ pub mod goose;
 pub mod logger;
 #[cfg(feature = "gaggle")]
 mod manager;
-mod metrics;
+pub mod metrics;
 pub mod prelude;
 mod throttle;
 mod user;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,7 @@
 //!
 //! ```rust
 //! use goose::goose::{
-//!     GooseMethod, GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet,
-//!     GooseUser,
+//!     GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet, GooseUser,
 //! };
 //! use goose::metrics::GooseMetrics;
 //! use goose::{task, taskset, GooseAttack, GooseError};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,5 +2,5 @@ pub use crate::goose::{
     GooseMethod, GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet,
     GooseUser,
 };
-pub use crate::metrics::{GooseMetrics, GooseRequestMetrics};
+pub use crate::metrics::GooseMetrics;
 pub use crate::{task, taskset, GooseAttack, GooseError};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,5 @@
 pub use crate::goose::{
-    GooseMethod, GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet,
-    GooseUser,
+    GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet, GooseUser,
 };
 pub use crate::metrics::GooseMetrics;
 pub use crate::{task, taskset, GooseAttack, GooseError};

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -3,6 +3,7 @@ use httpmock::{Mock, MockServer};
 
 mod common;
 
+use goose::goose::GooseMethod;
 use goose::prelude::*;
 use std::sync::Arc;
 


### PR DESCRIPTION
The prelude documentation had gotten out of date. This PR updates it with what's actually defined in `src/prelude.rs`.

Fixes #134 