### PR TITLE
revert --expect-workers changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1968,7 +1968,7 @@ pub struct GooseConfiguration {
     pub no_hash_check: bool,
 
     /// Gaggle: tells manager how many workers to expect
-    #[structopt(long, required_if("manager", "true"))]
+    #[structopt(long, required = false, default_value = "0")]
     pub expect_workers: u16,
 
     /// Gaggle: sets host manager listens on, formatted x.x.x.x


### PR DESCRIPTION
This reverts the changes to `--expect-workers` and fixes #143.

With this change:
```
$ cargo run --example drupal_loadtest -- -H http://local.dev/ -t5 -v
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/examples/drupal_loadtest -H 'http://local.dev/' -t5 -v`
13:22:29 [ INFO] Output verbosity level: INFO
13:22:29 [ INFO] Logfile verbosity level: INFO
13:22:29 [ INFO] Writing to log file: goose.log
13:22:29 [ INFO] run_time = 5
13:22:29 [ INFO] concurrent users defaulted to 8 (number of CPUs)
```

It correctly throws an error if the `--manager` flag is set w/o defining `--expect-workers`:
```
jandrews@piccolo:~/devel/rust/goose$ cargo run --example drupal_loadtest -- -H http://local.dev/ -t5 -v --manager
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/examples/drupal_loadtest -H 'http://local.dev/' -t5 -v --manager`
13:23:08 [ INFO] Output verbosity level: INFO
13:23:08 [ INFO] Logfile verbosity level: INFO
13:23:08 [ INFO] Writing to log file: goose.log
13:23:08 [ INFO] run_time = 5
Error: InvalidOption { option: "--expect-workers", value: "0", detail: Some("--expect-workers must be at least 1") }
```

And it doesn't error if `--expect-workers` is correctly added:
```
$ cargo run --example drupal_loadtest --features gaggle -- -H http://local.dev/ -t5 -v --manager --expect-workers 1
   Compiling goose v0.10.0-dev (/home/jandrews/devel/rust/goose)
    Finished dev [unoptimized + debuginfo] target(s) in 9.90s
     Running `target/debug/examples/drupal_loadtest -H 'http://local.dev/' -t5 -v --manager --expect-workers 1`
13:24:26 [ INFO] Output verbosity level: INFO
13:24:26 [ INFO] Logfile verbosity level: INFO
13:24:26 [ INFO] Writing to log file: goose.log
13:24:26 [ INFO] run_time = 5
13:24:26 [ INFO] global host configured: http://local.dev/
13:24:26 [ INFO] initializing user states...
13:24:26 [ INFO] worker connecting to manager at tcp://0.0.0.0:5115
13:24:26 [ INFO] manager listening on tcp://0.0.0.0:5115, waiting for 1 workers
13:24:26 [ INFO] each worker to start 8 users
```

It correctly errors if the option is used on the worker:
```
$ cargo run --example drupal_loadtest --features gaggle -- -H http://local.dev/ -t5 -v --worker --expect-workers 1
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/examples/drupal_loadtest -H 'http://local.dev/' -t5 -v --worker --expect-workers 1`
13:25:11 [ INFO] Output verbosity level: INFO
13:25:11 [ INFO] Logfile verbosity level: INFO
13:25:11 [ INFO] Writing to log file: goose.log
Error: InvalidOption { option: "--run-time", value: "true", detail: Some("The --run-time option is only available to the manager.") }
```

And also is an error if the option is used in stand-alone mode:
```
$ cargo run --example drupal_loadtest --features gaggle -- -H http://local.dev/ -t5 -v --expect-workers 1
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/examples/drupal_loadtest -H 'http://local.dev/' -t5 -v --expect-workers 1`
13:26:03 [ INFO] Output verbosity level: INFO
13:26:03 [ INFO] Logfile verbosity level: INFO
13:26:03 [ INFO] Writing to log file: goose.log
13:26:03 [ INFO] run_time = 5
13:26:03 [ INFO] concurrent users defaulted to 8 (number of CPUs)
Error: InvalidOption { option: "--expect-workers", value: "1", detail: Some("--expect-workers is only available when running in manager mode") }
```