### PR TITLE
register shutdown pipe handler on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - rework `hatch_rate` to be stored in an `Option<usize>` as it can be `None` on a Worker
  - remove redundant `GooseAttack.users` instead using the `Option<usize>` in `configuration`
  - improve bounds handling of defaults, generate errors for invalid values
+ - properly handle early shutdown of Gaggle distributed load test from Worker process
 
 ## 0.10.0 Sep 13, 2020
  - default to resetting statistics, disable with `--no-reset-stats`, display spawning statistics before resetting


### PR DESCRIPTION
Properly register shutdown pipe handler if the load test times out or is canceled, preventing a panic.

Prior to this change:

```bash
^C06:13:48 [ WARN] caught ctrl-c, stopping...
06:13:49 [ INFO] [2] stopping after 58 seconds...
06:13:49 [ INFO] [2] waiting for users to exit
06:13:49 [ INFO] [2] exiting user 3 from AnonBrowsingUser...
06:13:49 [ INFO] [2] exiting user 1 from AnonBrowsingUser...
06:13:49 [ INFO] [2] exiting user 4 from AnonBrowsingUser...
06:13:49 [ INFO] [2] exiting user 2 from AnonBrowsingUser...
thread '<unnamed>' panicked at '[2] manager went away, exiting', src/worker.rs:29:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
Aborted (core dumped)
```

After this change:
```bash
^C05:11:36 [ WARN] caught ctrl-c, stopping...
05:11:36 [ INFO] [1] stopping after 3 seconds...
05:11:36 [ INFO] [1] waiting for users to exit
05:11:36 [ INFO] [1] exiting user 2 from AnonBrowsingUser...
05:11:36 [ INFO] [1] exiting user 6 from AnonBrowsingUser...
05:11:36 [ INFO] [1] exiting user 1 from AnonBrowsingUser...
05:11:36 [ INFO] [1] exiting user 8 from AnonBrowsingUser...
05:11:36 [ INFO] [1] exiting user 4 from AuthBrowsingUser...
05:11:36 [ INFO] [1] exiting user 7 from AnonBrowsingUser...
05:11:36 [ INFO] [1] exiting user 3 from AnonBrowsingUser...
05:11:36 [ INFO] [1] exiting user 5 from AnonBrowsingUser...
05:11:36 [ INFO] [1] manager went away
```
Fixes #164 