### PR TITLE
fix formatting of `Default` section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,36 +354,36 @@ All run-time options can be configured with custom defaults. For example, you ma
 ```
 
 The following defaults can be configured with a `&str`:
- o host: `GooseDefault::Host`
- o log file name: `GooseDefault::LogFile`
- o metrics log file name: `GooseDefault::MetricsFile`
- o metrics log file format: `GooseDefault::MetricsFormat`
- o debug log file name: `GooseDefault::DebugFile`
- o debug log file format: `GooseDefault::DebugFormat`
- o host to bind Manager to: `GooseDefault::ManagerBindHost`
- o host for Worker to connect to: `GooseDefault::ManagerHost`
+ - host: `GooseDefault::Host`
+ - log file name: `GooseDefault::LogFile`
+ - metrics log file name: `GooseDefault::MetricsFile`
+ - metrics log file format: `GooseDefault::MetricsFormat`
+ - debug log file name: `GooseDefault::DebugFile`
+ - debug log file format: `GooseDefault::DebugFormat`
+ - host to bind Manager to: `GooseDefault::ManagerBindHost`
+ - host for Worker to connect to: `GooseDefault::ManagerHost`
 
 The following defaults can be configured with a `usize` integer:
- o total users to start: `GooseDefault::Users`
- o users to start per second: `GooseDefault::HatchRate`
- o number of seconds for test to run: `GooseDefault::RunTime`
- o log level: `GooseDefault::LogLevel`
- o verbosity: `GooseDefault::Verbose`
- o maximum requests per second: `GooseDefault::ThrottleRequests`
- o number of Workers to expect: `GooseDefault::ExpectWorkers`
- o port to bind Manager to: `GooseDefault::ManagerBindPort`
- o port for Worker to connect to: `GooseDefault::ManagerPort`
+ - total users to start: `GooseDefault::Users`
+ - users to start per second: `GooseDefault::HatchRate`
+ - number of seconds for test to run: `GooseDefault::RunTime`
+ - log level: `GooseDefault::LogLevel`
+ - verbosity: `GooseDefault::Verbose`
+ - maximum requests per second: `GooseDefault::ThrottleRequests`
+ - number of Workers to expect: `GooseDefault::ExpectWorkers`
+ - port to bind Manager to: `GooseDefault::ManagerBindPort`
+ - port for Worker to connect to: `GooseDefault::ManagerPort`
 
 The following defaults can be configured with a `bool`:
- o only print final summary metrics: `GooseDefault::OnlySummary`
- o do not reset metrics after all users start: `GooseDefault::NoResetMetrics`
- o do not track metrics: `GooseDefault::NoMetrics`
- o do not track task metrics: `GooseDefault::NoTaskMetrics`
- o track status codes: `GooseDefault::StatusCodes`
- o follow redirect of base_url: `GooseDefault::StickyFollow`
- o enable Manager mode: `GooseDefault::Manager`
- o ignore load test checksum: `GooseDefault::NoHashCheck`
- o enable Worker mode: `GooseDefault::Worker`
+ - only print final summary metrics: `GooseDefault::OnlySummary`
+ - do not reset metrics after all users start: `GooseDefault::NoResetMetrics`
+ - do not track metrics: `GooseDefault::NoMetrics`
+ - do not track task metrics: `GooseDefault::NoTaskMetrics`
+ - track status codes: `GooseDefault::StatusCodes`
+ - follow redirect of base_url: `GooseDefault::StickyFollow`
+ - enable Manager mode: `GooseDefault::Manager`
+ - ignore load test checksum: `GooseDefault::NoHashCheck`
+ - enable Worker mode: `GooseDefault::Worker`
 
 For example, without any run-time options the following load test would automatically run against `local.dev`, logging metrics to `goose-metrics.log` and debug to `goose-debug.log`. It will automatically launch 20 users in 4 seconds, and run the load test for 15 minutes. Metrics will only be displayed when the load test completes, and will include additional status code metrics. The order the defaults are set is not important.
 


### PR DESCRIPTION
Fixes #170 

Properly format list in `Default` section:

The following defaults can be configured with a `&str`:
 - host: `GooseDefault::Host`
 - log file name: `GooseDefault::LogFile`
 - metrics log file name: `GooseDefault::MetricsFile`
 - metrics log file format: `GooseDefault::MetricsFormat`
 - debug log file name: `GooseDefault::DebugFile`
 - debug log file format: `GooseDefault::DebugFormat`
 - host to bind Manager to: `GooseDefault::ManagerBindHost`
 - host for Worker to connect to: `GooseDefault::ManagerHost`

The following defaults can be configured with a `usize` integer:
 - total users to start: `GooseDefault::Users`
 - users to start per second: `GooseDefault::HatchRate`
 - number of seconds for test to run: `GooseDefault::RunTime`
 - log level: `GooseDefault::LogLevel`
 - verbosity: `GooseDefault::Verbose`
 - maximum requests per second: `GooseDefault::ThrottleRequests`
 - number of Workers to expect: `GooseDefault::ExpectWorkers`
 - port to bind Manager to: `GooseDefault::ManagerBindPort`
 - port for Worker to connect to: `GooseDefault::ManagerPort`

The following defaults can be configured with a `bool`:
 - only print final summary metrics: `GooseDefault::OnlySummary`
 - do not reset metrics after all users start: `GooseDefault::NoResetMetrics`
 - do not track metrics: `GooseDefault::NoMetrics`
 - do not track task metrics: `GooseDefault::NoTaskMetrics`
 - track status codes: `GooseDefault::StatusCodes`
 - follow redirect of base_url: `GooseDefault::StickyFollow`
 - enable Manager mode: `GooseDefault::Manager`
 - ignore load test checksum: `GooseDefault::NoHashCheck`
 - enable Worker mode: `GooseDefault::Worker`
