### PR TITLE
consistently build configuration from arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     o rewrote/simplified configuration descriptions to fit standard console width
  - update prelude documentation
  - increase precision of metrics for smaller values
+ - consistently build configuration from arguments
 
 ## 0.9.1 Aug 1, 2020
  - return `GooseStats` from `GooseAttack` `.execute()`

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -2207,11 +2207,14 @@ impl Hash for GooseTask {
 mod tests {
     use super::*;
 
+    use gumdrop::Options;
     use httpmock::Method::{GET, POST};
     use httpmock::{Mock, MockServer};
 
+    const EMPTY_ARGS: Vec<&str> = vec![];
+
     async fn setup_user(server: &MockServer) -> Result<GooseUser, GooseError> {
-        let configuration = GooseConfiguration::default();
+        let configuration = GooseConfiguration::parse_args_default(&EMPTY_ARGS).unwrap();
         let base_url = get_base_url(Some(server.url("/")), None, None).unwrap();
         GooseUser::single(base_url, &configuration)
     }
@@ -2639,7 +2642,7 @@ mod tests {
     #[tokio::test]
     async fn goose_user() {
         const HOST: &str = "http://example.com/";
-        let configuration = GooseConfiguration::default();
+        let configuration = GooseConfiguration::parse_args_default(&EMPTY_ARGS).unwrap();
         let base_url = get_base_url(Some(HOST.to_string()), None, None).unwrap();
         let user = GooseUser::new(0, base_url, 0, 0, &configuration, 0).unwrap();
         assert_eq!(user.task_sets_index, 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1856,7 +1856,7 @@ impl GooseAttack {
 }
 
 /// Options available when launching a Goose load test.
-#[derive(Options, Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Options, Debug, Clone, Serialize, Deserialize)]
 pub struct GooseConfiguration {
     /// Displays this help
     #[options(short = "h")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,18 +505,18 @@ impl GooseAttack {
     ///     let mut goose_attack = GooseAttack::initialize();
     /// ```
     pub fn initialize() -> Result<GooseAttack, GooseError> {
-        let config = GooseConfiguration::parse_args_default_or_exit();
-        let users = GooseAttack::set_users(&config)?;
+        let configuration = GooseConfiguration::parse_args_default_or_exit();
+        let users = GooseAttack::set_users(&configuration)?;
         let goose_attack = GooseAttack {
             test_start_task: None,
             test_stop_task: None,
             task_sets: Vec::new(),
             weighted_users: Vec::new(),
             host: None,
-            configuration: config,
+            configuration,
             number_of_cpus: num_cpus::get(),
             run_time: 0,
-            users: users,
+            users,
             started: None,
             metrics: GooseMetrics::default(),
         };
@@ -534,18 +534,20 @@ impl GooseAttack {
     ///     let configuration = GooseConfiguration::parse_args_default_or_exit();
     ///     let mut goose_attack = GooseAttack::initialize_with_config(configuration);
     /// ```
-    pub fn initialize_with_config(config: GooseConfiguration) -> Result<GooseAttack, GooseError> {
-        let users = GooseAttack::set_users(&config)?;
+    pub fn initialize_with_config(
+        configuration: GooseConfiguration,
+    ) -> Result<GooseAttack, GooseError> {
+        let users = GooseAttack::set_users(&configuration)?;
         Ok(GooseAttack {
             test_start_task: None,
             test_stop_task: None,
             task_sets: Vec::new(),
             weighted_users: Vec::new(),
             host: None,
-            configuration: config,
+            configuration,
             number_of_cpus: num_cpus::get(),
             run_time: 0,
-            users: users,
+            users,
             started: None,
             metrics: GooseMetrics::default(),
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,7 @@ impl GooseAttack {
     /// ```
     pub fn initialize() -> Result<GooseAttack, GooseError> {
         let configuration = GooseConfiguration::parse_args_default_or_exit();
-        let users = GooseAttack::set_users(&configuration)?;
+        let users = GooseAttack::calculate_users(&configuration)?;
         let goose_attack = GooseAttack {
             test_start_task: None,
             test_stop_task: None,
@@ -537,7 +537,7 @@ impl GooseAttack {
     pub fn initialize_with_config(
         configuration: GooseConfiguration,
     ) -> Result<GooseAttack, GooseError> {
-        let users = GooseAttack::set_users(&configuration)?;
+        let users = GooseAttack::calculate_users(&configuration)?;
         Ok(GooseAttack {
             test_start_task: None,
             test_stop_task: None,
@@ -597,9 +597,9 @@ impl GooseAttack {
         info!("Writing to log file: {}", log_file.display());
     }
 
-    // Helper to determine the number of user threads to launch, defaulting to the
-    // number of CPU cores available.
-    fn set_users(config: &GooseConfiguration) -> Result<usize, GooseError> {
+    // Helper to calculate the number of user threads to launch, defaulting to
+    // the number of CPU cores available.
+    fn calculate_users(config: &GooseConfiguration) -> Result<usize, GooseError> {
         match config.users {
             Some(u) => {
                 if u == 0 {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -506,9 +506,13 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
 mod tests {
     use super::*;
 
+    use gumdrop::Options;
+
+    const EMPTY_ARGS: Vec<&str> = vec![];
+
     #[test]
     fn test_distribute_users() {
-        let config = GooseConfiguration::default();
+        let config = GooseConfiguration::parse_args_default(&EMPTY_ARGS).unwrap();
         let mut goose_attack = GooseAttack::initialize_with_config(config);
 
         goose_attack.users = 10;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -508,27 +508,27 @@ mod tests {
 
     use gumdrop::Options;
 
-    const EMPTY_ARGS: Vec<&str> = vec![];
-
     #[test]
     fn test_distribute_users() {
-        let config = GooseConfiguration::parse_args_default(&EMPTY_ARGS).unwrap();
-        let mut goose_attack = GooseAttack::initialize_with_config(config);
-
-        goose_attack.users = 10;
-        goose_attack.configuration.expect_workers = 2;
+        let ten_users_two_workers: Vec<&str> = vec!["--users", "10", "--expect-workers", "2"];
+        let config = GooseConfiguration::parse_args_default(&ten_users_two_workers).unwrap();
+        let goose_attack = GooseAttack::initialize_with_config(config).unwrap();
         let (users_per_process, users_remainder) = distribute_users(&goose_attack);
         assert_eq!(users_per_process, 5);
         assert_eq!(users_remainder, 0);
 
-        goose_attack.users = 1;
-        goose_attack.configuration.expect_workers = 1;
+        let one_user_one_worker: Vec<&str> = vec!["--users", "1", "--expect-workers", "1"];
+        let config = GooseConfiguration::parse_args_default(&one_user_one_worker).unwrap();
+        let goose_attack = GooseAttack::initialize_with_config(config).unwrap();
         let (users_per_process, users_remainder) = distribute_users(&goose_attack);
         assert_eq!(users_per_process, 1);
         assert_eq!(users_remainder, 0);
 
-        goose_attack.users = 100;
-        goose_attack.configuration.expect_workers = 21;
+        let onehundred_users_twentyone_workers: Vec<&str> =
+            vec!["--users", "100", "--expect-workers", "21"];
+        let config =
+            GooseConfiguration::parse_args_default(&onehundred_users_twentyone_workers).unwrap();
+        let goose_attack = GooseAttack::initialize_with_config(config).unwrap();
         let (users_per_process, users_remainder) = distribute_users(&goose_attack);
         assert_eq!(users_per_process, 4);
         assert_eq!(users_remainder, 16);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -204,7 +204,10 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     );
     let sleep_duration = time::Duration::from_secs_f32(hatch_rate.unwrap());
 
-    let mut worker_goose_attack = GooseAttack::initialize_with_config(config.clone());
+    let mut worker_goose_attack = GooseAttack::initialize_with_config(config.clone())
+        .map_err(|error| eprintln!("{:?} worker_id({})", error, get_worker_id()))
+        .expect("failed to launch GooseAttack");
+
     worker_goose_attack.started = Some(time::Instant::now());
     worker_goose_attack.task_sets = goose_attack.task_sets.clone();
     if config.run_time != "" {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,8 +1,11 @@
+use gumdrop::Options;
 use nng::*;
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::Ordering;
 use std::{thread, time};
 use url::Url;
+
+const EMPTY_ARGS: Vec<&str> = vec![];
 
 use crate::goose::{GooseUser, GooseUserCommand};
 use crate::manager::GooseUserInitializer;
@@ -84,7 +87,8 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     );
 
     let mut hatch_rate: Option<f32> = None;
-    let mut config: GooseConfiguration = GooseConfiguration::default();
+    let mut config: GooseConfiguration = GooseConfiguration::parse_args_default(&EMPTY_ARGS)
+        .expect("failed to generate default configuration");
     let mut weighted_users: Vec<GooseUser> = Vec::new();
 
     // Wait for the manager to send user parameters.

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,25 +3,45 @@ use httpmock::MockServer;
 
 use goose::GooseConfiguration;
 
-pub fn build_configuration(server: &MockServer) -> GooseConfiguration {
-    // Using default options, except for those specified below
-    GooseConfiguration::parse_args_default(&[
-        // Set --host to server URL
-        "--host",
-        &server.url("/"),
-        // Set --users to 1
-        "--users",
-        "1",
-        // Set --hatch-rate to 1
-        "--hatch-rate",
-        "1",
-        // Set --run-time to 1
-        "--run-time",
-        "1",
-        // Set --no-metrics flag
-        "--no-metrics",
-        // Set --no-task-metrics flag
-        "--no-task-metrics",
-    ])
-    .unwrap()
+/// The following options are configured by default, if not set to a custom value
+/// and if not building a Worker configuration:
+///  --host <mock-server>
+///  --users 1
+///  --hatch-rate 1
+///  --run-time 1
+pub fn build_configuration(server: &MockServer, custom: Vec<&str>) -> GooseConfiguration {
+    // Start with an empty configuration.
+    let mut configuration: Vec<&str> = vec![];
+    // Declare server_url here no matter what, so its lifetime is sufficient when needed.
+    let server_url = server.url("/");
+
+    // Merge in all custom options first.
+    configuration.extend_from_slice(&custom);
+
+    // If not building a Worker configuration, set some defaults.
+    if !configuration.contains(&"--worker") {
+        // Default to using mock server if not otherwise configured.
+        if !configuration.contains(&"--host") {
+            configuration.extend_from_slice(&["--host", &server_url]);
+        }
+
+        // Default to testing with 1 user if not otherwise configured.
+        if !configuration.contains(&"--users") {
+            configuration.extend_from_slice(&["--users", "1"]);
+        }
+
+        // Default to hatch 1 user per second if not otherwise configured.
+        if !configuration.contains(&"--hatch-rate") {
+            configuration.extend_from_slice(&["--hatch-rate", "1"]);
+        }
+
+        // Default to running for 1 second if not otherwise configured.
+        if !configuration.contains(&"--run-time") {
+            configuration.extend_from_slice(&["--run-time", "1"]);
+        }
+    }
+
+    // Parse these options to generate a GooseConfiguration.
+    GooseConfiguration::parse_args_default(&configuration)
+        .expect("failed to parse options and generate a configuration")
 }

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -41,14 +41,7 @@ fn test_gaggle() {
     // Launch workers in their own threads, storing the thread handle.
     let mut worker_handles = Vec::new();
     // Each worker has the same identical configuration.
-    let mut worker_configuration = common::build_configuration(&server);
-    worker_configuration.worker = true;
-    worker_configuration.host = "".to_string();
-    worker_configuration.users = None;
-    worker_configuration.no_metrics = false;
-    worker_configuration.run_time = "".to_string();
-    // Can't change this on the worker.
-    worker_configuration.no_task_metrics = false;
+    let worker_configuration = common::build_configuration(&server, vec!["--worker"]);
     for _ in 0..2 {
         let configuration = worker_configuration.clone();
         // Start worker instance of the load test.
@@ -65,16 +58,22 @@ fn test_gaggle() {
     }
 
     // Start manager instance in current thread and run a distributed load test.
-    let mut manager_configuration = common::build_configuration(&server);
-    manager_configuration.users = Some(2);
-    manager_configuration.hatch_rate = 4;
-    manager_configuration.manager = true;
-    manager_configuration.expect_workers = 2;
-    manager_configuration.run_time = "3".to_string();
-    // Enable statistics so we can validate they are merged to the manager correctly.
-    manager_configuration.no_metrics = false;
-    manager_configuration.no_task_metrics = false;
-    manager_configuration.no_reset_metrics = true;
+    let manager_configuration = common::build_configuration(
+        &server,
+        vec![
+            "--manager",
+            "--expect-workers",
+            "2",
+            "--users",
+            "2",
+            "--hatch-rate",
+            "4",
+            "--run-time",
+            "3",
+            // Enable statistics so we can validate they are merged to the manager correctly.
+            "--no-reset-metrics",
+        ],
+    );
     let goose_metrics = crate::GooseAttack::initialize_with_config(manager_configuration)
         .unwrap()
         .setup()

--- a/tests/gaggle.rs
+++ b/tests/gaggle.rs
@@ -54,6 +54,7 @@ fn test_gaggle() {
         // Start worker instance of the load test.
         worker_handles.push(thread::spawn(move || {
             let _goose_metrics = crate::GooseAttack::initialize_with_config(configuration)
+                .unwrap()
                 .setup()
                 .unwrap()
                 .register_taskset(taskset!("User1").register_task(task!(get_index)))
@@ -75,6 +76,7 @@ fn test_gaggle() {
     manager_configuration.no_task_metrics = false;
     manager_configuration.no_reset_metrics = true;
     let goose_metrics = crate::GooseAttack::initialize_with_config(manager_configuration)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(taskset!("User1").register_task(task!(get_index)))

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -56,6 +56,7 @@ fn test_metrics_logs_json() {
     config.metrics_file = METRICS_FILE.to_string();
     config.no_metrics = false;
     let goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -93,6 +94,7 @@ fn test_metrics_logs_csv() {
     config.metrics_format = "csv".to_string();
     config.no_metrics = false;
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -127,6 +129,7 @@ fn test_metrics_logs_raw() {
     config.metrics_format = "raw".to_string();
     config.no_metrics = false;
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(taskset!("LoadTest").register_task(task!(get_index)))
@@ -165,6 +168,7 @@ fn test_debug_logs_raw() {
     config.debug_file = DEBUG_FILE.to_string();
     config.debug_format = "raw".to_string();
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(
@@ -207,6 +211,7 @@ fn test_debug_logs_json() {
     let mut config = common::build_configuration(&server);
     config.debug_file = DEBUG_FILE.to_string();
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(
@@ -252,6 +257,7 @@ fn test_metrics_and_debug_logs() {
     config.no_metrics = false;
     config.debug_file = DEBUG_FILE.to_string();
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -52,9 +52,7 @@ fn test_metrics_logs_json() {
         .return_status(200)
         .create_on(&server);
 
-    let mut config = common::build_configuration(&server);
-    config.metrics_file = METRICS_FILE.to_string();
-    config.no_metrics = false;
+    let config = common::build_configuration(&server, vec!["--metrics-file", METRICS_FILE]);
     let goose_metrics = crate::GooseAttack::initialize_with_config(config)
         .unwrap()
         .setup()
@@ -89,10 +87,10 @@ fn test_metrics_logs_csv() {
         .return_status(200)
         .create_on(&server);
 
-    let mut config = common::build_configuration(&server);
-    config.metrics_file = METRICS_FILE.to_string();
-    config.metrics_format = "csv".to_string();
-    config.no_metrics = false;
+    let config = common::build_configuration(
+        &server,
+        vec!["--metrics-file", METRICS_FILE, "--metrics-format", "csv"],
+    );
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
         .unwrap()
         .setup()
@@ -124,10 +122,10 @@ fn test_metrics_logs_raw() {
         .return_status(200)
         .create_on(&server);
 
-    let mut config = common::build_configuration(&server);
-    config.metrics_file = METRICS_FILE.to_string();
-    config.metrics_format = "raw".to_string();
-    config.no_metrics = false;
+    let config = common::build_configuration(
+        &server,
+        vec!["--metrics-file", METRICS_FILE, "--metrics-format", "raw"],
+    );
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
         .unwrap()
         .setup()
@@ -164,9 +162,10 @@ fn test_debug_logs_raw() {
         .return_status(503)
         .create_on(&server);
 
-    let mut config = common::build_configuration(&server);
-    config.debug_file = DEBUG_FILE.to_string();
-    config.debug_format = "raw".to_string();
+    let config = common::build_configuration(
+        &server,
+        vec!["--debug-file", DEBUG_FILE, "--debug-format", "raw"],
+    );
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
         .unwrap()
         .setup()
@@ -208,8 +207,7 @@ fn test_debug_logs_json() {
         .return_status(503)
         .create_on(&server);
 
-    let mut config = common::build_configuration(&server);
-    config.debug_file = DEBUG_FILE.to_string();
+    let config = common::build_configuration(&server, vec!["--debug-file", DEBUG_FILE]);
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
         .unwrap()
         .setup()
@@ -251,11 +249,17 @@ fn test_metrics_and_debug_logs() {
         .return_status(503)
         .create_on(&server);
 
-    let mut config = common::build_configuration(&server);
-    config.metrics_file = METRICS_FILE.to_string();
-    config.metrics_format = "raw".to_string();
-    config.no_metrics = false;
-    config.debug_file = DEBUG_FILE.to_string();
+    let config = common::build_configuration(
+        &server,
+        vec![
+            "--metrics-file",
+            METRICS_FILE,
+            "--metrics-format",
+            "raw",
+            "--debug-file",
+            DEBUG_FILE,
+        ],
+    );
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
         .unwrap()
         .setup()

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -37,6 +37,7 @@ fn test_no_normal_tasks() {
 
     let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server))
+            .unwrap()
             .setup()
             .unwrap()
             .register_taskset(

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -35,18 +35,20 @@ fn test_no_normal_tasks() {
         .return_status(200)
         .create_on(&server);
 
-    let _goose_stats =
-        crate::GooseAttack::initialize_with_config(common::build_configuration(&server))
-            .unwrap()
-            .setup()
-            .unwrap()
-            .register_taskset(
-                taskset!("LoadTest")
-                    .register_task(task!(login).set_on_start())
-                    .register_task(task!(logout).set_on_stop()),
-            )
-            .execute()
-            .unwrap();
+    let _goose_stats = crate::GooseAttack::initialize_with_config(common::build_configuration(
+        &server,
+        vec!["--no-metrics"],
+    ))
+    .unwrap()
+    .setup()
+    .unwrap()
+    .register_taskset(
+        taskset!("LoadTest")
+            .register_task(task!(login).set_on_start())
+            .register_task(task!(logout).set_on_stop()),
+    )
+    .execute()
+    .unwrap();
 
     // Confirm that the on_start and on_exit tasks actually ran.
     assert!(login_path.times_called() == 1);

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -45,6 +45,7 @@ fn test_single_taskset() {
     config.status_codes = true;
     config.no_reset_metrics = true;
     let goose_metrics = crate::GooseAttack::initialize_with_config(config.clone())
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(
@@ -119,6 +120,7 @@ fn test_single_taskset_empty_config_host() {
     config.no_metrics = false;
     config.no_reset_metrics = true;
     let goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(
@@ -235,6 +237,7 @@ fn test_single_taskset_closure() {
 
     // Run the loadtest.
     let goose_metrics = crate::GooseAttack::initialize_with_config(config.clone())
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(taskset)
@@ -327,6 +330,7 @@ fn test_single_taskset_reset_metrics() {
     config.hatch_rate = 4;
     config.status_codes = true;
     let goose_metrics = crate::GooseAttack::initialize_with_config(config.clone())
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -37,13 +37,18 @@ fn test_single_taskset() {
         .return_status(200)
         .create_on(&server);
 
-    let mut config = common::build_configuration(&server);
-    config.no_metrics = false;
-    // Start users in .5 seconds.
-    config.users = Some(2);
-    config.hatch_rate = 4;
-    config.status_codes = true;
-    config.no_reset_metrics = true;
+    let config = common::build_configuration(
+        &server,
+        vec![
+            "--users",
+            "2",
+            // Start users in .5 seconds.
+            "--hatch-rate",
+            "4",
+            "--status-codes",
+            "--no-reset-metrics",
+        ],
+    );
     let goose_metrics = crate::GooseAttack::initialize_with_config(config.clone())
         .unwrap()
         .setup()
@@ -64,6 +69,8 @@ fn test_single_taskset() {
     let one_third_index = index.times_called() / 3;
     let difference = about.times_called() as i32 - one_third_index as i32;
     assert!(difference >= -2 && difference <= 2);
+
+    println!("{:?}", &goose_metrics);
 
     let index_metrics = goose_metrics
         .requests
@@ -113,12 +120,10 @@ fn test_single_taskset_empty_config_host() {
         .return_status(200)
         .create_on(&server);
 
-    let mut config = common::build_configuration(&server);
+    let mut config = common::build_configuration(&server, vec!["--no-reset-metrics"]);
     // Leaves an empty string in config.host.
     let host = std::mem::take(&mut config.host);
-    // Enable statistics to confirm Goose and web server agree.
-    config.no_metrics = false;
-    config.no_reset_metrics = true;
+    // Enable metrics to confirm Goose and web server agree.
     let goose_metrics = crate::GooseAttack::initialize_with_config(config)
         .unwrap()
         .setup()
@@ -190,13 +195,18 @@ fn test_single_taskset_closure() {
     let server = MockServer::start();
 
     // Build configuration.
-    let mut config = common::build_configuration(&server);
-    config.no_metrics = false;
-    // Start users in .5 seconds.
-    config.users = Some(test_endpoints.len());
-    config.hatch_rate = 2 * test_endpoints.len();
-    config.status_codes = true;
-    config.no_reset_metrics = true;
+    let config = common::build_configuration(
+        &server,
+        vec![
+            "--no-reset-metrics",
+            "--no-task-metrics",
+            "--status-codes",
+            "--users",
+            &test_endpoints.len().to_string(),
+            "--hatch-rate",
+            &(2 * test_endpoints.len()).to_string(),
+        ],
+    );
 
     // Setup mock endpoints.
     let mut mock_endpoints = Vec::with_capacity(test_endpoints.len());
@@ -323,12 +333,17 @@ fn test_single_taskset_reset_metrics() {
         .return_status(200)
         .create_on(&server);
 
-    let mut config = common::build_configuration(&server);
-    config.no_metrics = false;
-    // Start users in .5 seconds.
-    config.users = Some(2);
-    config.hatch_rate = 4;
-    config.status_codes = true;
+    let config = common::build_configuration(
+        &server,
+        vec![
+            "--no-task-metrics",
+            "--status-codes",
+            "--users",
+            "2",
+            "--hatch-rate",
+            "4",
+        ],
+    );
     let goose_metrics = crate::GooseAttack::initialize_with_config(config.clone())
         .unwrap()
         .setup()

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -97,6 +97,7 @@ fn test_redirect() {
 
     let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server1))
+            .unwrap()
             .setup()
             .unwrap()
             .register_taskset(
@@ -163,6 +164,7 @@ fn test_domain_redirect() {
 
     let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server1))
+            .unwrap()
             .setup()
             .unwrap()
             .register_taskset(
@@ -227,6 +229,7 @@ fn test_sticky_domain_redirect() {
     let mut configuration = common::build_configuration(&server1);
     configuration.sticky_follow = true;
     let _goose_stats = crate::GooseAttack::initialize_with_config(configuration)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -95,21 +95,23 @@ fn test_redirect() {
         .return_body("<HTML><BODY>about page</BODY></HTML>")
         .create_on(&server1);
 
-    let _goose_stats =
-        crate::GooseAttack::initialize_with_config(common::build_configuration(&server1))
-            .unwrap()
-            .setup()
-            .unwrap()
-            .register_taskset(
-                taskset!("LoadTest")
-                    // Load index directly.
-                    .register_task(task!(get_index))
-                    // Load redirect path, redirect to redirect2 path, redirect to
-                    // redirect3 path, redirect to about.
-                    .register_task(task!(get_redirect)),
-            )
-            .execute()
-            .unwrap();
+    let _goose_stats = crate::GooseAttack::initialize_with_config(common::build_configuration(
+        &server1,
+        vec!["--no-metrics"],
+    ))
+    .unwrap()
+    .setup()
+    .unwrap()
+    .register_taskset(
+        taskset!("LoadTest")
+            // Load index directly.
+            .register_task(task!(get_index))
+            // Load redirect path, redirect to redirect2 path, redirect to
+            // redirect3 path, redirect to about.
+            .register_task(task!(get_redirect)),
+    )
+    .execute()
+    .unwrap();
 
     // Confirm that we loaded the mock endpoints; while we never load the about page
     // directly, we should follow the redirects and load it.
@@ -162,22 +164,24 @@ fn test_domain_redirect() {
         .return_status(200)
         .create_on(&server2);
 
-    let _goose_stats =
-        crate::GooseAttack::initialize_with_config(common::build_configuration(&server1))
-            .unwrap()
-            .setup()
-            .unwrap()
-            .register_taskset(
-                taskset!("LoadTest")
-                    // First load redirect, takes this request only to another domain.
-                    .register_task(task!(get_domain_redirect).set_on_start())
-                    // Load index directly.
-                    .register_task(task!(get_index))
-                    // Load about directly, always on original domain.
-                    .register_task(task!(get_about)),
-            )
-            .execute()
-            .unwrap();
+    let _goose_stats = crate::GooseAttack::initialize_with_config(common::build_configuration(
+        &server1,
+        vec!["--no-metrics"],
+    ))
+    .unwrap()
+    .setup()
+    .unwrap()
+    .register_taskset(
+        taskset!("LoadTest")
+            // First load redirect, takes this request only to another domain.
+            .register_task(task!(get_domain_redirect).set_on_start())
+            // Load index directly.
+            .register_task(task!(get_index))
+            // Load about directly, always on original domain.
+            .register_task(task!(get_about)),
+    )
+    .execute()
+    .unwrap();
 
     // Confirm that we load the index, about and redirect pages on the orginal domain.
     assert!(server1_index.times_called() > 0);
@@ -226,8 +230,8 @@ fn test_sticky_domain_redirect() {
         .create_on(&server2);
 
     // Enable sticky_follow option.
-    let mut configuration = common::build_configuration(&server1);
-    configuration.sticky_follow = true;
+    let configuration =
+        common::build_configuration(&server1, vec!["--no-metrics", "--sticky-follow"]);
     let _goose_stats = crate::GooseAttack::initialize_with_config(configuration)
         .unwrap()
         .setup()

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -49,6 +49,7 @@ fn test_start() {
 
     let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server))
+            .unwrap()
             .setup()
             .unwrap()
             .test_start(task!(setup))
@@ -91,6 +92,7 @@ fn test_stop() {
 
     let _goose_stats =
         crate::GooseAttack::initialize_with_config(common::build_configuration(&server))
+            .unwrap()
             .setup()
             .unwrap()
             .test_stop(task!(teardown))
@@ -136,6 +138,7 @@ fn test_setup_teardown() {
     configuration.hatch_rate = 5;
 
     let _goose_stats = crate::GooseAttack::initialize_with_config(configuration)
+        .unwrap()
         .setup()
         .unwrap()
         .test_start(task!(setup))

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -47,17 +47,17 @@ fn test_start() {
         .return_status(200)
         .create_on(&server);
 
-    let _goose_stats =
-        crate::GooseAttack::initialize_with_config(common::build_configuration(&server))
-            .unwrap()
-            .setup()
-            .unwrap()
-            .test_start(task!(setup))
-            .register_taskset(
-                taskset!("LoadTest").register_task(task!(get_index).set_weight(9).unwrap()),
-            )
-            .execute()
-            .unwrap();
+    let _goose_stats = crate::GooseAttack::initialize_with_config(common::build_configuration(
+        &server,
+        vec!["--no-metrics"],
+    ))
+    .unwrap()
+    .setup()
+    .unwrap()
+    .test_start(task!(setup))
+    .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9).unwrap()))
+    .execute()
+    .unwrap();
 
     // Confirm the load test ran.
     assert!(index.times_called() > 0);
@@ -90,17 +90,17 @@ fn test_stop() {
         .return_status(200)
         .create_on(&server);
 
-    let _goose_stats =
-        crate::GooseAttack::initialize_with_config(common::build_configuration(&server))
-            .unwrap()
-            .setup()
-            .unwrap()
-            .test_stop(task!(teardown))
-            .register_taskset(
-                taskset!("LoadTest").register_task(task!(get_index).set_weight(9).unwrap()),
-            )
-            .execute()
-            .unwrap();
+    let _goose_stats = crate::GooseAttack::initialize_with_config(common::build_configuration(
+        &server,
+        vec!["--no-metrics"],
+    ))
+    .unwrap()
+    .setup()
+    .unwrap()
+    .test_stop(task!(teardown))
+    .register_taskset(taskset!("LoadTest").register_task(task!(get_index).set_weight(9).unwrap()))
+    .execute()
+    .unwrap();
 
     // Confirm the load test ran.
     assert!(index.times_called() > 0);
@@ -132,10 +132,11 @@ fn test_setup_teardown() {
         .return_status(200)
         .create_on(&server);
 
-    let mut configuration = common::build_configuration(&server);
     // Launch several user threads, confirm we still only setup and teardown one time.
-    configuration.users = Some(5);
-    configuration.hatch_rate = 5;
+    let configuration = common::build_configuration(
+        &server,
+        vec!["--no-metrics", "--users", "5", "--hatch-rate", "5"],
+    );
 
     let _goose_stats = crate::GooseAttack::initialize_with_config(configuration)
         .unwrap()

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -40,17 +40,24 @@ fn test_throttle() {
     let users = 5;
     let run_time = 3;
 
-    let mut config = common::build_configuration(&server);
-    // Record all requests so we can confirm throttle is working.
-    config.metrics_file = METRICS_FILE.to_string();
-    config.no_metrics = false;
-    // Enable the throttle.
-    config.throttle_requests = Some(throttle_requests);
-    config.users = Some(users);
-    // Start all users in half a second.
-    config.hatch_rate = users;
-    // Run for a few seconds to be sure throttle really works.
-    config.run_time = run_time.to_string();
+    let config = common::build_configuration(
+        &server,
+        vec![
+            // Record all requests so we can confirm throttle is working.
+            "--metrics-file",
+            METRICS_FILE,
+            // Enable the throttle.
+            "--throttle-requests",
+            &throttle_requests.to_string(),
+            "--users",
+            &users.to_string(),
+            "--hatch-rate",
+            &users.to_string(),
+            // Run for a few seconds to be sure throttle really works.
+            "--run-time",
+            &run_time.to_string(),
+        ],
+    );
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
         .unwrap()
         .setup()
@@ -84,16 +91,22 @@ fn test_throttle() {
     // and confirm the throttle is actually working.
     throttle_requests *= 5;
 
-    let mut config = common::build_configuration(&server);
-    // Record all requests so we can confirm throttle is working.
-    config.metrics_file = METRICS_FILE.to_string();
-    config.no_metrics = false;
-    // Enable the throttle.
-    config.throttle_requests = Some(throttle_requests);
-    config.users = Some(users);
-    // Start all users in half a second.
-    config.hatch_rate = users;
-    config.run_time = run_time.to_string();
+    let config = common::build_configuration(
+        &server,
+        vec![
+            // Record all requests so we can confirm throttle is working.
+            "--metrics-file",
+            METRICS_FILE,
+            "--throttle-requests",
+            &throttle_requests.to_string(),
+            "--users",
+            &users.to_string(),
+            "--hatch-rate",
+            &users.to_string(),
+            "--run-time",
+            &run_time.to_string(),
+        ],
+    );
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
         .unwrap()
         .setup()

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -52,6 +52,7 @@ fn test_throttle() {
     // Run for a few seconds to be sure throttle really works.
     config.run_time = run_time.to_string();
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(
@@ -94,6 +95,7 @@ fn test_throttle() {
     config.hatch_rate = users;
     config.run_time = run_time.to_string();
     let _goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
         .setup()
         .unwrap()
         .register_taskset(


### PR DESCRIPTION
Consistently build configuration from arguments:
 - remove cases where parameters were manually modified directly in the configuration object
 - remove cases where defaults were automagically derived

This fixes #144.
