### PR TITLE
convert from structopt to gumpdrop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
     o `--metrics-log-file` became `--metrics-file`
     o `--metrics-log-format` became `--metrics-format`
  - reworded errors for consistency, made error.detail required
+ - replace `structopt` with `gumdrop`
+    o restructured help page to logically group related options
+    o rewrote/simplified configuration descriptions to fit standard console width
 
 ## 0.9.1 Aug 1, 2020
  - return `GooseStats` from `GooseAttack` `.execute()`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "Apache-2.0"
 [dependencies]
 ctrlc = "3.1"
 futures = "0.3"
+gumdrop = "0.8"
 http = "0.2"
 itertools = "0.9"
 lazy_static = "1.4"
@@ -27,7 +28,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"
 simplelog = "0.7"
-structopt = "0.3"
 tokio = { version = "0.2.20", features = ["fs", "io-util", "macros", "rt-core", "sync", "time"] }
 url = "2.1"
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,10 @@ optimized code. This can generate considerably more load test traffic.
 The `-h` flag will show all run-time configuration options available to Goose load tests. For example, pass the `-h` flag to the `simple` example, `cargo run --example simple -- -h`:
 
 ```
+Usage: target/debug/examples/simple [OPTIONS]
+
 Options available when launching a Goose load test.
+
 
 Optional arguments:
   -h, --help                 Displays this help
@@ -196,7 +199,7 @@ Optional arguments:
   -r, --hatch-rate RATE      Sets per-second user hatch rate (default: 1)
   -t, --run-time TIME        Stops after (30s, 20m, 3h, 1h30m, etc)
   -g, --log-level            Sets log level (-g, -gg, etc)
-  -L, --log-file LOG-FILE    Sets log file name (default: goose.log)
+  -L, --log-file NAME        Sets log file name (default: goose.log)
   -v, --verbose              Sets debug level (-v, -vv, etc)
 
 Metrics:
@@ -204,7 +207,7 @@ Metrics:
   --no-reset-metrics         Doesn't reset metrics after all users have started
   --no-metrics               Doesn't track metrics
   --no-task-metrics          Doesn't track task metrics
-  --metrics-file NAME        Sets metrics log file name
+  -m, --metrics-file NAME    Sets metrics log file name
   --metrics-format FORMAT    Sets metrics log format (csv, json, raw) (default: json)
   -d, --debug-file NAME      Sets debug log file name
   --debug-format FORMAT      Sets debug log format (json, raw) (default: json)

--- a/README.md
+++ b/README.md
@@ -184,46 +184,45 @@ optimized code. This can generate considerably more load test traffic.
 The `-h` flag will show all run-time configuration options available to Goose load tests. For example, pass the `-h` flag to the `simple` example, `cargo run --example simple -- -h`:
 
 ```
-Goose 0.10.0
-Options available when launching a Goose load test
+Options available when launching a Goose load test.
 
-USAGE:
-    simple [FLAGS] [OPTIONS]
+Optional arguments:
+  -h, --help                 Displays this help
+  -V, --version              Prints version information
+  -l, --list                 Lists all tasks and exits
 
-FLAGS:
-    -h, --help                Prints help information
-    -l, --list                Lists all tasks and exits
-    -g, --log-level           Sets log level (-g, -gg, -ggg, etc.)
-        --manager             Gaggle: enables Manager mode
-        --no-hash-check       Gaggle: ignores Worker load test checksum
-        --no-metrics          Doesn't track or print metrics
-        --no-reset-metrics    Resets metrics once all users have started
-        --no-task-metrics     Doesn't track or print task metrics
-        --only-summary        Only prints final summary metrics in the console
-        --status-codes        Tracks and prints status code metrics
-        --sticky-follow       Tells users to follow redirect of base_url with subsequent requests
-    -V, --version             Prints version information
-    -v, --verbose             Sets debug level (-v, -vv, -vvv, etc.)
-        --worker              Gaggle: enables Worker mode
+  -H, --host HOST            Defines host to load test (ie http://10.21.32.33)
+  -u, --users USERS          Sets concurrent users (default: number of CPUs)
+  -r, --hatch-rate RATE      Sets per-second user hatch rate (default: 1)
+  -t, --run-time TIME        Stops after (30s, 20m, 3h, 1h30m, etc)
+  -g, --log-level            Sets log level (-g, -gg, etc)
+  -L, --log-file LOG-FILE    Sets log file name (default: goose.log)
+  -v, --verbose              Sets debug level (-v, -vv, etc)
 
-OPTIONS:
-    -d, --debug-file <debug-file>                  Sets debug log file name [default: ]
-        --debug-format <debug-format>              Sets debug log format ('json' or 'raw') [default: json]
-        --expect-workers <expect-workers>          Gaggle: tells Manager how many Workers to expect [default: 0]
-    -r, --hatch-rate <hatch-rate>                  Sets per-second user hatch rate [default: 1]
-    -H, --host <host>                              Host to load test (ie http://10.21.32.33) [default: ]
-        --log-file <log-file>                      Sets log file name [default: goose.log]
-        --manager-bind-host <manager-bind-host>
-            Gaggle: sets host Manager listens on, formatted x.x.x.x [default: 0.0.0.0]
+Metrics:
+  --only-summary             Only prints final summary metrics
+  --no-reset-metrics         Doesn't reset metrics after all users have started
+  --no-metrics               Doesn't track metrics
+  --no-task-metrics          Doesn't track task metrics
+  --metrics-file NAME        Sets metrics log file name
+  --metrics-format FORMAT    Sets metrics log format (csv, json, raw) (default: json)
+  -d, --debug-file NAME      Sets debug log file name
+  --debug-format FORMAT      Sets debug log format (json, raw) (default: json)
+  --status-codes             Tracks additional status code metrics
 
-        --manager-bind-port <manager-bind-port>    Gaggle: sets port Manager listens on [default: 5115]
-        --manager-host <manager-host>              Gaggle: sets host Worker connects to Manager on [default: 127.0.0.1]
-        --manager-port <manager-port>              Gaggle: sets port Worker connects to Manager on [default: 5115]
-    -s, --metrics-file <metrics-file>              Sets metrics log file name [default: ]
-        --metrics-format <metrics-format>          Sets metrics log format ('csv', 'json', or 'raw') [default: json]
-    -t, --run-time <run-time>                      Stops load test after e.g. (30s, 20m, 3h, 1h30m, etc.) [default: ]
-        --throttle-requests <throttle-requests>    Sets maximum requests per second
-    -u, --users <users>                            Sets concurrent Goose users (defaults to available CPUs)
+Advanced:
+  --throttle-requests VALUE  Sets maximum requests per second
+  --sticky-follow            Follows base_url redirect with subsequent requests
+
+Gaggle:
+  --manager                  Enables distributed load test Manager mode
+  --expect-workers VALUE     Sets number of Workers to expect
+  --no-hash-check            Tells Manager to ignore load test checksum
+  --manager-bind-host HOST   Sets host Manager listens on (default: 0.0.0.0)
+  --manager-bind-port PORT   Sets port Manager listens on (default: 5115)
+  --worker                   Enables distributed load test Worker mode
+  --manager-host HOST        Sets host Worker connects to (default: 127.0.0.1)
+  --manager-port PORT        Sets port Worker connects to (default: 5115)
 ```
 
 The `examples/simple.rs` example copies the simple load test documented on the locust.io web page, rewritten in Rust for Goose. It uses minimal advanced functionality, but demonstrates how to GET and POST pages. It defines a single Task Set which has the user log in and then load a couple of pages.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1881,7 +1881,7 @@ pub struct GooseConfiguration {
     #[options(short = "g", count)]
     pub log_level: u8,
     /// Sets log file name
-    #[options(default = "goose.log", help = "Sets log file name")]
+    #[options(default = "goose.log", help = "Sets log file name", meta = "NAME")]
     pub log_file: String,
     #[options(
         count,
@@ -1904,7 +1904,7 @@ pub struct GooseConfiguration {
     #[options(no_short)]
     pub no_task_metrics: bool,
     /// Sets metrics log file name
-    #[options(no_short, meta = "NAME")]
+    #[options(short = "m", meta = "NAME")]
     pub metrics_file: String,
     /// Sets metrics log format (csv, json, raw)
     #[options(no_short, default = "json", meta = "FORMAT")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,9 +524,9 @@ impl GooseAttack {
     /// # Example
     /// ```rust,no_run
     ///     use goose::{GooseAttack, GooseConfiguration};
-    ///     use structopt::StructOpt;
+    ///     use gumdrop::Options;
     ///
-    ///     let configuration = GooseConfiguration::from_args();
+    ///     let configuration = GooseConfiguration::parse_args_default_or_exit();
     ///     let mut goose_attack = GooseAttack::initialize_with_config(configuration);
     /// ```
     pub fn initialize_with_config(config: GooseConfiguration) -> GooseAttack {
@@ -590,7 +590,13 @@ impl GooseAttack {
     }
 
     pub fn setup(mut self) -> Result<Self, GooseError> {
-        //self.initialize_logger();
+        // If version flag is set, display package name and version and exit.
+        if self.configuration.version {
+            println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+            std::process::exit(0);
+        }
+
+        self.initialize_logger();
 
         // Collecting metrics is required for the following options.
         if self.configuration.no_metrics {
@@ -1852,6 +1858,9 @@ pub struct GooseConfiguration {
     /// Displays this help
     #[options(short = "h")]
     pub help: bool,
+    /// Prints version information
+    #[options(short = "V")]
+    pub version: bool,
     // Add a blank line after this option
     #[options(short = "l", help = "Lists all tasks and exits\n")]
     pub list: bool,
@@ -1859,14 +1868,14 @@ pub struct GooseConfiguration {
     /// Defines host to load test (ie http://10.21.32.33)
     #[options(short = "H")]
     pub host: String,
-    /// Sets concurrent users (default: # of CPUs)
+    /// Sets concurrent users (default: number of CPUs)
     #[options(short = "u")]
     pub users: Option<usize>,
     /// Sets per-second user hatch rate
     #[options(short = "r", default = "1", meta = "RATE")]
     pub hatch_rate: usize,
     /// Stops after (30s, 20m, 3h, 1h30m, etc)
-    #[options(short = "t", default = "", meta = "TIME")]
+    #[options(short = "t", meta = "TIME")]
     pub run_time: String,
     /// Sets log level (-g, -gg, etc)
     #[options(short = "g", count)]
@@ -1874,10 +1883,10 @@ pub struct GooseConfiguration {
     /// Sets log file name
     #[options(default = "goose.log", help = "Sets log file name")]
     pub log_file: String,
-    // Add a blank line and then a Metrics: header after this option
     #[options(
-        short = "v",
         count,
+        short = "v",
+        // Add a blank line and then a 'Metrics:' header after this option
         help = "Sets debug level (-v, -vv, etc)\n\nMetrics:"
     )]
     pub verbose: u8,
@@ -1885,7 +1894,7 @@ pub struct GooseConfiguration {
     /// Only prints final summary metrics
     #[options(no_short)]
     pub only_summary: bool,
-    /// Resets metrics once all users have started
+    /// Doesn't reset metrics after all users have started
     #[options(no_short)]
     pub no_reset_metrics: bool,
     /// Doesn't track metrics
@@ -1895,15 +1904,15 @@ pub struct GooseConfiguration {
     #[options(no_short)]
     pub no_task_metrics: bool,
     /// Sets metrics log file name
-    #[options(no_short, default = "", meta = "NAME")]
+    #[options(no_short, meta = "NAME")]
     pub metrics_file: String,
-    /// Sets metrics log format ('csv', 'json', 'raw')
+    /// Sets metrics log format (csv, json, raw)
     #[options(no_short, default = "json", meta = "FORMAT")]
     pub metrics_format: String,
     /// Sets debug log file name
-    #[options(short = "d", default = "", meta = "NAME")]
+    #[options(short = "d", meta = "NAME")]
     pub debug_file: String,
-    /// Sets debug log format ('json', 'raw')
+    /// Sets debug log format (json, raw)
     #[options(no_short, default = "json", meta = "FORMAT")]
     pub debug_format: String,
     // Add a blank line and then an Advanced: header after this option
@@ -1923,7 +1932,7 @@ pub struct GooseConfiguration {
     #[options(no_short)]
     pub manager: bool,
     /// Sets number of Workers to expect
-    #[options(no_short, default = "0", meta = "VALUE")]
+    #[options(no_short, meta = "VALUE")]
     pub expect_workers: u16,
     /// Tells Manager to ignore load test checksum
     #[options(no_short)]
@@ -1932,7 +1941,7 @@ pub struct GooseConfiguration {
     #[options(no_short, default = "0.0.0.0", meta = "HOST")]
     pub manager_bind_host: String,
     /// Sets port Manager listens on
-    // @TODO: use constant
+    // @TODO: use const for default
     #[options(no_short, default = "5115", meta = "PORT")]
     pub manager_bind_port: u16,
     /// Enables distributed load test Worker mode
@@ -1942,7 +1951,7 @@ pub struct GooseConfiguration {
     #[options(no_short, default = "127.0.0.1", meta = "HOST")]
     pub manager_host: String,
     /// Sets port Worker connects to
-    // @TODO: use constant
+    // @TODO: use const for default
     #[options(no_short, default = "5115", meta = "PORT")]
     pub manager_port: u16,
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,38 +1,27 @@
+use gumdrop::Options;
 use httpmock::MockServer;
 
 use goose::GooseConfiguration;
 
 pub fn build_configuration(server: &MockServer) -> GooseConfiguration {
-    // Manually specify configuration for test, normally this is provided as
-    // CLI options.
-    GooseConfiguration {
-        help: false,
-        host: server.url("/"),
-        users: Some(1),
-        hatch_rate: 1,
-        run_time: "1".to_string(),
-        no_metrics: true,
-        no_task_metrics: true,
-        status_codes: false,
-        only_summary: false,
-        no_reset_metrics: false,
-        list: false,
-        verbose: 0,
-        log_level: 0,
-        log_file: "goose.log".to_string(),
-        metrics_file: "".to_string(),
-        metrics_format: "json".to_string(),
-        debug_file: "".to_string(),
-        debug_format: "json".to_string(),
-        throttle_requests: None,
-        sticky_follow: false,
-        manager: false,
-        no_hash_check: false,
-        expect_workers: 0,
-        manager_bind_host: "0.0.0.0".to_string(),
-        manager_bind_port: 5115,
-        worker: false,
-        manager_host: "127.0.0.1".to_string(),
-        manager_port: 5115,
-    }
+    // Using default options, except for those specified below
+    GooseConfiguration::parse_args_default(&[
+        // Set --host to server URL
+        "--host",
+        &server.url("/"),
+        // Set --users to 1
+        "--users",
+        "1",
+        // Set --hatch-rate to 1
+        "--hatch-rate",
+        "1",
+        // Set --run-time to 1
+        "--run-time",
+        "1",
+        // Set --no-metrics flag
+        "--no-metrics",
+        // Set --no-task-metrics flag
+        "--no-task-metrics",
+    ])
+    .unwrap()
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -6,6 +6,7 @@ pub fn build_configuration(server: &MockServer) -> GooseConfiguration {
     // Manually specify configuration for test, normally this is provided as
     // CLI options.
     GooseConfiguration {
+        help: false,
         host: server.url("/"),
         users: Some(1),
         hatch_rate: 1,


### PR DESCRIPTION
**CHANGES**
 - replaced `structopt` with `gumpdrop`, fixing #149 
 - gumpdrop doesn't auto-sort options, so this proved a good opportunity to structure options more logically
 - added spaces between and headers before grouped options
 - renamed "meta" variable names for options with longer names, for example, `--metrics-format <metrics-format>` becomes `--metrics-format FORMAT`, and `--expect-workers <expect-workers>` becomes `--expect-workers VALUE`
 - `gumpdrop` moves us closer to addressing #144 as it also parses a slice of &str's the same as parsing run-time-options (it's a non-trivial change to fix completely, so will do in a followup PR)

Compiling on my 8-core laptop with `structopt`:
```
    Finished dev [unoptimized + debuginfo] target(s) in 57.51s

real	0m57.551s
user	4m8.621s
sys	0m13.067s
```

Compiling on my 8-core laptop with `gumdrop` (a 18% speedup):
```
    Finished dev [unoptimized + debuginfo] target(s) in 47.72s

real	0m47.733s
user	3m54.526s
sys	0m11.110s
```

Compiling on my 1-core testing VM with `structopt`:
```
    Finished release [optimized] target(s) in 7m 26s

real	7m26.085s
user	7m20.924s
sys	0m4.614s
```

And again, compiling on my 1-core testing VM with `gumdrop` (an 8% speedup):
```
   Compiling goose v0.10.0-dev (/home/jandrews/goose)
    Finished release [optimized] target(s) in 6m 47s

real	6m47.811s
user	6m41.236s
sys	0m4.315s
```
I also was able to take more control of the resulting help screen. This is how it looks with `structopt`:
```
CLI options available when launching a Goose load test

USAGE:
    drupal_loadtest [FLAGS] [OPTIONS]

FLAGS:
    -h, --help                Prints help information
    -l, --list                Lists all tasks and exits
    -g, --log-level           Sets log level (-g, -gg, -ggg, etc.)
        --manager             Gaggle: enables manager mode
        --no-hash-check       Gaggle: ignores worker load test checksum
        --no-metrics          Doesn't track or print metrics
        --no-reset-metrics    Resets metrics once all users have started
        --no-task-metrics     Doesn't track or print task metrics
        --only-summary        Only prints final summary metrics in the console
        --status-codes        Tracks and prints status code metrics
        --sticky-follow       Tells users to follow redirect of base_url with subsequent requests
    -V, --version             Prints version information
    -v, --verbose             Sets debug level (-v, -vv, -vvv, etc.)
        --worker              Gaggle: enables worker mode

OPTIONS:
    -d, --debug-log-file <debug-log-file>            Sets debug log file name [default: ]
        --debug-log-format <debug-log-format>        Sets debug log format ('json' or 'raw') [default: json]
        --expect-workers <expect-workers>            Gaggle: tells manager how many workers to expect [default: 0]
    -r, --hatch-rate <hatch-rate>                    Sets per-second user hatch rate [default: 1]
    -H, --host <host>                                Host to load test (ie http://10.21.32.33) [default: ]
        --log-file <log-file>                        Sets log file name [default: goose.log]
        --manager-bind-host <manager-bind-host>
            Gaggle: sets host manager listens on, formatted x.x.x.x [default: 0.0.0.0]

        --manager-bind-port <manager-bind-port>      Gaggle: sets port manager listens on [default: 5115]
        --manager-host <manager-host>
            Gaggle: sets host worker connects to manager on [default: 127.0.0.1]

        --manager-port <manager-port>                Gaggle: sets port worker connects to manager on [default: 5115]
    -s, --metrics-log-file <metrics-log-file>        Sets metrics log file name [default: ]
        --metrics-log-format <metrics-log-format>    Sets metrics log format ('csv', 'json', or 'raw') [default: json]
    -t, --run-time <run-time>                        Stops load test after e.g. (30s, 20m, 3h, 1h30m, etc.) [default: ]
        --throttle-requests <throttle-requests>      Sets maximum requests per second
    -u, --users <users>                              Sets concurrent Goose users (defaults to available CPUs)
```

Here it is restructured using `gumdrop` in this PR:
```
Usage: target/debug/examples/drupal_loadtest [OPTIONS]

Options available when launching a Goose load test.


Optional arguments:
  -h, --help                 Displays this help
  -V, --version              Prints version information
  -l, --list                 Lists all tasks and exits

  -H, --host HOST            Defines host to load test (ie http://10.21.32.33)
  -u, --users USERS          Sets concurrent users (default: number of CPUs)
  -r, --hatch-rate RATE      Sets per-second user hatch rate (default: 1)
  -t, --run-time TIME        Stops after (30s, 20m, 3h, 1h30m, etc)
  -g, --log-level            Sets log level (-g, -gg, etc)
  -L, --log-file NAME        Sets log file name (default: goose.log)
  -v, --verbose              Sets debug level (-v, -vv, etc)

Metrics:
  --only-summary             Only prints final summary metrics
  --no-reset-metrics         Doesn't reset metrics after all users have started
  --no-metrics               Doesn't track metrics
  --no-task-metrics          Doesn't track task metrics
  -m, --metrics-file NAME    Sets metrics log file name
  --metrics-format FORMAT    Sets metrics log format (csv, json, raw) (default: json)
  -d, --debug-file NAME      Sets debug log file name
  --debug-format FORMAT      Sets debug log format (json, raw) (default: json)
  --status-codes             Tracks additional status code metrics

Advanced:
  --throttle-requests VALUE  Sets maximum requests per second
  --sticky-follow            Follows base_url redirect with subsequent requests

Gaggle:
  --manager                  Enables distributed load test manager mode
  --expect-workers VALUE     Sets number of workers to expect
  --no-hash-check            Tells manager to ignore load test checksum
  --manager-bind-host HOST   Sets host manager listens on (default: 0.0.0.0)
  --manager-bind-port PORT   Sets port manager listens on (default: 5115)
  --worker                   Enables distributed load test worker mode
  --manager-host HOST        Sets host worker connects to (default: 127.0.0.1)
  --manager-port PORT        Sets port worker connects to (default: 5115)
```