### PR TITLE
fix statistics with GooseTask name

### DIFF
--- a/src/goose.rs
+++ b/src/goose.rs
@@ -290,14 +290,14 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{self, AtomicUsize};
 use std::sync::Arc;
 use std::{future::Future, pin::Pin, time::Instant};
 use tokio::sync::{mpsc, Mutex, RwLock};
 use url::Url;
 
 use crate::metrics::GooseMetric;
-use crate::{GooseConfiguration, GooseError};
+use crate::{GooseConfiguration, GooseError, WeightedGooseTasks};
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
@@ -464,11 +464,11 @@ pub struct GooseTaskSet {
     /// A vector containing one copy of each GooseTask that will run by users running this task set.
     pub tasks: Vec<GooseTask>,
     /// A vector of vectors of integers, controlling the sequence and order GooseTasks are run.
-    pub weighted_tasks: Vec<Vec<usize>>,
+    pub weighted_tasks: WeightedGooseTasks,
     /// A vector of vectors of integers, controlling the sequence and order on_start GooseTasks are run when the user first starts.
-    pub weighted_on_start_tasks: Vec<Vec<usize>>,
+    pub weighted_on_start_tasks: WeightedGooseTasks,
     /// A vector of vectors of integers, controlling the sequence and order on_stop GooseTasks are run when the user stops.
-    pub weighted_on_stop_tasks: Vec<Vec<usize>>,
+    pub weighted_on_stop_tasks: WeightedGooseTasks,
     /// An optional default host to run this TaskSet against.
     pub host: Option<String>,
 }
@@ -918,13 +918,11 @@ pub struct GooseUser {
     /// An index into the internal `GooseTest.weighted_users, indicating which weighted GooseTaskSet is running.
     pub weighted_users_index: usize,
     /// A weighted list of all tasks that run when the user first starts.
-    pub weighted_on_start_tasks: Vec<Vec<usize>>,
+    pub weighted_on_start_tasks: WeightedGooseTasks,
     /// A weighted list of all tasks that this user runs once started.
-    pub weighted_tasks: Vec<Vec<usize>>,
+    pub weighted_tasks: WeightedGooseTasks,
     /// A weighted list of all tasks that run when the user stops.
-    pub weighted_on_stop_tasks: Vec<Vec<usize>>,
-    /// Optional name of all requests made within the current task.
-    pub task_request_name: Option<String>,
+    pub weighted_on_stop_tasks: WeightedGooseTasks,
     /// Load test hash.
     pub load_test_hash: u64,
 }
@@ -963,7 +961,6 @@ impl GooseUser {
             weighted_on_start_tasks: Vec::new(),
             weighted_tasks: Vec::new(),
             weighted_on_stop_tasks: Vec::new(),
-            task_request_name: None,
             load_test_hash,
         })
     }
@@ -1546,15 +1543,31 @@ impl GooseUser {
         Ok(())
     }
 
-    /// If `request_name` is set, unwrap and use this. Otherwise, if `task_request_name`
-    /// is set, use this. Otherwise, use path.
+    /// If `request_name` is set, unwrap and use this. Otherwise, if the GooseTask has a name
+    /// set use it. Otherwise use the path.
     fn get_request_name(&self, path: &str, request_name: Option<&str>) -> String {
         match request_name {
+            // If a request_name was passed in, unwrap and return a copy of it.
             Some(rn) => rn.to_string(),
-            None => match &self.task_request_name {
-                Some(trn) => trn.to_string(),
-                None => path.to_string(),
-            },
+            None => {
+                // Otherwise determine if the current GooseTask is named, and if so return
+                // a copy of it.
+                let weighted_bucket = self.weighted_bucket.load(atomic::Ordering::SeqCst);
+                let weighted_bucket_position =
+                    self.weighted_bucket_position.load(atomic::Ordering::SeqCst);
+                if !self.weighted_tasks.is_empty()
+                    && !self.weighted_tasks[weighted_bucket][weighted_bucket_position]
+                        .1
+                        .is_empty()
+                {
+                    self.weighted_tasks[weighted_bucket][weighted_bucket_position]
+                        .1
+                        .clone()
+                } else {
+                    // Otherwise return a copy of the the path.
+                    path.to_string()
+                }
+            }
         }
     }
 
@@ -2649,11 +2662,9 @@ mod tests {
         assert_eq!(user.weighted_on_start_tasks.len(), 0);
         assert_eq!(user.weighted_tasks.len(), 0);
         assert_eq!(user.weighted_on_stop_tasks.len(), 0);
-        assert_eq!(user.task_request_name, None);
 
         // Confirm the URLs are correctly built using the default_host.
         let url = user.build_url("/foo").await.unwrap();
-        eprintln!("url: {}", url);
         assert_eq!(&url, &[HOST, "foo"].concat());
         let url = user.build_url("bar/").await.unwrap();
         assert_eq!(&url, &[HOST, "bar/"].concat());

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -925,8 +925,6 @@ pub struct GooseUser {
     pub weighted_on_stop_tasks: Vec<Vec<usize>>,
     /// Optional name of all requests made within the current task.
     pub task_request_name: Option<String>,
-    /// Optional name of all requests made within the current task.
-    pub request_name: Option<String>,
     /// Load test hash.
     pub load_test_hash: u64,
 }
@@ -966,7 +964,6 @@ impl GooseUser {
             weighted_tasks: Vec::new(),
             weighted_on_stop_tasks: Vec::new(),
             task_request_name: None,
-            request_name: None,
             load_test_hash,
         })
     }
@@ -2653,7 +2650,6 @@ mod tests {
         assert_eq!(user.weighted_tasks.len(), 0);
         assert_eq!(user.weighted_on_stop_tasks.len(), 0);
         assert_eq!(user.task_request_name, None);
-        assert_eq!(user.request_name, None);
 
         // Confirm the URLs are correctly built using the default_host.
         let url = user.build_url("/foo").await.unwrap();


### PR DESCRIPTION
The `GooseUser` object didn't have direct access to the `GooseTask` name if set. The old implementation was essentially caching the last seem task name, but this wasn't working correctly. Instead I've re-worked the logic so we pass the actual `GooseTask` name to the `GooseUser` when building a weighted list of tasks for the user.

Now statistics are being generated exactly as expected, and the documentation can be properly updated for the [0.10.0 release](https://github.com/tag1consulting/goose/pull/160). Fixes #161 

Running the example load test generates the following statistics, and all the numbers now match up correctly as expected:

```
 === PER TASK METRICS ===
 ------------------------------------------------------------------------------
 Name                     |   # times run |        # fails |   task/s |  fail/s
 ------------------------------------------------------------------------------
 1: LoadtestTasks         |
   1:                     |         9,231 |         0 (0%) |   307.70 |    0.00
   2: bar                 |         1,843 |         0 (0%) |    61.43 |    0.00
 -------------------------+---------------+----------------+----------+--------
 Aggregated               |        11,074 |         0 (0%) |   369.13 |    0.00
 ------------------------------------------------------------------------------
 Name                     |    Avg (ms) |        Min |         Max |     Median
 ------------------------------------------------------------------------------
 1: LoadtestTasks         |
   1:                     |       21.37 |          6 |         152 |         18
   2: bar                 |       21.28 |          9 |         152 |         18
 -------------------------+-------------+------------+-------------+-----------
 Aggregated               |       21.36 |          6 |         152 |         18

 === PER REQUEST METRICS ===
 ------------------------------------------------------------------------------
 Name                     |        # reqs |        # fails |    req/s |  fail/s
 ------------------------------------------------------------------------------
 GET /path/to/foo         |         9,231 |         0 (0%) |   307.70 |    0.00
 GET bar                  |         1,843 |         0 (0%) |    61.43 |    0.00
 -------------------------+---------------+----------------+----------+--------
 Aggregated               |        11,074 |         0 (0%) |   369.13 |    0.00
 ------------------------------------------------------------------------------
 Name                     |    Avg (ms) |        Min |        Max |      Median
 ------------------------------------------------------------------------------
 GET /path/to/foo         |       21.33 |          6 |         152 |         18
 GET bar                  |       21.23 |          9 |         152 |         18
 -------------------------+-------------+------------+-------------+-----------
 Aggregated               |       21.31 |          6 |         152 |         18
 ------------------------------------------------------------------------------
 Slowest page load within specified percentile of requests (in ms):
 ------------------------------------------------------------------------------
 Name                     |    50% |    75% |    98% |    99% |  99.9% | 99.99%
 ------------------------------------------------------------------------------
 GET /path/to/foo         |     18 |     21 |     69 |     73 |    140 |    140
 GET bar                  |     18 |     21 |     69 |     73 |    150 |    150
 -------------------------+--------+--------+--------+--------+--------+-------
 Aggregated               |     18 |     21 |     69 |     73 |    150 |    150
```