### PR TITLE
deduplicate code in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.10.3-dev
  - fixup sticky redirect tests to properly test functionality
  - add `test/sequence.rs` to confirm sequencing tests works correctly, even in Gaggle mode
+ - deduplicate test logic by moving shared functionality into `tests/common.rs`
 
 ## 0.10.2 Sep 27, 2020
  - remove unnecessary `GooseAttack.number_of_cpus` instead calling `num_cpus::get()` directly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.10.3-dev
  - fixup sticky redirect tests to properly test functionality
  - add `test/sequence.rs` to confirm sequencing tests works correctly, even in Gaggle mode
- - deduplicate test logic by moving shared functionality into `tests/common.rs`
+ - deduplicate test logic by moving shared functionality into `tests/common.rs`; consistently test functionality both in standalone and Gaggle mode
 
 ## 0.10.2 Sep 27, 2020
  - remove unnecessary `GooseAttack.number_of_cpus` instead calling `num_cpus::get()` directly

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -354,6 +354,11 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                     // so unwrap() is safe.
                     if workers.len() >= goose_attack.configuration.expect_workers.unwrap() as usize
                     {
+                        warn!(
+                            "telling extra worker ({} of {}) to exit",
+                            workers.len() + 1,
+                            goose_attack.configuration.expect_workers.unwrap()
+                        );
                         // We already have enough workers, tell this extra one to EXIT.
                         if !tell_worker_to_exit(&server) {
                             // All workers have exited, shut down the
@@ -366,6 +371,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                         // New worker has to send us a single
                         // GaggleMetrics::WorkerInit object or it's invalid.
                         if gaggle_metrics.len() != 1 {
+                            warn!("invalid message from Worker, exiting load test");
                             // Invalid message, tell worker to EXIT.
                             if !tell_worker_to_exit(&server) {
                                 // All workers have exited, shut down the
@@ -378,7 +384,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                         if let GaggleMetrics::WorkerInit(load_test_hash) = goose_metric {
                             if load_test_hash != goose_attack.metrics.hash {
                                 if goose_attack.configuration.no_hash_check {
-                                    warn!("worker is running a different load test, ignoring")
+                                    warn!("worker is running a different load test, ignoring");
                                 } else {
                                     panic!("worker is running a different load test, set --no-hash-check to ignore");
                                 }
@@ -386,6 +392,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                         } else {
                             // Unexpected object received, tell the worker
                             // to EXIT.
+                            warn!("invalid object from Worker, exiting load test");
                             if !tell_worker_to_exit(&server) {
                                 // All workers have exited, shut down the
                                 // load test.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -214,7 +214,19 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     worker_goose_attack.run_time = run_time;
     worker_goose_attack.weighted_users = weighted_users;
     worker_goose_attack.configuration.worker = true;
-    // The throttle_requests configuration option is set on the Worker.
+    // The metrics_file option is configured on the Worker.
+    worker_goose_attack.configuration.metrics_file =
+        goose_attack.configuration.metrics_file.to_string();
+    // The metrics_format option is configured on the Worker.
+    worker_goose_attack.configuration.metrics_format =
+        goose_attack.configuration.metrics_format.to_string();
+    // The debug_file option is configured on the Worker.
+    worker_goose_attack.configuration.debug_file =
+        goose_attack.configuration.debug_file.to_string();
+    // The debug_format option is configured on the Worker.
+    worker_goose_attack.configuration.debug_format =
+        goose_attack.configuration.debug_format.to_string();
+    // The throttle_requests option is set on the Worker.
     worker_goose_attack.configuration.throttle_requests =
         goose_attack.configuration.throttle_requests;
     worker_goose_attack.attack_mode = GooseMode::Worker;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -84,7 +84,7 @@ pub fn build_load_test(
     stop_task: Option<&GooseTask>,
 ) -> GooseAttack {
     // First set up the common base configuration.
-    let mut goose = crate::GooseAttack::initialize_with_config(configuration.clone())
+    let mut goose = crate::GooseAttack::initialize_with_config(configuration)
         .unwrap()
         .register_taskset(taskset.clone());
 
@@ -126,5 +126,15 @@ pub fn file_length(file_name: &str) -> usize {
         io::BufReader::new(file).lines().count()
     } else {
         0
+    }
+}
+
+// Helper to delete test artifact, if existing.
+#[allow(dead_code)]
+pub fn cleanup_files(files: Vec<&str>) {
+    for file in files {
+        if std::path::Path::new(file).exists() {
+            std::fs::remove_file(file).expect("failed to remove file");
+        }
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,5 +1,6 @@
 use gumdrop::Options;
 use httpmock::MockServer;
+use std::io::{self, BufRead};
 
 use goose::goose::{GooseTask, GooseTaskSet};
 use goose::metrics::GooseMetrics;
@@ -116,4 +117,14 @@ pub fn run_load_test(
     }
 
     goose_metrics
+}
+
+// Helper to count the number of lines in a test artifact.
+#[allow(dead_code)]
+pub fn file_length(file_name: &str) -> usize {
+    if let Ok(file) = std::fs::File::open(std::path::Path::new(file_name)) {
+        io::BufReader::new(file).lines().count()
+    } else {
+        0
+    }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -75,6 +75,7 @@ pub fn launch_gaggle_workers(
 
 // Create a GooseAttack object from the configuration, taskset, and optional start and
 // stop tasks.
+#[allow(dead_code)]
 pub fn build_load_test(
     configuration: GooseConfiguration,
     taskset: &GooseTaskSet,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -8,6 +8,9 @@ use goose::{GooseAttack, GooseConfiguration};
 
 type WorkerHandles = Vec<std::thread::JoinHandle<()>>;
 
+/// Not all functions are used by all tests, so we enable allow(dead_code) to avoid
+/// compiler warnings during testing.
+
 /// The following options are configured by default, if not set to a custom value
 /// and if not building a Worker configuration:
 ///  --host <mock-server>
@@ -51,9 +54,8 @@ pub fn build_configuration(server: &MockServer, custom: Vec<&str>) -> GooseConfi
         .expect("failed to parse options and generate a configuration")
 }
 
-// This code is only used when the Gaggle feature is enabled.
+/// Launch each Worker in its own thread, and return a vector of Worker handles.
 #[allow(dead_code)]
-// Execute each Worker in its own thread, returning a vector of handles.
 pub fn launch_gaggle_workers(
     // A goose attack object which is cloned for each Worker.
     goose_attack: GooseAttack,
@@ -99,8 +101,7 @@ pub fn build_load_test(
     goose
 }
 
-// Run the actual load test. Rely on the mock server to confirm it ran correctly, so
-// do not return metrics.
+/// Run the actual load test, returning the GooseMetrics.
 pub fn run_load_test(
     goose_attack: GooseAttack,
     worker_handles: Option<WorkerHandles>,
@@ -119,7 +120,7 @@ pub fn run_load_test(
     goose_metrics
 }
 
-// Helper to count the number of lines in a test artifact.
+/// Helper to count the number of lines in a test artifact.
 #[allow(dead_code)]
 pub fn file_length(file_name: &str) -> usize {
     if let Ok(file) = std::fs::File::open(std::path::Path::new(file_name)) {
@@ -129,7 +130,7 @@ pub fn file_length(file_name: &str) -> usize {
     }
 }
 
-// Helper to delete test artifact, if existing.
+/// Helper to delete test artifacts, if existing.
 #[allow(dead_code)]
 pub fn cleanup_files(files: Vec<&str>) {
     for file in files {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,7 @@
 use gumdrop::Options;
 use httpmock::MockServer;
 
+use goose::goose::{GooseTask, GooseTaskSet};
 use goose::metrics::GooseMetrics;
 use goose::{GooseAttack, GooseConfiguration};
 
@@ -68,6 +69,30 @@ pub fn launch_gaggle_workers(
     }
 
     worker_handles
+}
+
+// Create a GooseAttack object from the configuration, taskset, and optional start and
+// stop tasks.
+pub fn build_load_test(
+    configuration: GooseConfiguration,
+    taskset: &GooseTaskSet,
+    start_task: Option<&GooseTask>,
+    stop_task: Option<&GooseTask>,
+) -> GooseAttack {
+    // First set up the common base configuration.
+    let mut goose = crate::GooseAttack::initialize_with_config(configuration.clone())
+        .unwrap()
+        .register_taskset(taskset.clone());
+
+    if let Some(task) = start_task {
+        goose = goose.test_start(task.clone());
+    }
+
+    if let Some(task) = stop_task {
+        goose = goose.test_stop(task.clone());
+    }
+
+    goose
 }
 
 // Run the actual load test. Rely on the mock server to confirm it ran correctly, so

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -5,6 +5,8 @@ use goose::goose::{GooseTask, GooseTaskSet};
 use goose::metrics::GooseMetrics;
 use goose::{GooseAttack, GooseConfiguration};
 
+type WorkerHandles = Vec<std::thread::JoinHandle<()>>;
+
 /// The following options are configured by default, if not set to a custom value
 /// and if not building a Worker configuration:
 ///  --host <mock-server>
@@ -56,7 +58,7 @@ pub fn launch_gaggle_workers(
     goose_attack: GooseAttack,
     // The number of Workers to launch.
     expect_workers: usize,
-) -> Vec<std::thread::JoinHandle<()>> {
+) -> WorkerHandles {
     // Launch each worker in its own thread, storing the join handles.
     let mut worker_handles = Vec::new();
     for _ in 0..expect_workers {
@@ -99,7 +101,7 @@ pub fn build_load_test(
 // do not return metrics.
 pub fn run_load_test(
     goose_attack: GooseAttack,
-    worker_handles: Option<Vec<std::thread::JoinHandle<()>>>,
+    worker_handles: Option<WorkerHandles>,
 ) -> GooseMetrics {
     // Execute the load test.
     let goose_metrics = goose_attack.execute().unwrap();

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -1,7 +1,6 @@
 use httpmock::Method::GET;
 use httpmock::{Mock, MockRef, MockServer};
 use serial_test::serial;
-use std::io::{self, BufRead};
 
 mod common;
 
@@ -50,15 +49,6 @@ fn cleanup_files(files: Vec<&str>) {
         if std::path::Path::new(file).exists() {
             std::fs::remove_file(file).expect("failed to remove file");
         }
-    }
-}
-
-// Helper to count the number of lines in a test artifact.
-fn file_length(file_name: &str) -> usize {
-    if let Ok(file) = std::fs::File::open(std::path::Path::new(file_name)) {
-        io::BufReader::new(file).lines().count()
-    } else {
-        0
     }
 }
 
@@ -129,9 +119,8 @@ fn validate_test(
     // Verify that the metrics file was created and has the correct number of lines.
     let mut metrics_lines = 0;
     for metrics_file in metrics_files {
-        println!("metrics_file: {}", metrics_file);
         assert!(std::path::Path::new(metrics_file).exists());
-        metrics_lines += file_length(metrics_file);
+        metrics_lines += common::file_length(metrics_file);
     }
     assert!(
         metrics_lines
@@ -141,7 +130,7 @@ fn validate_test(
     // Verify that the debug file was created and is empty.
     for debug_file in debug_files {
         assert!(std::path::Path::new(debug_file).exists());
-        assert!(file_length(debug_file) == 0);
+        assert!(common::file_length(debug_file) == 0);
     }
 
     // Requests are made while GooseUsers are hatched, and then for run_time seconds.

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -43,15 +43,6 @@ pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
     Ok(())
 }
 
-// Helper to delete test artifact, if existing.
-fn cleanup_files(files: Vec<&str>) {
-    for file in files {
-        if std::path::Path::new(file).exists() {
-            std::fs::remove_file(file).expect("failed to remove file");
-        }
-    }
-}
-
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
     let mut endpoints: Vec<MockRef> = Vec::new();
@@ -145,10 +136,10 @@ fn validate_test(
 
     // Cleanup from test.
     for file in metrics_files {
-        cleanup_files(vec![file]);
+        common::cleanup_files(vec![file]);
     }
     for file in debug_files {
-        cleanup_files(vec![file]);
+        common::cleanup_files(vec![file]);
     }
 }
 
@@ -160,7 +151,7 @@ fn test_defaults() {
     let debug_file = "defaults-".to_string() + DEBUG_FILE;
 
     // Be sure there's no files left over from an earlier test.
-    cleanup_files(vec![&metrics_file, &debug_file]);
+    common::cleanup_files(vec![&metrics_file, &debug_file]);
 
     let server = MockServer::start();
 
@@ -233,9 +224,9 @@ fn test_defaults_gaggle() {
     // Be sure there's no files left over from an earlier test.
     for i in 0..EXPECT_WORKERS {
         let file = metrics_file.to_string() + &i.to_string();
-        cleanup_files(vec![&file]);
+        common::cleanup_files(vec![&file]);
         let file = debug_file.to_string() + &i.to_string();
-        cleanup_files(vec![&file]);
+        common::cleanup_files(vec![&file]);
     }
 
     let server = MockServer::start();
@@ -349,7 +340,7 @@ fn test_no_defaults() {
     let debug_file = "nodefaults-".to_string() + DEBUG_FILE;
 
     // Be sure there's no files left over from an earlier test.
-    cleanup_files(vec![&metrics_file, &debug_file]);
+    common::cleanup_files(vec![&metrics_file, &debug_file]);
 
     let server = MockServer::start();
 
@@ -409,9 +400,9 @@ fn test_no_defaults_gaggle() {
     // Be sure there's no files left over from an earlier test.
     for i in 0..EXPECT_WORKERS {
         let file = metrics_file.to_string() + &i.to_string();
-        cleanup_files(vec![&file]);
+        common::cleanup_files(vec![&file]);
         let file = debug_file.to_string() + &i.to_string();
-        cleanup_files(vec![&file]);
+        common::cleanup_files(vec![&file]);
     }
 
     let server = MockServer::start();

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -1,7 +1,7 @@
 use httpmock::Method::GET;
 use httpmock::{Mock, MockRef, MockServer};
+use serial_test::serial;
 use std::io::{self, BufRead};
-use std::thread;
 
 mod common;
 
@@ -10,37 +10,18 @@ use goose::prelude::*;
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
+const INDEX_KEY: usize = 0;
+const ABOUT_KEY: usize = 1;
+
 const USERS: usize = 3;
-const RUN_TIME: usize = 2;
+const RUN_TIME: usize = 3;
 const HATCH_RATE: usize = 10;
 const LOG_LEVEL: usize = 0;
 const METRICS_FILE: &str = "metrics-test.log";
 const DEBUG_FILE: &str = "debug-test.log";
 const LOG_FORMAT: &str = "raw";
 const THROTTLE_REQUESTS: usize = 10;
-
-// Has tests:
-// - GooseDefault::Host
-// - GooseDefault::MetricsFile
-// - GooseDefault::MetricsFormat
-// - GooseDefault::DebugFile
-// - GooseDefault::DebugFormat
-// - GooseDefault::HatchRate
-// - GooseDefault::RunTime
-// - GooseDefault::ThrottleRequests
-// - GooseDefault::Users
-// - GooseDefault::NoResetMetrics
-// - GooseDefault::StatusCodes
-// - GooseDefault::OnlySummary
-// - GooseDefault::NoTaskMetrics
-// - GooseDefault::Manager
-// - GooseDefault::ExpectWorkers
-// - GooseDefault::NoHashCheck
-// - GooseDefault::ManagerBindHost
-// - GooseDefault::ManagerBindPort
-// - GooseDefault::Worker
-// - GooseDefault::ManagerHost
-// - GooseDefault::ManagerPort
+const EXPECT_WORKERS: usize = 2;
 
 // Can't be tested:
 // - GooseDefault::LogFile (logger can only be configured once)
@@ -63,8 +44,124 @@ pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
     Ok(())
 }
 
-// Note: we're not testing log_file as tests run in threads, and only one
-// logger can be configured globally.
+// Helper to delete test artifact, if existing.
+fn cleanup_files(files: Vec<&str>) {
+    for file in files {
+        if std::path::Path::new(file).exists() {
+            std::fs::remove_file(file).expect("failed to remove file");
+        }
+    }
+}
+
+// Helper to count the number of lines in a test artifact.
+fn file_length(file_name: &str) -> usize {
+    if let Ok(file) = std::fs::File::open(std::path::Path::new(file_name)) {
+        io::BufReader::new(file).lines().count()
+    } else {
+        0
+    }
+}
+
+// All tests in this file run against common endpoints.
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
+    let mut endpoints: Vec<MockRef> = Vec::new();
+
+    // First, set up INDEX_PATH, store in vector at INDEX_KEY.
+    endpoints.push(
+        Mock::new()
+            .expect_method(GET)
+            .expect_path(INDEX_PATH)
+            .return_status(200)
+            .create_on(&server),
+    );
+    // Next, set up ABOUT_PATH, store in vector at ABOUT_KEY.
+    endpoints.push(
+        Mock::new()
+            .expect_method(GET)
+            .expect_path(ABOUT_PATH)
+            .return_status(200)
+            .create_on(&server),
+    );
+
+    endpoints
+}
+
+/// Helper that validates test results are the same regardless of if setting
+/// run-time options, or defaults.
+fn validate_test(
+    goose_metrics: GooseMetrics,
+    mock_endpoints: &[MockRef],
+    metrics_files: &[String],
+    debug_files: &[String],
+) {
+    // Confirm that we loaded the mock endpoints. This confirms that we started
+    // both users, which also verifies that hatch_rate was properly set.
+    assert!(mock_endpoints[INDEX_KEY].times_called() > 0);
+    assert!(mock_endpoints[ABOUT_KEY].times_called() > 0);
+
+    let index_metrics = goose_metrics
+        .requests
+        .get(&format!("GET {}", INDEX_PATH))
+        .unwrap();
+    let about_metrics = goose_metrics
+        .requests
+        .get(&format!("GET {}", ABOUT_PATH))
+        .unwrap();
+
+    // Confirm that Goose and the server saw the same number of page loads.
+    assert!(index_metrics.response_time_counter == mock_endpoints[INDEX_KEY].times_called());
+    assert!(index_metrics.success_count == mock_endpoints[INDEX_KEY].times_called());
+    assert!(index_metrics.fail_count == 0);
+    assert!(about_metrics.response_time_counter == mock_endpoints[ABOUT_KEY].times_called());
+    assert!(about_metrics.success_count == mock_endpoints[ABOUT_KEY].times_called());
+    assert!(about_metrics.fail_count == 0);
+
+    // Confirm that we tracked status codes.
+    assert!(!index_metrics.status_code_counts.is_empty());
+    assert!(!about_metrics.status_code_counts.is_empty());
+
+    // Confirm that we did not track task metrics.
+    assert!(goose_metrics.tasks.is_empty());
+
+    // Verify that Goose started the correct number of users.
+    assert!(goose_metrics.users == USERS);
+
+    // Verify that the metrics file was created and has the correct number of lines.
+    let mut metrics_lines = 0;
+    for metrics_file in metrics_files {
+        println!("metrics_file: {}", metrics_file);
+        assert!(std::path::Path::new(metrics_file).exists());
+        metrics_lines += file_length(metrics_file);
+    }
+    assert!(
+        metrics_lines
+            == mock_endpoints[INDEX_KEY].times_called() + mock_endpoints[ABOUT_KEY].times_called()
+    );
+
+    // Verify that the debug file was created and is empty.
+    for debug_file in debug_files {
+        assert!(std::path::Path::new(debug_file).exists());
+        assert!(file_length(debug_file) == 0);
+    }
+
+    // Requests are made while GooseUsers are hatched, and then for run_time seconds.
+    // Verify that the test ran as long as it was supposed to.
+    assert!(goose_metrics.duration == RUN_TIME);
+
+    // Be sure there were no more requests made than the throttle should allow.
+    // In the case of a gaggle, there's multiple processes running with the same
+    // throttle.
+    let number_of_processes = metrics_files.len();
+    assert!(metrics_lines <= (RUN_TIME + 1) * THROTTLE_REQUESTS * number_of_processes);
+
+    // Cleanup from test.
+    for file in metrics_files {
+        cleanup_files(vec![file]);
+    }
+    for file in debug_files {
+        cleanup_files(vec![file]);
+    }
+}
 
 #[test]
 /// Load test confirming that Goose respects configured defaults.
@@ -78,16 +175,8 @@ fn test_defaults() {
 
     let server = MockServer::start();
 
-    let index = Mock::new()
-        .expect_method(GET)
-        .expect_path(INDEX_PATH)
-        .return_status(200)
-        .create_on(&server);
-    let about = Mock::new()
-        .expect_method(GET)
-        .expect_path(ABOUT_PATH)
-        .return_status(200)
-        .create_on(&server);
+    // Setup the mock endpoints needed for this test.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
 
     let mut config = common::build_configuration(&server, vec![]);
 
@@ -135,79 +224,25 @@ fn test_defaults() {
         .execute()
         .unwrap();
 
-    validate_test(goose_metrics, index, about, &[metrics_file], &[debug_file]);
-}
-
-#[test]
-/// Load test confirming that Goose respects CLI options.
-fn test_no_defaults() {
-    // Multiple tests run together, so set a unique name.
-    let metrics_file = "nodefaults-".to_string() + METRICS_FILE;
-    let debug_file = "nodefaults-".to_string() + DEBUG_FILE;
-
-    // Be sure there's no files left over from an earlier test.
-    cleanup_files(vec![&metrics_file, &debug_file]);
-
-    let server = MockServer::start();
-
-    let index = Mock::new()
-        .expect_method(GET)
-        .expect_path(INDEX_PATH)
-        .return_status(200)
-        .create_on(&server);
-    let about = Mock::new()
-        .expect_method(GET)
-        .expect_path(ABOUT_PATH)
-        .return_status(200)
-        .create_on(&server);
-
-    let config = common::build_configuration(
-        &server,
-        vec![
-            "--users",
-            &USERS.to_string(),
-            "--hatch-rate",
-            &HATCH_RATE.to_string(),
-            "--run-time",
-            &RUN_TIME.to_string(),
-            "--metrics-file",
-            &metrics_file,
-            "--metrics-format",
-            LOG_FORMAT,
-            "--debug-file",
-            &debug_file,
-            "--debug-format",
-            LOG_FORMAT,
-            "--throttle-requests",
-            &THROTTLE_REQUESTS.to_string(),
-            "--no-reset-metrics",
-            "--no-task-metrics",
-            "--status-codes",
-            "--only-summary",
-            "--sticky-follow",
-        ],
+    validate_test(
+        goose_metrics,
+        &mock_endpoints,
+        &[metrics_file],
+        &[debug_file],
     );
-
-    let goose_metrics = crate::GooseAttack::initialize_with_config(config)
-        .unwrap()
-        .register_taskset(taskset!("Index").register_task(task!(get_index)))
-        .register_taskset(taskset!("About").register_task(task!(get_about)))
-        .execute()
-        .unwrap();
-
-    validate_test(goose_metrics, index, about, &[metrics_file], &[debug_file]);
 }
 
 #[test]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 /// Load test confirming that Goose respects configured gaggle-related defaults.
-fn test_gaggle_defaults() {
+#[serial]
+fn test_defaults_gaggle() {
     // Multiple tests run together, so set a unique name.
-    let metrics_file = "gaggle-".to_string() + METRICS_FILE;
-    let debug_file = "gaggle-".to_string() + DEBUG_FILE;
+    let metrics_file = "gaggle-defaults".to_string() + METRICS_FILE;
+    let debug_file = "gaggle-defaults".to_string() + DEBUG_FILE;
 
     // Be sure there's no files left over from an earlier test.
-    for i in 0..USERS {
+    for i in 0..EXPECT_WORKERS {
         let file = metrics_file.to_string() + &i.to_string();
         cleanup_files(vec![&file]);
         let file = debug_file.to_string() + &i.to_string();
@@ -216,16 +251,8 @@ fn test_gaggle_defaults() {
 
     let server = MockServer::start();
 
-    let index = Mock::new()
-        .expect_method(GET)
-        .expect_path(INDEX_PATH)
-        .return_status(200)
-        .create_on(&server);
-    let about = Mock::new()
-        .expect_method(GET)
-        .expect_path(ABOUT_PATH)
-        .return_status(200)
-        .create_on(&server);
+    // Setup the mock endpoints needed for this test.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
 
     const HOST: &str = "127.0.0.1";
     const PORT: usize = 9988;
@@ -240,11 +267,11 @@ fn test_gaggle_defaults() {
 
     // Launch workers in their own threads, storing the thread handle.
     let mut worker_handles = Vec::new();
-    for i in 0..USERS {
+    for i in 0..EXPECT_WORKERS {
         let worker_configuration = configuration.clone();
         let worker_metrics_file = metrics_file.clone() + &i.to_string();
         let worker_debug_file = debug_file.clone() + &i.to_string();
-        worker_handles.push(thread::spawn(move || {
+        worker_handles.push(std::thread::spawn(move || {
             let _ = crate::GooseAttack::initialize_with_config(worker_configuration)
                 .unwrap()
                 .register_taskset(taskset!("Index").register_task(task!(get_index)))
@@ -298,7 +325,7 @@ fn test_gaggle_defaults() {
         // Manager configuration using defaults instead of run-time options.
         .set_default(GooseDefault::Manager, true)
         .unwrap()
-        .set_default(GooseDefault::ExpectWorkers, USERS)
+        .set_default(GooseDefault::ExpectWorkers, EXPECT_WORKERS)
         .unwrap()
         .set_default(GooseDefault::NoHashCheck, true)
         .unwrap()
@@ -316,13 +343,179 @@ fn test_gaggle_defaults() {
 
     let mut metrics_files: Vec<String> = vec![];
     let mut debug_files: Vec<String> = vec![];
-    for i in 0..USERS {
+    for i in 0..EXPECT_WORKERS {
         let file = metrics_file.to_string() + &i.to_string();
         metrics_files.push(file);
         let file = debug_file.to_string() + &i.to_string();
         debug_files.push(file);
     }
-    validate_test(goose_metrics, index, about, &metrics_files, &debug_files);
+    validate_test(goose_metrics, &mock_endpoints, &metrics_files, &debug_files);
+}
+
+#[test]
+/// Load test confirming that Goose respects CLI options.
+fn test_no_defaults() {
+    // Multiple tests run together, so set a unique name.
+    let metrics_file = "nodefaults-".to_string() + METRICS_FILE;
+    let debug_file = "nodefaults-".to_string() + DEBUG_FILE;
+
+    // Be sure there's no files left over from an earlier test.
+    cleanup_files(vec![&metrics_file, &debug_file]);
+
+    let server = MockServer::start();
+
+    // Setup the mock endpoints needed for this test.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    let config = common::build_configuration(
+        &server,
+        vec![
+            "--users",
+            &USERS.to_string(),
+            "--hatch-rate",
+            &HATCH_RATE.to_string(),
+            "--run-time",
+            &RUN_TIME.to_string(),
+            "--metrics-file",
+            &metrics_file,
+            "--metrics-format",
+            LOG_FORMAT,
+            "--debug-file",
+            &debug_file,
+            "--debug-format",
+            LOG_FORMAT,
+            "--throttle-requests",
+            &THROTTLE_REQUESTS.to_string(),
+            "--no-reset-metrics",
+            "--no-task-metrics",
+            "--status-codes",
+            "--only-summary",
+            "--sticky-follow",
+        ],
+    );
+
+    let goose_metrics = crate::GooseAttack::initialize_with_config(config)
+        .unwrap()
+        .register_taskset(taskset!("Index").register_task(task!(get_index)))
+        .register_taskset(taskset!("About").register_task(task!(get_about)))
+        .execute()
+        .unwrap();
+
+    validate_test(
+        goose_metrics,
+        &mock_endpoints,
+        &[metrics_file],
+        &[debug_file],
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+/// Load test confirming that Goose respects configured gaggle-related defaults.
+#[serial]
+fn test_no_defaults_gaggle() {
+    let metrics_file = "gaggle-nodefaults".to_string() + METRICS_FILE;
+    let debug_file = "gaggle-nodefaults".to_string() + DEBUG_FILE;
+
+    // Be sure there's no files left over from an earlier test.
+    for i in 0..EXPECT_WORKERS {
+        let file = metrics_file.to_string() + &i.to_string();
+        cleanup_files(vec![&file]);
+        let file = debug_file.to_string() + &i.to_string();
+        cleanup_files(vec![&file]);
+    }
+
+    let server = MockServer::start();
+
+    // Setup the mock endpoints needed for this test.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    const HOST: &str = "127.0.0.1";
+    const PORT: usize = 9988;
+
+    // Launch workers in their own threads, storing the thread handle.
+    let mut worker_handles = Vec::new();
+    for i in 0..EXPECT_WORKERS {
+        let worker_metrics_file = metrics_file.to_string() + &i.to_string();
+        let worker_debug_file = debug_file.to_string() + &i.to_string();
+        let worker_configuration = common::build_configuration(
+            &server,
+            vec![
+                "--worker",
+                "--manager-host",
+                &HOST.to_string(),
+                "--manager-port",
+                &PORT.to_string(),
+                "--metrics-file",
+                &worker_metrics_file,
+                "--metrics-format",
+                LOG_FORMAT,
+                "--debug-file",
+                &worker_debug_file,
+                "--debug-format",
+                LOG_FORMAT,
+                "--throttle-requests",
+                &THROTTLE_REQUESTS.to_string(),
+                "--verbose",
+            ],
+        );
+        println!("{:#?}", worker_configuration);
+        worker_handles.push(std::thread::spawn(move || {
+            let _ = crate::GooseAttack::initialize_with_config(worker_configuration)
+                .unwrap()
+                .register_taskset(taskset!("Index").register_task(task!(get_index)))
+                .register_taskset(taskset!("About").register_task(task!(get_about)))
+                .execute()
+                .unwrap();
+        }));
+    }
+
+    let manager_configuration = common::build_configuration(
+        &server,
+        vec![
+            "--manager",
+            "--expect-workers",
+            &EXPECT_WORKERS.to_string(),
+            "--manager-bind-host",
+            &HOST.to_string(),
+            "--manager-bind-port",
+            &PORT.to_string(),
+            "--users",
+            &USERS.to_string(),
+            "--hatch-rate",
+            &HATCH_RATE.to_string(),
+            "--run-time",
+            &RUN_TIME.to_string(),
+            "--no-reset-metrics",
+            "--no-task-metrics",
+            "--status-codes",
+            "--only-summary",
+            "--sticky-follow",
+            "--verbose",
+        ],
+    );
+
+    let goose_metrics = crate::GooseAttack::initialize_with_config(manager_configuration)
+        .unwrap()
+        .register_taskset(taskset!("Index").register_task(task!(get_index)))
+        .register_taskset(taskset!("About").register_task(task!(get_about)))
+        .execute()
+        .unwrap();
+
+    // Wait for both worker threads to finish and exit.
+    for worker_handle in worker_handles {
+        let _ = worker_handle.join();
+    }
+
+    let mut metrics_files: Vec<String> = vec![];
+    let mut debug_files: Vec<String> = vec![];
+    for i in 0..EXPECT_WORKERS {
+        let file = metrics_file.to_string() + &i.to_string();
+        metrics_files.push(file);
+        let file = debug_file.to_string() + &i.to_string();
+        debug_files.push(file);
+    }
+    validate_test(goose_metrics, &mock_endpoints, &metrics_files, &debug_files);
 }
 
 #[test]
@@ -330,16 +523,8 @@ fn test_gaggle_defaults() {
 fn test_defaults_no_metrics() {
     let server = MockServer::start();
 
-    let index = Mock::new()
-        .expect_method(GET)
-        .expect_path(INDEX_PATH)
-        .return_status(200)
-        .create_on(&server);
-    let about = Mock::new()
-        .expect_method(GET)
-        .expect_path(ABOUT_PATH)
-        .return_status(200)
-        .create_on(&server);
+    // Setup the mock endpoints needed for this test.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
 
     let mut config = common::build_configuration(&server, vec!["--no-reset-metrics"]);
 
@@ -365,8 +550,8 @@ fn test_defaults_no_metrics() {
         .unwrap();
 
     // Confirm that we loaded the mock endpoints.
-    assert!(index.times_called() > 0);
-    assert!(about.times_called() > 0);
+    assert!(mock_endpoints[INDEX_KEY].times_called() > 0);
+    assert!(mock_endpoints[ABOUT_KEY].times_called() > 0);
 
     // Confirm that we did not track metrics.
     assert!(goose_metrics.requests.is_empty());
@@ -375,96 +560,4 @@ fn test_defaults_no_metrics() {
     assert!(goose_metrics.duration == RUN_TIME);
     assert!(!goose_metrics.display_metrics);
     assert!(!goose_metrics.display_status_codes);
-}
-
-// Helper to delete test artifact, if existing.
-fn cleanup_files(files: Vec<&str>) {
-    for file in files {
-        if std::path::Path::new(file).exists() {
-            std::fs::remove_file(file).expect("failed to remove file");
-        }
-    }
-}
-
-// Helper to count the number of lines in a test artifact.
-fn file_length(file_name: &str) -> usize {
-    if let Ok(file) = std::fs::File::open(std::path::Path::new(file_name)) {
-        io::BufReader::new(file).lines().count()
-    } else {
-        0
-    }
-}
-
-/// Helper that validates test results are the same regardless of if setting
-/// run-time options, or defaults.
-fn validate_test(
-    goose_metrics: GooseMetrics,
-    index: MockRef,
-    about: MockRef,
-    metrics_files: &[String],
-    debug_files: &[String],
-) {
-    // Confirm that we loaded the mock endpoints. This confirms that we started
-    // both users, which also verifies that hatch_rate was properly set.
-    assert!(index.times_called() > 0);
-    assert!(about.times_called() > 0);
-
-    let index_metrics = goose_metrics
-        .requests
-        .get(&format!("GET {}", INDEX_PATH))
-        .unwrap();
-    let about_metrics = goose_metrics
-        .requests
-        .get(&format!("GET {}", ABOUT_PATH))
-        .unwrap();
-
-    // Confirm that Goose and the server saw the same number of page loads.
-    assert!(index_metrics.response_time_counter == index.times_called());
-    assert!(index_metrics.success_count == index.times_called());
-    assert!(index_metrics.fail_count == 0);
-    assert!(about_metrics.response_time_counter == about.times_called());
-    assert!(about_metrics.success_count == about.times_called());
-    assert!(about_metrics.fail_count == 0);
-
-    // Confirm that we tracked status codes.
-    assert!(!index_metrics.status_code_counts.is_empty());
-    assert!(!about_metrics.status_code_counts.is_empty());
-
-    // Confirm that we did not track task metrics.
-    assert!(goose_metrics.tasks.is_empty());
-
-    // Verify that Goose started the correct number of users.
-    assert!(goose_metrics.users == USERS);
-
-    // Verify that the metrics file was created and has the correct number of lines.
-    let mut metrics_lines = 0;
-    for metrics_file in metrics_files {
-        assert!(std::path::Path::new(metrics_file).exists());
-        metrics_lines += file_length(metrics_file);
-    }
-    assert!(metrics_lines == index.times_called() + about.times_called());
-
-    // Verify that the debug file was created and is empty.
-    for debug_file in debug_files {
-        assert!(std::path::Path::new(debug_file).exists());
-        assert!(file_length(debug_file) == 0);
-    }
-
-    // Requests are made while GooseUsers are hatched, and then for run_time seconds.
-    // Verify that the test ran as long as it was supposed to.
-    assert!(goose_metrics.duration == RUN_TIME);
-
-    // Be sure there were no more requests made than the throttle should allow.
-    // In the case of a gaggle, there's multiple processes running with the same
-    // throttle.
-    let number_of_processes = metrics_files.len();
-    assert!(metrics_lines <= (RUN_TIME + 1) * THROTTLE_REQUESTS * number_of_processes);
-
-    // Cleanup from test.
-    for file in metrics_files {
-        cleanup_files(vec![file]);
-    }
-    for file in debug_files {
-        cleanup_files(vec![file]);
-    }
 }

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -6,12 +6,15 @@ mod common;
 
 use goose::prelude::*;
 
+// Paths used in load tests performed during these tests.
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
 
+// Indexes to the above paths.
 const INDEX_KEY: usize = 0;
 const ABOUT_KEY: usize = 1;
 
+// Load test configuration.
 const USERS: usize = 3;
 const RUN_TIME: usize = 3;
 const HATCH_RATE: usize = 10;
@@ -33,11 +36,13 @@ const EXPECT_WORKERS: usize = 2;
 // - GooseDefault::StickyFollow
 //     Needs more complex tests
 
+// Test task.
 pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await?;
     Ok(())
 }
 
+// Test task.
 pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(ABOUT_PATH).await?;
     Ok(())
@@ -67,8 +72,7 @@ fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
     endpoints
 }
 
-/// Helper that validates test results are the same regardless of if setting
-/// run-time options, or defaults.
+// Helper to confirm all variations generate appropriate results.
 fn validate_test(
     goose_metrics: GooseMetrics,
     mock_endpoints: &[MockRef],
@@ -144,7 +148,7 @@ fn validate_test(
 }
 
 #[test]
-/// Load test confirming that Goose respects configured defaults.
+// Configure load test with set_default.
 fn test_defaults() {
     // Multiple tests run together, so set a unique name.
     let metrics_file = "defaults-".to_string() + METRICS_FILE;
@@ -214,8 +218,8 @@ fn test_defaults() {
 
 #[test]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-/// Load test confirming that Goose respects configured gaggle-related defaults.
 #[serial]
+// Configure load test with set_default, run as Gaggle.
 fn test_defaults_gaggle() {
     // Multiple tests run together, so set a unique name.
     let metrics_file = "gaggle-defaults".to_string() + METRICS_FILE;
@@ -333,7 +337,7 @@ fn test_defaults_gaggle() {
 }
 
 #[test]
-/// Load test confirming that Goose respects CLI options.
+// Configure load test with run time options (not with defaults).
 fn test_no_defaults() {
     // Multiple tests run together, so set a unique name.
     let metrics_file = "nodefaults-".to_string() + METRICS_FILE;
@@ -391,8 +395,8 @@ fn test_no_defaults() {
 
 #[test]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-/// Load test confirming that Goose respects configured gaggle-related defaults.
 #[serial]
+// Configure load test with run time options (not with defaults), run as Gaggle.
 fn test_no_defaults_gaggle() {
     let metrics_file = "gaggle-nodefaults".to_string() + METRICS_FILE;
     let debug_file = "gaggle-nodefaults".to_string() + DEBUG_FILE;
@@ -499,14 +503,14 @@ fn test_no_defaults_gaggle() {
 }
 
 #[test]
-/// Load test confirming that Goose respects configured defaults.
+// Configure load test with defaults, disable metrics.
 fn test_defaults_no_metrics() {
     let server = MockServer::start();
 
     // Setup the mock endpoints needed for this test.
     let mock_endpoints = setup_mock_server_endpoints(&server);
 
-    let mut config = common::build_configuration(&server, vec!["--no-reset-metrics"]);
+    let mut config = common::build_configuration(&server, vec![]);
 
     // Unset options set in common.rs so set_default() is instead used.
     config.users = None;

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -7,22 +7,29 @@ mod common;
 
 use goose::prelude::*;
 
+// Paths used in load tests performed during these tests.
 const INDEX_PATH: &str = "/";
 const ERROR_PATH: &str = "/error";
 
+// Indexes to the above paths.
 const INDEX_KEY: usize = 0;
 const ERROR_KEY: usize = 1;
 
+// Load test configuration.
 const EXPECT_WORKERS: usize = 2;
 
+// There are multiple test variations in this file.
 enum TestType {
+    // Test with metrics log enabled.
     Metrics,
+    // Test with debug log enabled.
     Debug,
+    // Test with metrics log and debug log both enabled.
     MetricsAndDebug,
 }
 
-// As tests run in parallel, implement fmt::Display so we can uniquely name
-// the logs for each type of test.
+// Implement fmt::Display for TestType to uniquely name the log files generated
+// by each test. This is necessary as tests run in parallel.
 impl fmt::Display for TestType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let printable = match *self {
@@ -34,11 +41,13 @@ impl fmt::Display for TestType {
     }
 }
 
+// Test task.
 pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await?;
     Ok(())
 }
 
+// Test task.
 pub async fn get_error(user: &GooseUser) -> GooseTaskResult {
     let mut goose = user.get(ERROR_PATH).await?;
 
@@ -81,14 +90,14 @@ fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
     endpoints
 }
 
-// Returns the appropriate taskset, start_task and stop_task needed to build this load test.
+// Returns the appropriate taskset, start_task and stop_task needed to build these tests.
 fn get_tasks() -> GooseTaskSet {
     taskset!("LoadTest")
         .register_task(task!(get_index))
         .register_task(task!(get_error))
 }
 
-// Helper to validate the test results.
+// Helper to confirm all variations generate appropriate results.
 fn validate_test(
     goose_metrics: GooseMetrics,
     mock_endpoints: &[MockRef],
@@ -314,91 +323,91 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
     }
 }
 
-// Create a json formatted metrics log.
 #[test]
+// Enable json-formatted metrics log.
 fn test_metrics_logs_json() {
     run_standalone_test(TestType::Metrics, "json");
 }
 
-// Create a json formatted metrics log in Gaggle mode.
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable json-formatted metrics log, in Gaggle mode.
 fn test_metrics_logs_json_gaggle() {
     run_gaggle_test(TestType::Metrics, "json");
 }
 
-// Create a csv formatted metrics log.
 #[test]
+// Enable csv-formatted metrics log.
 fn test_metrics_logs_csv() {
     run_standalone_test(TestType::Metrics, "csv");
 }
 
-// Create a csv formatted metrics log in Gaggle mode.
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable csv-formatted metrics log, in Gaggle mode.
 fn test_metrics_logs_csv_gaggle() {
     run_gaggle_test(TestType::Metrics, "csv");
 }
 
-// Create a raw formatted metrics log.
 #[test]
+// Enable raw-formatted metrics log.
 fn test_metrics_logs_raw() {
     run_standalone_test(TestType::Metrics, "raw");
 }
 
-// Create a raw formatted metrics log in Gaggle mode.
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable raw-formatted metrics log, in Gaggle mode.
 fn test_metrics_logs_raw_gaggle() {
     run_gaggle_test(TestType::Metrics, "raw");
 }
 
-// Create a raw formatted debug log.
 #[test]
+// Enable raw-formatted debug log.
 fn test_debug_logs_raw() {
     run_standalone_test(TestType::Debug, "raw");
 }
 
 /* @TODO: FIXME: https://github.com/tag1consulting/goose/issues/194
-// Create a raw formatted debug log in Gaggle mode.
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable raw-formatted debug log, in Gaggle mode.
 fn test_debug_logs_raw_gaggle() {
     run_gaggle_test(TestType::Debug, "raw");
 }
 */
 
-// Create a json formatted debug log.
 #[test]
+// Enable json-formatted debug log.
 fn test_debug_logs_json() {
     run_standalone_test(TestType::Debug, "json");
 }
 
 /* @TODO: FIXME: https://github.com/tag1consulting/goose/issues/194
-// Create a json formatted debug log in Gaggle mode.
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable json-formatted debug log, in Gaggle mode.
 fn test_debug_logs_json_gaggle() {
     run_gaggle_test(TestType::Debug, "json");
 }
 */
 
-// Create raw formatted debug and metrics logs.
 #[test]
+// Enable raw-formatted debug log and metrics log.
 fn test_metrics_and_debug_logs() {
     run_standalone_test(TestType::MetricsAndDebug, "raw");
 }
 
 /* @TODO: FIXME: https://github.com/tag1consulting/goose/issues/194
-// Create raw formatted debug and metrics logs in Gaggle mode.
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable raw-formatted debug log and metrics log, in Gaggle mode.
 fn test_metrics_and_debug_logs_gaggle() {
     run_gaggle_test(TestType::MetricsAndDebug, "raw");
 }

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -7,16 +7,20 @@ use goose::goose::GooseTaskSet;
 use goose::prelude::*;
 use goose::GooseConfiguration;
 
+// Paths used in load tests performed during these tests.
 const LOGIN_PATH: &str = "/login";
 const LOGOUT_PATH: &str = "/logout";
 
+// Indexes to the above paths.
 const LOGIN_KEY: usize = 0;
 const LOGOUT_KEY: usize = 1;
 
+// Load test configuration.
 const EXPECT_WORKERS: usize = 2;
 const USERS: usize = 5;
 const RUN_TIME: usize = 2;
 
+// Test task.
 pub async fn login(user: &GooseUser) -> GooseTaskResult {
     let request_builder = user.goose_post(LOGIN_PATH).await?;
     let params = [("username", "me"), ("password", "s3crET!")];
@@ -24,6 +28,7 @@ pub async fn login(user: &GooseUser) -> GooseTaskResult {
     Ok(())
 }
 
+// Test task.
 pub async fn logout(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(LOGOUT_PATH).await?;
     Ok(())
@@ -53,7 +58,7 @@ fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
     endpoints
 }
 
-// Create a custom configuration for this test.
+// Build appropriate configuration for these tests.
 fn common_build_configuration(
     server: &MockServer,
     worker: Option<bool>,
@@ -93,69 +98,78 @@ fn common_build_configuration(
     }
 }
 
+// Helper to confirm all variations generate appropriate results.
 fn validate_test(mock_endpoints: &[MockRef]) {
     // Confirm that the on_start and on_exit tasks actually ran once per GooseUser.
     assert!(mock_endpoints[LOGIN_KEY].times_called() == USERS);
     assert!(mock_endpoints[LOGOUT_KEY].times_called() == USERS);
 }
 
+// Returns the appropriate taskset needed to build these tests.
 fn get_tasks() -> GooseTaskSet {
     taskset!("LoadTest")
         .register_task(task!(login).set_on_start())
         .register_task(task!(logout).set_on_stop())
 }
 
-// Verify Goose works with only on_start() and on_stop() tasks.
-#[test]
-fn test_no_normal_tasks() {
+// Helper to run the test, takes a flag for indicating if running in standalone
+// mode or Gaggle mode.
+fn run_load_test(is_gaggle: bool) {
     // Start the mock server.
     let server = MockServer::start();
 
     // Setup the mock endpoints needed for this test.
     let mock_endpoints = setup_mock_server_endpoints(&server);
 
-    // Build common configuration.
-    let configuration = common_build_configuration(&server, None, None);
+    // Configure and run test differently in standalone versus Gaggle mode.
+    match is_gaggle {
+        false => {
+            // Build common configuration.
+            let configuration = common_build_configuration(&server, None, None);
 
-    // Run the Goose Attack.
-    common::run_load_test(
-        common::build_load_test(configuration, &get_tasks(), None, None),
-        None,
-    );
+            // Run the Goose Attack.
+            common::run_load_test(
+                common::build_load_test(configuration, &get_tasks(), None, None),
+                None,
+            );
+        }
+        true => {
+            // Build common configuration.
+            let worker_configuration = common_build_configuration(&server, Some(true), None);
+
+            // Workers launched in own threads, store thread handles.
+            let worker_handles = common::launch_gaggle_workers(
+                common::build_load_test(worker_configuration, &get_tasks(), None, None),
+                EXPECT_WORKERS,
+            );
+
+            // Build Manager configuration.
+            let manager_configuration =
+                common_build_configuration(&server, None, Some(EXPECT_WORKERS));
+
+            // Run the Goose Attack.
+            common::run_load_test(
+                common::build_load_test(manager_configuration, &get_tasks(), None, None),
+                Some(worker_handles),
+            );
+        }
+    }
 
     // Confirm the load test ran correctly.
     validate_test(&mock_endpoints);
 }
 
-// Verify Goose works in Gaggle mode with only on_start() and on_stop() tasks.
 #[test]
-// Only run gaggle tests if the feature is compiled into the codebase.
+// Test taskset with only on_start() and on_stop() tasks.
+fn test_no_normal_tasks() {
+    // Run load test with is_gaggle set to false.
+    run_load_test(false);
+}
+
+#[test]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
+// Test taskset with only on_start() and on_stop() tasks, in Gaggle mode.
 fn test_no_normal_tasks_gaggle() {
-    // Start the mock server.
-    let server = MockServer::start();
-
-    // Setup the mock endpoints needed for this test.
-    let mock_endpoints = setup_mock_server_endpoints(&server);
-
-    // Build common configuration.
-    let worker_configuration = common_build_configuration(&server, Some(true), None);
-
-    // Workers launched in own threads, store thread handles.
-    let worker_handles = common::launch_gaggle_workers(
-        common::build_load_test(worker_configuration, &get_tasks(), None, None),
-        EXPECT_WORKERS,
-    );
-
-    // Build Manager configuration.
-    let manager_configuration = common_build_configuration(&server, None, Some(EXPECT_WORKERS));
-
-    // Run the Goose Attack.
-    common::run_load_test(
-        common::build_load_test(manager_configuration, &get_tasks(), None, None),
-        Some(worker_handles),
-    );
-
-    // Confirm the load test ran correctly.
-    validate_test(&mock_endpoints);
+    // Run load test with is_gaggle set to true.
+    run_load_test(true);
 }

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -1,12 +1,21 @@
 use httpmock::Method::{GET, POST};
-use httpmock::{Mock, MockServer};
+use httpmock::{Mock, MockRef, MockServer};
 
 mod common;
 
+use goose::goose::GooseTaskSet;
 use goose::prelude::*;
+use goose::GooseConfiguration;
 
 const LOGIN_PATH: &str = "/login";
 const LOGOUT_PATH: &str = "/logout";
+
+const LOGIN_KEY: usize = 0;
+const LOGOUT_KEY: usize = 1;
+
+const EXPECT_WORKERS: usize = 2;
+const USERS: usize = 5;
+const RUN_TIME: usize = 2;
 
 pub async fn login(user: &GooseUser) -> GooseTaskResult {
     let request_builder = user.goose_post(LOGIN_PATH).await?;
@@ -20,35 +29,133 @@ pub async fn logout(user: &GooseUser) -> GooseTaskResult {
     Ok(())
 }
 
+// All tests in this file run against common endpoints.
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
+    let mut endpoints: Vec<MockRef> = Vec::new();
+
+    // First set up LOGIN_PATH, store in vector at LOGIN_KEY.
+    endpoints.push(
+        Mock::new()
+            .expect_method(POST)
+            .expect_path(LOGIN_PATH)
+            .return_status(200)
+            .create_on(&server),
+    );
+    // Next set up LOGOUT_PATH, store in vector at LOGOUT_KEY.
+    endpoints.push(
+        Mock::new()
+            .expect_method(GET)
+            .expect_path(LOGOUT_PATH)
+            .return_status(200)
+            .create_on(&server),
+    );
+
+    endpoints
+}
+
+// Create a custom configuration for this test.
+fn common_build_configuration(
+    server: &MockServer,
+    worker: Option<bool>,
+    manager: Option<usize>,
+) -> GooseConfiguration {
+    if let Some(expect_workers) = manager {
+        common::build_configuration(
+            &server,
+            vec![
+                "--manager",
+                "--expect-workers",
+                &expect_workers.to_string(),
+                "--users",
+                &USERS.to_string(),
+                "--hatch-rate",
+                &USERS.to_string(),
+                "--run-time",
+                &RUN_TIME.to_string(),
+                "--no-reset-metrics",
+            ],
+        )
+    } else if worker.is_some() {
+        common::build_configuration(&server, vec!["--worker"])
+    } else {
+        common::build_configuration(
+            &server,
+            vec![
+                "--users",
+                &USERS.to_string(),
+                "--hatch-rate",
+                &USERS.to_string(),
+                "--run-time",
+                &RUN_TIME.to_string(),
+                "--no-reset-metrics",
+            ],
+        )
+    }
+}
+
+fn validate_test(mock_endpoints: &[MockRef]) {
+    // Confirm that the on_start and on_exit tasks actually ran once per GooseUser.
+    assert!(mock_endpoints[LOGIN_KEY].times_called() == USERS);
+    assert!(mock_endpoints[LOGOUT_KEY].times_called() == USERS);
+}
+
+fn get_tasks() -> GooseTaskSet {
+    taskset!("LoadTest")
+        .register_task(task!(login).set_on_start())
+        .register_task(task!(logout).set_on_stop())
+}
+
+// Verify Goose works with only on_start() and on_stop() tasks.
 #[test]
 fn test_no_normal_tasks() {
+    // Start the mock server.
     let server = MockServer::start();
 
-    let login_path = Mock::new()
-        .expect_method(POST)
-        .expect_path(LOGIN_PATH)
-        .return_status(200)
-        .create_on(&server);
-    let logout_path = Mock::new()
-        .expect_method(GET)
-        .expect_path(LOGOUT_PATH)
-        .return_status(200)
-        .create_on(&server);
+    // Setup the mock endpoints needed for this test.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
 
-    let _goose_stats = crate::GooseAttack::initialize_with_config(common::build_configuration(
-        &server,
-        vec!["--no-metrics"],
-    ))
-    .unwrap()
-    .register_taskset(
-        taskset!("LoadTest")
-            .register_task(task!(login).set_on_start())
-            .register_task(task!(logout).set_on_stop()),
-    )
-    .execute()
-    .unwrap();
+    // Build common configuration.
+    let configuration = common_build_configuration(&server, None, None);
 
-    // Confirm that the on_start and on_exit tasks actually ran.
-    assert!(login_path.times_called() == 1);
-    assert!(logout_path.times_called() == 1);
+    // Run the Goose Attack.
+    common::run_load_test(
+        common::build_load_test(configuration, &get_tasks(), None, None),
+        None,
+    );
+
+    // Confirm the load test ran correctly.
+    validate_test(&mock_endpoints);
+}
+
+// Verify Goose works in Gaggle mode with only on_start() and on_stop() tasks.
+#[test]
+// Only run gaggle tests if the feature is compiled into the codebase.
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+fn test_no_normal_tasks_gaggle() {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    // Setup the mock endpoints needed for this test.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    // Build common configuration.
+    let worker_configuration = common_build_configuration(&server, Some(true), None);
+
+    // Workers launched in own threads, store thread handles.
+    let worker_handles = common::launch_gaggle_workers(
+        common::build_load_test(worker_configuration, &get_tasks(), None, None),
+        EXPECT_WORKERS,
+    );
+
+    // Build Manager configuration.
+    let manager_configuration = common_build_configuration(&server, None, Some(EXPECT_WORKERS));
+
+    // Run the Goose Attack.
+    common::run_load_test(
+        common::build_load_test(manager_configuration, &get_tasks(), None, None),
+        Some(worker_handles),
+    );
+
+    // Confirm the load test ran correctly.
+    validate_test(&mock_endpoints);
 }

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -8,25 +8,33 @@ use goose::goose::GooseMethod;
 use goose::prelude::*;
 use goose::GooseConfiguration;
 
+// Paths used in load tests performed during these tests.
 const INDEX_PATH: &str = "/";
 const ABOUT_PATH: &str = "/about.html";
+
+// Indexes to the above paths.
 const INDEX_KEY: usize = 0;
 const ABOUT_KEY: usize = 1;
 
+// Load test configuration.
 const EXPECT_WORKERS: usize = 2;
 
-// Define the different types of tests run in this file.
+// There are multiple test variations in this file.
 #[derive(Clone)]
 enum TestType {
+    // Enable --no-reset-metrics.
     NoResetMetrics,
+    // Do not enable --no-reset-metrics.
     ResetMetrics,
 }
 
+// Test task.
 pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await?;
     Ok(())
 }
 
+// Test task.
 pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(ABOUT_PATH).await?;
     Ok(())
@@ -56,7 +64,7 @@ fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
     endpoints
 }
 
-// Create a custom configuration for this test.
+// Build appropriate configuration for these tests.
 fn common_build_configuration(server: &MockServer, custom: &mut Vec<&str>) -> GooseConfiguration {
     // Common elements in all our tests.
     let mut configuration = vec![
@@ -76,7 +84,7 @@ fn common_build_configuration(server: &MockServer, custom: &mut Vec<&str>) -> Go
     common::build_configuration(&server, configuration)
 }
 
-// Common validation of load tests for the tests run in this file.
+// Helper to confirm all variations generate appropriate results.
 fn validate_one_taskset(
     goose_metrics: &GooseMetrics,
     mock_endpoints: &[MockRef],
@@ -162,7 +170,7 @@ fn validate_one_taskset(
     assert!(goose_metrics.users == configuration.users.unwrap());
 }
 
-// Returns the appropriate taskset needed to build this load test.
+// Returns the appropriate taskset needed to build these tests.
 fn get_tasks() -> GooseTaskSet {
     taskset!("LoadTest")
         .register_task(task!(get_index).set_weight(9).unwrap())
@@ -246,24 +254,21 @@ fn run_gaggle_test(test_type: TestType) {
 }
 
 #[test]
-// Load test with a single task set containing two weighted tasks. Validate
-// weighting and statistics.
+// Test a single task set with multiple weighted tasks.
 fn test_one_taskset() {
     run_standalone_test(TestType::NoResetMetrics);
 }
 
 #[test]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-// Load test with a single task set containing two weighted tasks. Validate
-// weighting and statistics when run in a distributed Gaggle.
 #[serial]
+// Test a single task set with multiple weighted tasks, in Gaggle mode.
 fn test_one_taskset_gaggle() {
     run_gaggle_test(TestType::NoResetMetrics);
 }
 
 #[test]
-// Load test with a single task set containing two weighted tasks. Validate
-// weighting and statistics after resetting metrics.
+// Test a single task set with multiple weighted tasks, enable --no-reset-metrics.
 fn test_one_taskset_reset_metrics() {
     run_standalone_test(TestType::ResetMetrics);
 }
@@ -272,10 +277,9 @@ fn test_one_taskset_reset_metrics() {
  * Issue: https://github.com/tag1consulting/goose/issues/193
 #[test]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-// Load test with a single task set containing two weighted tasks. Validate
-// weighting and statistics after resetting metrics when run in a distributed
-// Gaggle.
 #[serial]
+// Test a single task set with multiple weighted tasks, enable --no-reset-metrics
+// in Gaggle mode.
 fn test_one_taskset_reset_metrics_gaggle() {
     run_gaggle_test(TestType::ResetMetrics);
 }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -347,7 +347,7 @@ fn run_standalone_test(test_type: TestType) {
 
     // Run the Goose Attack.
     common::run_load_test(
-        common::build_load_test(configuration.clone(), &get_tasks(&test_type), None, None),
+        common::build_load_test(configuration, &get_tasks(&test_type), None, None),
         None,
     );
 

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -256,13 +256,13 @@ fn test_not_sequenced_gaggle() {
     let mock_endpoints = setup_mock_server_endpoints(&server);
 
     // Build common configuration.
-    let configuration = common_build_configuration(&server, Some(true), None);
+    let worker_configuration = common_build_configuration(&server, Some(true), None);
 
     // Define the type of test.
     let test_type = TestType::NotSequenced;
 
     // Build the Goose Attack as configured.
-    let goose_attack = build_load_test(&test_type, &configuration);
+    let goose_attack = build_load_test(&test_type, &worker_configuration);
 
     // Workers launched in own threads, store thread handles.
     let worker_handles = common::launch_gaggle_workers(goose_attack, EXPECT_WORKERS);

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -7,33 +7,38 @@ mod common;
 use goose::prelude::*;
 use goose::GooseConfiguration;
 
+// Paths used in load tests performed during these tests.
 const INDEX_PATH: &str = "/";
 const SETUP_PATH: &str = "/setup";
 const TEARDOWN_PATH: &str = "/teardown";
 
+// Indexes to the above paths.
 const INDEX_KEY: usize = 0;
 const SETUP_KEY: usize = 1;
 const TEARDOWN_KEY: usize = 2;
 
+// Load test configuration.
 const EXPECT_WORKERS: usize = 2;
 const USERS: &str = "4";
 
-// Defines the different types of tests.
+// There are multiple test variations in this file.
 #[derive(Clone)]
 enum TestType {
-    // Testing on_start alone.
+    // Test on_start alone.
     Start,
-    // Testing on_stop alone.
+    // Test on_stop alone.
     Stop,
-    // Testing on_start and on_stop together.
+    // Test on_start and on_stop both together.
     StartAndStop,
 }
 
+// Test task.
 pub async fn setup(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.post(SETUP_PATH, "setting up load test").await?;
     Ok(())
 }
 
+// Test task.
 pub async fn teardown(user: &GooseUser) -> GooseTaskResult {
     let _goose = user
         .post(TEARDOWN_PATH, "cleaning up after load test")
@@ -41,6 +46,7 @@ pub async fn teardown(user: &GooseUser) -> GooseTaskResult {
     Ok(())
 }
 
+// Test task.
 pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
     let _goose = user.get(INDEX_PATH).await?;
     Ok(())
@@ -78,7 +84,7 @@ fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
     endpoints
 }
 
-// Create a custom configuration for this test.
+// Build appropriate configuration for these tests.
 fn common_build_configuration(
     server: &MockServer,
     worker: Option<bool>,
@@ -104,7 +110,7 @@ fn common_build_configuration(
     }
 }
 
-// Common validation for the load tests in this file.
+// Helper to confirm all variations generate appropriate results.
 fn validate_test(test_type: &TestType, mock_endpoints: &[MockRef]) {
     // Confirm the load test ran.
     assert!(mock_endpoints[INDEX_KEY].times_called() > 0);
@@ -199,50 +205,44 @@ fn run_gaggle_test(test_type: TestType) {
     validate_test(&test_type, &mock_endpoints);
 }
 
-/// Test test_start alone.
 #[test]
+// Test test_start().
 fn test_setup() {
     run_standalone_test(TestType::Start);
 }
 
-/// Test test_start alone.
 #[test]
-// Only run gaggle tests if the feature is compiled into the codebase.
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-// Gaggle tests have to be run serially instead of in parallel.
 #[serial]
+// Test test_start(), in Gaggle mode.
 fn test_setup_gaggle() {
     run_gaggle_test(TestType::Start);
 }
 
-/// Test test_stop alone.
 #[test]
+// Test test_stop().
 fn test_teardown() {
     run_standalone_test(TestType::Stop);
 }
 
-/// Test test_start alone in Gaggle mode.
 #[test]
-// Only run Gaggle tests if the feature is compiled into the codebase.
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-// Gaggle tests have to be run serially instead of in parallel.
 #[serial]
+// Test test_stop(), in Gaggle mode.
 fn test_teardown_gaggle() {
     run_gaggle_test(TestType::Stop);
 }
 
-/// Test test_start and test_stop together.
 #[test]
+/// Test test_start and test_stop together.
 fn test_setup_teardown() {
     run_standalone_test(TestType::StartAndStop);
 }
 
-/// Test test_start and test_Stop together in Gaggle mode.
 #[test]
-// Only run Gaggle tests if the feature is compiled into the codebase.
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-// Gaggle tests have to be run serially instead of in parallel.
 #[serial]
+/// Test test_start and test_stop together, in Gaggle mode.
 fn test_setup_teardown_gaggle() {
     run_gaggle_test(TestType::StartAndStop);
 }

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -306,7 +306,7 @@ fn test_throttle_gaggle() {
 
     // Build the load test for the Manager.
     let manager_goose_attack =
-        common::build_load_test(manager_configuration.clone(), &get_tasks(), None, None);
+        common::build_load_test(manager_configuration, &get_tasks(), None, None);
 
     // Run the Goose Attack.
     common::run_load_test(manager_goose_attack, Some(worker_handles));


### PR DESCRIPTION
Restructures tests to re-use code where possible, also moving some common code into `tests/common.rs`. De-duplicates the code to fix #133 and ensures all functionality is tested both in Standalone and Gaggle mode.