### PR TITLE
properly invoke test_start and test_stop in Gaggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.10.2-dev
  - remove unnecessary `GooseAttack.number_of_cpus` instead calling `num_cpus::get()` directly
  - remove `tests/gaggle.rs`, instead mixing gaggle tests with per-feature integration tests
+ - ensure `test_start` and `test_stop` run one and only one time even in Gaggle mode
 
 ## 0.10.1 Sep 20, 2020
  - rework `hatch_rate` to be stored in an `Option<usize>` as it can be `None` on a Worker

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -453,6 +453,9 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                             goose_attack.started = Some(started);
                             running_metrics_timer = time::Instant::now();
                             load_test_running = true;
+
+                            // Run any configured test_start() functions.
+                            goose_attack.run_test_start().await.unwrap();
                         }
                     }
                 }
@@ -525,6 +528,9 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
             }
         }
     }
+    // Run any configured test_stop() functions.
+    goose_attack.run_test_stop().await.unwrap();
+
     goose_attack
 }
 

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -278,12 +278,7 @@ fn validate_redirect(test_type: &TestType, mock_endpoints: &[MockRef]) {
         TestType::Sticky => {
             // Confirm we redirect on startup, and never load index or about.
             assert!(mock_endpoints[SERVER1_INDEX_KEY].times_called() == 0);
-            // @FIXME: when https://github.com/tag1consulting/goose/issues/182 lands
-            // this should always be `== 1`.
-            assert!(
-                mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == 1
-                    || mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == EXPECT_WORKERS
-            );
+            assert!(mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == 1);
             assert!(mock_endpoints[SERVER1_ABOUT_KEY].times_called() == 0);
 
             // Confirm that we load the alternative index and about pages (mocked using
@@ -550,3 +545,4 @@ fn test_sticky_domain_redirect_gaggle() {
     // Confirm that the load test was actually redirected.
     validate_redirect(&test_type, &mock_endpoints);
 }
+

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -278,7 +278,12 @@ fn validate_redirect(test_type: &TestType, mock_endpoints: &[MockRef]) {
         TestType::Sticky => {
             // Confirm we redirect on startup, and never load index or about.
             assert!(mock_endpoints[SERVER1_INDEX_KEY].times_called() == 0);
-            assert!(mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == 1);
+            // @FIXME: when https://github.com/tag1consulting/goose/issues/182 lands
+            // this should always be `== 1`.
+            assert!(
+                mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == 1
+                    || mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == EXPECT_WORKERS
+            );
             assert!(mock_endpoints[SERVER1_ABOUT_KEY].times_called() == 0);
 
             // Confirm that we load the alternative index and about pages (mocked using
@@ -545,4 +550,3 @@ fn test_sticky_domain_redirect_gaggle() {
     // Confirm that the load test was actually redirected.
     validate_redirect(&test_type, &mock_endpoints);
 }
-

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -105,53 +105,29 @@ fn common_build_configuration(
 }
 
 // Common validation for the load tests in this file.
-// @FIXME: remove the `is_gaggle` flag once issue #182 lands.
-fn validate_test(test_type: &TestType, mock_endpoints: &[MockRef], is_gaggle: bool) {
+fn validate_test(test_type: &TestType, mock_endpoints: &[MockRef]) {
     // Confirm the load test ran.
     assert!(mock_endpoints[INDEX_KEY].times_called() > 0);
 
     // Now confirm TestType-specific counters.
-    if is_gaggle {
-        // @FIXME: when https://github.com/tag1consulting/goose/issues/182 lands
-        // remove the `is_gaggle` flag and everything in it: the gaggle and standalone
-        // tests should have the same validation.
-        match test_type {
-            TestType::Start => {
-                // @FIXME: setup should have run.
-                assert!(mock_endpoints[SETUP_KEY].times_called() == 0);
-                assert!(mock_endpoints[TEARDOWN_KEY].times_called() == 0);
-            }
-            TestType::Stop => {
-                // @FIXME: teardown should have run.
-                assert!(mock_endpoints[SETUP_KEY].times_called() == 0);
-                assert!(mock_endpoints[TEARDOWN_KEY].times_called() == 0);
-            }
-            TestType::StartAndStop => {
-                // @FIXME: setup and teardown should have run.
-                assert!(mock_endpoints[SETUP_KEY].times_called() == 0);
-                assert!(mock_endpoints[TEARDOWN_KEY].times_called() == 0);
-            }
+    match test_type {
+        TestType::Start => {
+            // Confirm setup ran one time.
+            assert!(mock_endpoints[SETUP_KEY].times_called() == 1);
+            // Confirm teardown did not run.
+            assert!(mock_endpoints[TEARDOWN_KEY].times_called() == 0);
         }
-    } else {
-        match test_type {
-            TestType::Start => {
-                // Confirm setup ran one time.
-                assert!(mock_endpoints[SETUP_KEY].times_called() == 1);
-                // Confirm teardown did not run.
-                assert!(mock_endpoints[TEARDOWN_KEY].times_called() == 0);
-            }
-            TestType::Stop => {
-                // Confirm setup did not run.
-                assert!(mock_endpoints[SETUP_KEY].times_called() == 0);
-                // Confirm teardown ran one time.
-                assert!(mock_endpoints[TEARDOWN_KEY].times_called() == 1);
-            }
-            TestType::StartAndStop => {
-                // Confirm setup ran one time.
-                assert!(mock_endpoints[SETUP_KEY].times_called() == 1);
-                // Confirm teardown ran one time.
-                assert!(mock_endpoints[TEARDOWN_KEY].times_called() == 1);
-            }
+        TestType::Stop => {
+            // Confirm setup did not run.
+            assert!(mock_endpoints[SETUP_KEY].times_called() == 0);
+            // Confirm teardown ran one time.
+            assert!(mock_endpoints[TEARDOWN_KEY].times_called() == 1);
+        }
+        TestType::StartAndStop => {
+            // Confirm setup ran one time.
+            assert!(mock_endpoints[SETUP_KEY].times_called() == 1);
+            // Confirm teardown ran one time.
+            assert!(mock_endpoints[TEARDOWN_KEY].times_called() == 1);
         }
     }
 }
@@ -235,7 +211,7 @@ fn test_setup() {
     run_load_test(&test_type, &configuration, None);
 
     // Confirm the load test ran correctly.
-    validate_test(&TestType::Start, &mock_endpoints, false);
+    validate_test(&TestType::Start, &mock_endpoints);
 }
 
 /// Test test_start alone.
@@ -267,7 +243,7 @@ fn test_setup_gaggle() {
     run_load_test(&test_type, &manager_configuration, Some(worker_handles));
 
     // Confirm the load test ran correctly.
-    validate_test(&test_type, &mock_endpoints, true);
+    validate_test(&test_type, &mock_endpoints);
 }
 
 /// Test test_stop alone.
@@ -289,7 +265,7 @@ fn test_teardown() {
     run_load_test(&test_type, &configuration, None);
 
     // Confirm the load test ran correctly.
-    validate_test(&test_type, &mock_endpoints, false);
+    validate_test(&test_type, &mock_endpoints);
 }
 
 /// Test test_start alone in Gaggle mode.
@@ -321,7 +297,7 @@ fn test_teardown_gaggle() {
     run_load_test(&test_type, &manager_configuration, Some(worker_handles));
 
     // Confirm the load test ran correctly.
-    validate_test(&test_type, &mock_endpoints, true);
+    validate_test(&test_type, &mock_endpoints);
 }
 
 /// Test test_start and test_stop together.
@@ -343,7 +319,7 @@ fn test_setup_teardown() {
     run_load_test(&test_type, &configuration, None);
 
     // Confirm the load test ran correctly.
-    validate_test(&test_type, &mock_endpoints, false);
+    validate_test(&test_type, &mock_endpoints);
 }
 
 /// Test test_start and test_Stop together in Gaggle mode.
@@ -375,5 +351,5 @@ fn test_setup_teardown_gaggle() {
     run_load_test(&test_type, &manager_configuration, Some(worker_handles));
 
     // Confirm the load test ran correctly.
-    validate_test(&test_type, &mock_endpoints, true);
+    validate_test(&test_type, &mock_endpoints);
 }


### PR DESCRIPTION
Fixes #182 

 - split out `test_start` and `test_stop` logic into helper functions
 - invoke `run_test_start` and `run_test_stop` as Manager
 - remove special-handling for `test/setup_teardown.rs` confirming `test_start` and `test_stop` are the same in standalone and Gaggle mode

Note: `test/redirect.rs` incorrectly suggests there's a difference between standalone and Gaggle mode, but this was a misunderstanding of the problem. This will instead be addressed in #186 