### PR TITLE
reset goose_attack.started once all workers start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - remove redundant `GooseAttack.users` instead using the `Option<usize>` in `configuration`
  - improve bounds handling of defaults, generate errors for invalid values
  - properly handle early shutdown of Gaggle distributed load test from Worker process
+ - Manager starts timing Gaggle distributed load test only after all Workers start
 
 ## 0.10.0 Sep 13, 2020
  - default to resetting statistics, disable with `--no-reset-stats`, display spawning statistics before resetting

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -257,6 +257,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
 
     // Track start time, we'll reset this when the test actually starts.
     let mut started = time::Instant::now();
+    goose_attack.started = Some(started);
     let mut running_metrics_timer = time::Instant::now();
     let mut exit_timer = time::Instant::now();
     let mut load_test_running = false;
@@ -449,6 +450,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                             info!("gaggle distributed load test started");
                             // Reset start time, the distributed load test is truly starting now.
                             started = time::Instant::now();
+                            goose_attack.started = Some(started);
                             running_metrics_timer = time::Instant::now();
                             load_test_running = true;
                         }


### PR DESCRIPTION
The `goose_attack.started` timestamp wasn't getting reset after all Workers start, resulting in some confusing metrics and debug output. This PR properly resets the timestamp when all Workers start.

Fixes #171 