### PR TITLE
add Gaggle versions of all redirect integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 httpmock = "0.4"
+serial_test = "0.5"

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -1,15 +1,28 @@
 use httpmock::Method::GET;
-use httpmock::{Mock, MockServer};
+use httpmock::{Mock, MockRef, MockServer};
 
 mod common;
 
 use goose::prelude::*;
+use goose::GooseConfiguration;
 
 const INDEX_PATH: &str = "/";
 const REDIRECT_PATH: &str = "/redirect";
 const REDIRECT2_PATH: &str = "/redirect2";
 const REDIRECT3_PATH: &str = "/redirect3";
 const ABOUT_PATH: &str = "/about.php";
+
+const INDEX_KEY: usize = 0;
+const REDIRECT_KEY: usize = 1;
+const REDIRECT_KEY2: usize = 2;
+const REDIRECT_KEY3: usize = 3;
+const ABOUT_KEY: usize = 4;
+
+const SERVER1_INDEX_KEY: usize = 0;
+const SERVER1_ABOUT_KEY: usize = 1;
+const SERVER1_REDIRECT_KEY: usize = 2;
+const SERVER2_INDEX_KEY: usize = 3;
+const SERVER2_ABOUT_KEY: usize = 4;
 
 // Task function, load INDEX_PATH.
 pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
@@ -59,71 +72,256 @@ pub async fn get_domain_redirect(user: &GooseUser) -> GooseTaskResult {
     Ok(())
 }
 
+// Defines the different types of redirects being tested.
+enum TestType {
+    // Chains many different redirects together.
+    Chain,
+    // Redirects between domains.
+    Domain,
+    // Permanently redirects between domains.
+    Sticky,
+}
+
+// Sets up the endpoints used to test redirects.
+fn setup_mock_server_endpoints<'a>(
+    test_type: &TestType,
+    server: &'a MockServer,
+    server2: Option<&'a MockServer>,
+) -> Vec<MockRef<'a>> {
+    let mut endpoints: Vec<MockRef> = Vec::new();
+
+    match test_type {
+        TestType::Chain => {
+            // First set up INDEX_PATH, store in vector at INDEX_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(INDEX_PATH)
+                    .return_status(200)
+                    .create_on(&server),
+            );
+            // Next set up REDIRECT_PATH, store in vector at REDIRECT_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(REDIRECT_PATH)
+                    .return_status(301)
+                    .return_header("Location", REDIRECT2_PATH)
+                    .create_on(&server),
+            );
+            // Next set up REDIRECT2_PATH, store in vector at REDIRECT2_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(REDIRECT2_PATH)
+                    .return_status(302)
+                    .return_header("Location", REDIRECT3_PATH)
+                    .create_on(&server),
+            );
+            // Next set up REDIRECT3_PATH, store in vector at REDIRECT3_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(REDIRECT3_PATH)
+                    .return_status(303)
+                    .return_header("Location", ABOUT_PATH)
+                    .create_on(&server),
+            );
+            // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(ABOUT_PATH)
+                    .return_status(200)
+                    .return_body("<HTML><BODY>about page</BODY></HTML>")
+                    .create_on(&server),
+            );
+        }
+        TestType::Domain | TestType::Sticky => {
+            // First set up INDEX_PATH, store in vector at SERVER1_INDEX_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(INDEX_PATH)
+                    .return_status(200)
+                    .create_on(&server),
+            );
+            // Next set up ABOUT_PATH, store in vector at SERVER1_ABOUT_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(ABOUT_PATH)
+                    .return_status(200)
+                    .return_body("<HTML><BODY>about page</BODY></HTML>")
+                    .create_on(&server),
+            );
+            // Next set up REDIRECT_PATH, store in vector at SERVER1_REDIRECT_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(REDIRECT_PATH)
+                    .return_status(301)
+                    .return_header("Location", &server2.unwrap().url(INDEX_PATH))
+                    .create_on(&server),
+            );
+            // Next set up INDEX_PATH on server 2, store in vector at SERVER2_INDEX_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(INDEX_PATH)
+                    .return_status(200)
+                    .create_on(&server2.unwrap()),
+            );
+            // Next set up ABOUT_PATH on server 2, store in vector at SERVER2_ABOUT_KEY.
+            endpoints.push(
+                Mock::new()
+                    .expect_method(GET)
+                    .expect_path(ABOUT_PATH)
+                    .return_status(200)
+                    .create_on(&server2.unwrap()),
+            );
+        }
+    }
+
+    endpoints
+}
+
+// Build configuration for a load test.
+fn common_build_configuration(
+    server: &MockServer,
+    sticky: bool,
+    worker: Option<bool>,
+    manager: Option<usize>,
+) -> GooseConfiguration {
+    if sticky {
+        common::build_configuration(&server, vec!["--no-metrics", "--sticky-follow"])
+    } else {
+        common::build_configuration(&server, vec!["--no-metrics"])
+    }
+}
+
+// Common validation for the load tests in this file.
+fn validate_redirect(test_type: &TestType, mock_endpoints: &Vec<MockRef>) {
+    match test_type {
+        TestType::Chain => {
+            // Confirm that we loaded the mock endpoints; while we never load the about page
+            // directly, we should follow the redirects and load it.
+            assert!(mock_endpoints[INDEX_KEY].times_called() > 0);
+            assert!(mock_endpoints[REDIRECT_KEY].times_called() > 0);
+            assert!(mock_endpoints[REDIRECT_KEY2].times_called() > 0);
+            assert!(mock_endpoints[REDIRECT_KEY3].times_called() > 0);
+            assert!(mock_endpoints[ABOUT_KEY].times_called() > 0);
+
+            // We should have called all redirects the same number of times as we called the
+            // final about page.
+            assert!(
+                mock_endpoints[REDIRECT_KEY].times_called()
+                    == mock_endpoints[REDIRECT_KEY2].times_called()
+            );
+            assert!(
+                mock_endpoints[REDIRECT_KEY].times_called()
+                    == mock_endpoints[REDIRECT_KEY3].times_called()
+            );
+            assert!(
+                mock_endpoints[REDIRECT_KEY].times_called()
+                    == mock_endpoints[ABOUT_KEY].times_called()
+            );
+        }
+        TestType::Domain => {
+            // Confirm that we load the index, about and redirect pages on the original domain.
+            assert!(mock_endpoints[SERVER1_INDEX_KEY].times_called() > 0);
+            assert!(mock_endpoints[SERVER1_REDIRECT_KEY].times_called() > 0);
+            assert!(mock_endpoints[SERVER1_ABOUT_KEY].times_called() > 0);
+
+            // Confirm that the redirect sends us to the second domain (mocked using a
+            // server on a different port).
+            assert!(mock_endpoints[SERVER2_INDEX_KEY].times_called() > 0);
+
+            // Confirm the we never loaded the about page on the second domain.
+            assert!(mock_endpoints[SERVER2_ABOUT_KEY].times_called() == 0);
+        }
+        TestType::Sticky => {
+            // Confirm we redirect on startup, and never load index or about.
+            assert!(mock_endpoints[SERVER1_INDEX_KEY].times_called() == 0);
+            assert!(mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == 1);
+            assert!(mock_endpoints[SERVER1_ABOUT_KEY].times_called() == 0);
+
+            // Confirm that we load the alternative index and about pages (mocked using
+            // a server on a different port).
+            assert!(mock_endpoints[SERVER2_INDEX_KEY].times_called() > 0);
+            assert!(mock_endpoints[SERVER2_ABOUT_KEY].times_called() > 0);
+        }
+    }
+}
+
+// Run the actual load test. Validation is done server-side, so no need to
+// return the GooseMetrics.
+fn run_load_test(test_type: &TestType, configuration: &GooseConfiguration) {
+    // First, initialize an empty load test with the provided configuration.
+    let goose = crate::GooseAttack::initialize_with_config(configuration.clone()).unwrap();
+
+    // Now, add task sets as required by the specifying test_type.
+    let goose = match test_type {
+        TestType::Chain => {
+            goose.register_taskset(
+                taskset!("LoadTest")
+                    // Load index directly.
+                    .register_task(task!(get_index))
+                    // Load redirect path, redirect to redirect2 path, redirect to
+                    // redirect3 path, redirect to about.
+                    .register_task(task!(get_redirect)),
+            )
+        }
+        TestType::Domain => {
+            goose.register_taskset(
+                taskset!("LoadTest")
+                    // First load redirect, takes this request only to another domain.
+                    .register_task(task!(get_domain_redirect).set_on_start())
+                    // Load index directly.
+                    .register_task(task!(get_index))
+                    // Load about directly, always on original domain.
+                    .register_task(task!(get_about)),
+            )
+        }
+        TestType::Sticky => {
+            goose.register_taskset(
+                taskset!("LoadTest")
+                    // First load redirect, due to stick_follow the load test stays on the
+                    // new domain for all subsequent requests.
+                    .register_task(task!(get_domain_redirect).set_on_start())
+                    // Due to sticky follow, we should always load the alternative index.
+                    .register_task(task!(get_index))
+                    // Due to sticky follow, we should always load the alternative about.
+                    .register_task(task!(get_about)),
+            )
+        }
+    };
+
+    // Finally, execute the load test.
+    let _goose_metrics = goose.execute().unwrap();
+}
+
 #[test]
 /// Simulate a load test which includes a page with a redirect chain, confirms
 /// all redirects are correctly followed.
 fn test_redirect() {
-    let server1 = MockServer::start();
+    // Start the mock server.
+    let server = MockServer::start();
 
-    let server1_index = Mock::new()
-        .expect_method(GET)
-        .expect_path(INDEX_PATH)
-        .return_status(200)
-        .create_on(&server1);
-    let server1_redirect = Mock::new()
-        .expect_method(GET)
-        .expect_path(REDIRECT_PATH)
-        .return_status(301)
-        .return_header("Location", REDIRECT2_PATH)
-        .create_on(&server1);
-    let server1_redirect2 = Mock::new()
-        .expect_method(GET)
-        .expect_path(REDIRECT2_PATH)
-        .return_status(302)
-        .return_header("Location", REDIRECT3_PATH)
-        .create_on(&server1);
-    let server1_redirect3 = Mock::new()
-        .expect_method(GET)
-        .expect_path(REDIRECT3_PATH)
-        .return_status(303)
-        .return_header("Location", ABOUT_PATH)
-        .create_on(&server1);
-    let server1_about = Mock::new()
-        .expect_method(GET)
-        .expect_path(ABOUT_PATH)
-        .return_status(200)
-        .return_body("<HTML><BODY>about page</BODY></HTML>")
-        .create_on(&server1);
+    // Define the type of redirect being tested.
+    let test_type = TestType::Chain;
 
-    let _goose_stats = crate::GooseAttack::initialize_with_config(common::build_configuration(
-        &server1,
-        vec!["--no-metrics"],
-    ))
-    .unwrap()
-    .register_taskset(
-        taskset!("LoadTest")
-            // Load index directly.
-            .register_task(task!(get_index))
-            // Load redirect path, redirect to redirect2 path, redirect to
-            // redirect3 path, redirect to about.
-            .register_task(task!(get_redirect)),
-    )
-    .execute()
-    .unwrap();
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&test_type, &server, None);
 
-    // Confirm that we loaded the mock endpoints; while we never load the about page
-    // directly, we should follow the redirects and load it.
-    assert!(server1_index.times_called() > 0);
-    assert!(server1_redirect.times_called() > 0);
-    assert!(server1_redirect2.times_called() > 0);
-    assert!(server1_redirect3.times_called() > 0);
-    assert!(server1_about.times_called() > 0);
+    // Build configuration.
+    let configuration = common_build_configuration(&server, false, None, None);
 
-    // We should have called all redirects the same number of times as we called the
-    // final about page.
-    assert!(server1_redirect.times_called() == server1_redirect2.times_called());
-    assert!(server1_redirect.times_called() == server1_redirect3.times_called());
-    assert!(server1_redirect.times_called() == server1_about.times_called());
+    // Run the load test as configured.
+    run_load_test(&test_type, &configuration);
+
+    // Confirm that the load test was actually throttled.
+    validate_redirect(&test_type, &mock_endpoints);
 }
 
 #[test]
@@ -131,125 +329,44 @@ fn test_redirect() {
 /// (which in this case is a second mock server running on a different path).
 /// all redirects are correctly followed.
 fn test_domain_redirect() {
+    // Start the mock servers.
     let server1 = MockServer::start();
     let server2 = MockServer::start();
 
-    let server1_index = Mock::new()
-        .expect_method(GET)
-        .expect_path(INDEX_PATH)
-        .return_status(200)
-        .create_on(&server1);
-    let server1_about = Mock::new()
-        .expect_method(GET)
-        .expect_path(ABOUT_PATH)
-        .return_status(200)
-        .create_on(&server1);
-    let server1_redirect = Mock::new()
-        .expect_method(GET)
-        .expect_path(REDIRECT_PATH)
-        .return_status(301)
-        .return_header("Location", &server2.url(INDEX_PATH))
-        .create_on(&server1);
+    // Define the type of redirect being tested.
+    let test_type = TestType::Domain;
 
-    let server2_index = Mock::new()
-        .expect_method(GET)
-        .expect_path(INDEX_PATH)
-        .return_status(200)
-        .create_on(&server2);
-    let server2_about = Mock::new()
-        .expect_method(GET)
-        .expect_path(ABOUT_PATH)
-        .return_status(200)
-        .create_on(&server2);
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&test_type, &server1, Some(&server2));
 
-    let _goose_stats = crate::GooseAttack::initialize_with_config(common::build_configuration(
-        &server1,
-        vec!["--no-metrics"],
-    ))
-    .unwrap()
-    .register_taskset(
-        taskset!("LoadTest")
-            // First load redirect, takes this request only to another domain.
-            .register_task(task!(get_domain_redirect).set_on_start())
-            // Load index directly.
-            .register_task(task!(get_index))
-            // Load about directly, always on original domain.
-            .register_task(task!(get_about)),
-    )
-    .execute()
-    .unwrap();
+    // Build configuration.
+    let configuration = common_build_configuration(&server1, false, None, None);
 
-    // Confirm that we load the index, about and redirect pages on the original domain.
-    assert!(server1_index.times_called() > 0);
-    assert!(server1_redirect.times_called() > 0);
-    assert!(server1_about.times_called() > 0);
+    // Run the load test as configured.
+    run_load_test(&test_type, &configuration);
 
-    // Confirm that the redirect sends us to the second domain (mocked using a
-    // server on a different port).
-    assert!(server2_index.times_called() > 0);
-
-    // Confirm the we never loaded the about page on the second domain.
-    assert!(server2_about.times_called() == 0);
+    // Confirm that the load test was actually throttled.
+    validate_redirect(&test_type, &mock_endpoints);
 }
 
 #[test]
 fn test_sticky_domain_redirect() {
+    // Start the mock servers.
     let server1 = MockServer::start();
     let server2 = MockServer::start();
 
-    let server1_index = Mock::new()
-        .expect_method(GET)
-        .expect_path(INDEX_PATH)
-        .return_status(200)
-        .create_on(&server1);
-    let server1_about = Mock::new()
-        .expect_method(GET)
-        .expect_path(ABOUT_PATH)
-        .return_status(200)
-        .create_on(&server1);
-    let server1_redirect = Mock::new()
-        .expect_method(GET)
-        .expect_path(REDIRECT_PATH)
-        .return_status(301)
-        .return_header("Location", &server2.url(INDEX_PATH))
-        .create_on(&server1);
+    // Define the type of redirect being tested.
+    let test_type = TestType::Sticky;
 
-    let server2_index = Mock::new()
-        .expect_method(GET)
-        .expect_path(INDEX_PATH)
-        .return_status(200)
-        .create_on(&server2);
-    let server2_about = Mock::new()
-        .expect_method(GET)
-        .expect_path(ABOUT_PATH)
-        .return_status(200)
-        .create_on(&server2);
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&test_type, &server1, Some(&server2));
 
-    // Enable sticky_follow option.
-    let configuration =
-        common::build_configuration(&server1, vec!["--no-metrics", "--sticky-follow"]);
-    let _goose_stats = crate::GooseAttack::initialize_with_config(configuration)
-        .unwrap()
-        .register_taskset(
-            taskset!("LoadTest")
-                // First load redirect, due to stick_follow the load test stays on the
-                // new domain for all subsequent requests.
-                .register_task(task!(get_domain_redirect).set_on_start())
-                // Due to sticky follow, we should always load the alternative index.
-                .register_task(task!(get_index))
-                // Due to sticky follow, we should always load the alternative about.
-                .register_task(task!(get_about)),
-        )
-        .execute()
-        .unwrap();
+    // Build configuration, enabling --sticky-follow.
+    let configuration = common_build_configuration(&server1, true, None, None);
 
-    // Confirm we redirect on startup, and never load index or about.
-    assert!(server1_redirect.times_called() == 1);
-    assert!(server1_index.times_called() == 0);
-    assert!(server1_about.times_called() == 0);
+    // Run the load test as configured.
+    run_load_test(&test_type, &configuration);
 
-    // Confirm that we load the alternative index and about pages (mocked using
-    // a server on a different port).
-    assert!(server2_index.times_called() > 0);
-    assert!(server2_about.times_called() > 0);
+    // Confirm that the load test was actually throttled.
+    validate_redirect(&test_type, &mock_endpoints);
 }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -228,17 +228,15 @@ fn common_build_configuration(
         }
     } else if worker.is_some() {
         common::build_configuration(&server, vec!["--worker"])
+    } else if sticky {
+        common::build_configuration(&server, vec!["--sticky-follow"])
     } else {
-        if sticky {
-            common::build_configuration(&server, vec!["--sticky-follow"])
-        } else {
-            common::build_configuration(&server, vec![])
-        }
+        common::build_configuration(&server, vec![])
     }
 }
 
 // Common validation for the load tests in this file.
-fn validate_redirect(test_type: &TestType, mock_endpoints: &Vec<MockRef>) {
+fn validate_redirect(test_type: &TestType, mock_endpoints: &[MockRef]) {
     match test_type {
         TestType::Chain => {
             // Confirm that we loaded the mock endpoints; while we never load the about page
@@ -280,7 +278,12 @@ fn validate_redirect(test_type: &TestType, mock_endpoints: &Vec<MockRef>) {
         TestType::Sticky => {
             // Confirm we redirect on startup, and never load index or about.
             assert!(mock_endpoints[SERVER1_INDEX_KEY].times_called() == 0);
-            assert!(mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == 1);
+            // @FIXME: when https://github.com/tag1consulting/goose/issues/182 lands
+            // this should always be `== 1`.
+            assert!(
+                mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == 1
+                    || mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == EXPECT_WORKERS
+            );
             assert!(mock_endpoints[SERVER1_ABOUT_KEY].times_called() == 0);
 
             // Confirm that we load the alternative index and about pages (mocked using
@@ -357,7 +360,7 @@ fn test_redirect() {
     // Run the load test as configured.
     run_load_test(&test_type, &configuration);
 
-    // Confirm that the load test was actually throttled.
+    // Confirm that the load test was actually redirected.
     validate_redirect(&test_type, &mock_endpoints);
 }
 
@@ -402,7 +405,7 @@ fn test_redirect_gaggle() {
     // Run the load test as configured.
     run_load_test(&test_type, &manager_configuration);
 
-    // Confirm that the load test was actually throttled.
+    // Confirm that the load test was actually redirected.
     validate_redirect(&test_type, &mock_endpoints);
 }
 
@@ -427,7 +430,7 @@ fn test_domain_redirect() {
     // Run the load test as configured.
     run_load_test(&test_type, &configuration);
 
-    // Confirm that the load test was actually throttled.
+    // Confirm that the load test was actually redirected.
     validate_redirect(&test_type, &mock_endpoints);
 }
 
@@ -474,11 +477,13 @@ fn test_domain_redirect_gaggle() {
     // Run the load test as configured.
     run_load_test(&test_type, &manager_configuration);
 
-    // Confirm that the load test was actually throttled.
+    // Confirm that the load test was actually redirected.
     validate_redirect(&test_type, &mock_endpoints);
 }
 
 #[test]
+/// Simulate a load test which permanently follows a redirect due to the
+/// --sticky-follow run-time option.
 fn test_sticky_domain_redirect() {
     // Start the mock servers.
     let server1 = MockServer::start();
@@ -496,6 +501,52 @@ fn test_sticky_domain_redirect() {
     // Run the load test as configured.
     run_load_test(&test_type, &configuration);
 
-    // Confirm that the load test was actually throttled.
+    // Confirm that the load test was actually redirected.
+    validate_redirect(&test_type, &mock_endpoints);
+}
+
+#[test]
+// Only run gaggle tests if the feature is compiled into the codebase.
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Gaggle tests have to be running serially instead of in parallel.
+#[serial]
+/// Simulate a distributed load test which permanently follows a redirect
+/// due to the --sticky-follow run-time option.
+fn test_sticky_domain_redirect_gaggle() {
+    // Start the mock servers.
+    let server1 = MockServer::start();
+    let server2 = MockServer::start();
+
+    // Define the type of redirect being tested.
+    let test_type = TestType::Sticky;
+
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&test_type, &server1, Some(&server2));
+
+    // Build Worker configuration.
+    let configuration = common_build_configuration(&server1, false, Some(true), None);
+
+    // Workers launched in own threads, store thread handles.
+    let mut worker_handles = Vec::new();
+
+    // Launch Workers in threads.
+    for _ in 0..EXPECT_WORKERS {
+        let worker_test_type = test_type.clone();
+        let worker_configuration = configuration.clone();
+        // Start worker instance of the load test.
+        worker_handles.push(std::thread::spawn(move || {
+            // Run the load test as configured.
+            run_load_test(&worker_test_type, &worker_configuration);
+        }));
+    }
+
+    // Build Manager configuration, enabling --sticky-follow.
+    let manager_configuration =
+        common_build_configuration(&server1, true, None, Some(EXPECT_WORKERS));
+
+    // Run the load test as configured.
+    run_load_test(&test_type, &manager_configuration);
+
+    // Confirm that the load test was actually redirected.
     validate_redirect(&test_type, &mock_endpoints);
 }


### PR DESCRIPTION
Continuing what was started in #175, this de-duplicates and adds Gaggle tests for `tests/redirect.rs`.

There are three distinct tests in this integration test file, and all of them logically need their own Gaggle versions. [I reached out to the `httpmock` author](https://github.com/alexliesenfeld/httpmock/issues/15) to ask if there was a way to serialize some tests in a single file, and he pointed me to the [`serial_test` module](https://crates.io/crates/serial_test), which this PR also adds.