### PR TITLE
Tag 0.10.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.10.1-dev
+## 0.10.1 Sep 20, 2020
  - rework `hatch_rate` to be stored in an `Option<usize>` as it can be `None` on a Worker
  - remove redundant `GooseAttack.users` instead using the `Option<usize>` in `configuration`
  - improve bounds handling of defaults, generate errors for invalid values

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.10.1-dev"
+version = "0.10.1"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ At this point it's possible to compile all dependencies, though the resulting bi
 ```
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.10.0
+  Downloaded goose v0.10.1
       ...
-   Compiling goose v0.10.0
+   Compiling goose v0.10.1
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`


### PR DESCRIPTION
Release `0.10.1`.

## 0.10.1 Sep 20, 2020
 - rework `hatch_rate` to be stored in an `Option<usize>` as it can be `None` on a Worker
 - remove redundant `GooseAttack.users` instead using the `Option<usize>` in `configuration`
 - improve bounds handling of defaults, generate errors for invalid values
 - properly handle early shutdown of Gaggle distributed load test from Worker process
 - Manager starts timing Gaggle distributed load test only after all Workers start