### PR TITLE
add example testing Drupal 9 Umami install profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.4-dev
+ - add new `examples/umami` for load testing Drupal 9 demo install profile
+
 ## 0.10.3 Oct 14, 2020
  - fixup sticky redirect tests to properly test functionality
  - add `test/sequence.rs` to confirm sequencing tests works correctly, even in Gaggle mode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.10.3"
+version = "0.10.4-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/examples/umami/README.md
+++ b/examples/umami/README.md
@@ -1,0 +1,35 @@
+# Overview
+
+This is a load test for Drupal's Umami Profile, which is included as part of Drupal 9 core. In order to use this load test, you must first install the Umami Profile as documented here:
+https://www.drupal.org/docs/umami-drupal-demonstration-installation-profile
+
+The load test was developed using a locally hosted Drupal 9 install hosted in a DDEV container:
+https://www.ddev.com/
+
+By default it will try and load pages from https://drupal-9.0.7.ddev.site/.
+
+## Load Test Implementation
+
+The load test is split into the following files:
+ - `main.rs`: This file contains the main() function and defines the actual load test;
+ - `common.rs`: This file contains helper functions used by the task functions;
+ - `english.rs`: This files contains all task functions loading pages in English;
+ - `spanish.rs`: This files contains all task functions loading pages in Spanish.
+
+## Load Test Features
+
+The load test defines the following users:
+ - Anonymous English user: this user performs all tasks in English, it runs 3 times as often as the Spanish user;
+ - Anonymous Spanish user: this user performs all tasks in Spanish, it runs 1/3 as often as the English user.
+
+Each load test user runs the following tasks in their own language, and also loads all static elements on any pages loaded:
+ - Loads the front page;
+ - Loads a "basic page";
+ - Loads the article listing page;
+ - Loads an "article";
+ - Loads the recipe listing page;
+ - Loads a "recipe";
+ - Loads a random node by nid;
+ - Loads the term listing page filtered by a random term;
+ - Performs a search using a random word from a random node's title;
+ - Submits website feedback through the contact form;

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -1,0 +1,761 @@
+use goose::goose::GooseResponse;
+use goose::prelude::*;
+
+use log::info;
+use rand::prelude::IteratorRandom;
+use rand::seq::SliceRandom;
+use regex::Regex;
+
+/// The Umami website defines three content types.
+pub enum ContentType {
+    Article,
+    BasicPage,
+    Recipe,
+}
+
+/// Details tracked about individual nodes used to run load test and validate
+/// that pages are being correctly loaded.
+pub struct Node<'a> {
+    pub nid: u8,
+    pub url_en: &'a str,
+    pub url_es: &'a str,
+    pub title_en: &'a str,
+    pub title_es: &'a str,
+}
+
+/// Vocabulary term details.
+pub struct Term<'a> {
+    pub url_en: &'a str,
+    pub url_es: &'a str,
+    pub title_en: &'a str,
+    pub title_es: &'a str,
+}
+
+/// Returns a vector of all nodes of a specified content type.
+pub fn get_nodes(content_type: &ContentType) -> Vec<Node> {
+    let mut nodes: Vec<Node> = Vec::new();
+
+    match content_type {
+        ContentType::Article => {
+            nodes.push(Node {
+                nid: 10,
+                url_en: "/en/articles/give-it-a-go-and-grow-your-own-herbs",
+                url_es: "/es/articles/prueba-y-cultiva-tus-propias-hierbas",
+                title_en: "Give it a go and grow your own herbs",
+                title_es: "Prueba y cultiva tus propias hierbas",
+            });
+            nodes.push(Node {
+                nid: 11,
+                url_en: "/en/articles/dairy-free-and-delicious-milk-chocolate",
+                url_es: "/es/articles/delicioso-chocolate-sin-lactosa",
+                title_en: "Dairy-free and delicious milk chocolate",
+                title_es: "Delicioso chocolate sin lactosa",
+            });
+            nodes.push(Node {
+                nid: 12,
+                url_en: "/en/articles/the-real-deal-for-supermarket-savvy-shopping",
+                url_es: "/es/articles/el-verdadeo-negocio-para-comprar-en-el-supermercado",
+                title_en: "The real deal for supermarket savvy shopping",
+                title_es: "El verdadero negocio para comprar en el supermercado",
+            });
+            nodes.push(Node {
+                nid: 13,
+                url_en: "/en/articles/the-umami-guide-to-our-favourite-mushrooms",
+                url_es: "/es/articles/guia-umami-de-nuestras-setas-preferidas",
+                title_en: "The Umami guide to our favorite mushrooms",
+                title_es: "Guía Umami de nuestras setas preferidas",
+            });
+            nodes.push(Node {
+                nid: 14,
+                url_en: "/en/articles/lets-hear-it-for-carrots",
+                url_es: "/es/articles/un-aplauso-para-las-zanahorias",
+                title_en: "Let&#039;s hear it for carrots",
+                title_es: "Un aplauso para las zanahorias",
+            });
+            nodes.push(Node {
+                nid: 15,
+                url_en: "/en/articles/baking-mishaps-our-troubleshooting-tips",
+                url_es:
+                    "/es/articles/percances-al-hornear-nuestros-consejos-para-solucionar-problemas",
+                title_en: "Baking mishaps - our troubleshooting tips",
+                title_es: "Percances al hornear - nuestros consejos para solucionar los problemas",
+            });
+            nodes.push(Node {
+                nid: 16,
+                url_en: "/en/articles/skip-the-spirits-with-delicious-mocktails",
+                url_es: "/es/articles/salta-los-espiritus-con-deliciosos-cocteles-sin-alcohol",
+                title_en: "Skip the spirits with delicious mocktails",
+                title_es: "Salta los espíritus con deliciosos cócteles sin alcohol",
+            });
+            nodes.push(Node {
+                nid: 17,
+                url_en: "/en/articles/give-your-oatmeal-the-ultimate-makeover",
+                url_es: "/es/articles/dale-a-tu-avena-el-cambio-de-imagen-definitivo",
+                title_en: "Give your oatmeal the ultimate makeover",
+                title_es: "Dale a tu avena el cambio de imagen definitivo",
+            });
+        }
+        ContentType::BasicPage => {
+            nodes.push(Node {
+                nid: 18,
+                url_en: "/en/about-umami",
+                url_es: "/es/acerca-de-umami",
+                title_en: "About Umami",
+                title_es: "Acerca de Umami",
+            });
+        }
+        ContentType::Recipe => {
+            nodes.push(Node {
+                nid: 1,
+                url_en: "/en/recipes/deep-mediterranean-quiche",
+                url_es: "/es/recipes/quiche-mediterráneo-profundo",
+                title_en: "Deep mediterranean quiche",
+                title_es: "Quiche mediterráneo profundo",
+            });
+            nodes.push(Node {
+                nid: 2,
+                url_en: "/en/recipes/vegan-chocolate-and-nut-brownies",
+                url_es: "/es/recipes/bizcochos-veganos-de-chocolate-y-nueces",
+                title_en: "Vegan chocolate and nut brownies",
+                title_es: "Bizcochos veganos de chocolate y nueces",
+            });
+            nodes.push(Node {
+                nid: 3,
+                url_en: "/en/recipes/super-easy-vegetarian-pasta-bake",
+                url_es: "/es/recipes/pasta-vegetariana-horno-super-facil",
+                title_en: "Super easy vegetarian pasta bake",
+                title_es: "Pasta vegetariana al horno súper fácil",
+            });
+            nodes.push(Node {
+                nid: 4,
+                url_en: "/en/recipes/watercress-soup",
+                url_es: "/es/recipes/sopa-de-berro",
+                title_en: "Watercress soup",
+                title_es: "Sopa de berro",
+            });
+            nodes.push(Node {
+                nid: 5,
+                url_en: "/en/recipes/victoria-sponge-cake",
+                url_es: "/es/recipes/pastel-victoria",
+                title_en: "Victoria sponge cake",
+                title_es: "Pastel Victoria",
+            });
+            nodes.push(Node {
+                nid: 6,
+                url_en: "/en/recipes/gluten-free-pizza",
+                url_es: "/es/recipes/pizza-sin-gluten",
+                title_en: "Gluten free pizza",
+                title_es: "Pizza sin gluten",
+            });
+            nodes.push(Node {
+                nid: 7,
+                url_en: "/en/recipes/thai-green-curry",
+                url_es: "/es/recipes/curry-verde-tailandes",
+                title_en: "Thai green curry",
+                title_es: "Curry verde tailandés",
+            });
+            nodes.push(Node {
+                nid: 8,
+                url_en: "/en/recipes/crema-catalana",
+                url_es: "/es/recipes/crema-catalana",
+                title_en: "Crema catalana",
+                title_es: "Crema catalana",
+            });
+            nodes.push(Node {
+                nid: 9,
+                url_en: "/en/recipes/fiery-chili-sauce",
+                url_es: "/es/recipes/salsa-de-chile-ardiente",
+                title_en: "Fiery chili sauce",
+                title_es: "Salsa de chile ardiente",
+            });
+        }
+    }
+
+    nodes
+}
+
+/// Returns a vector of all taxonomy terms.
+pub fn get_terms() -> Vec<Term<'static>> {
+    let mut terms: Vec<Term> = Vec::new();
+
+    terms.push(Term {
+        url_en: "/en/recipe-category/accompaniments",
+        url_es: "/es/recipe-category/acompañamientos",
+        title_en: "Accompaniments",
+        title_es: "Acompañamientos",
+    });
+    terms.push(Term {
+        url_en: "/en/recipe-category/desserts",
+        url_es: "/es/recipe-category/postres",
+        title_en: "Desserts",
+        title_es: "Postres",
+    });
+    terms.push(Term {
+        url_en: "/en/recipe-category/main-courses",
+        url_es: "/es/recipe-category/platos-principales",
+        title_en: "Main courses",
+        title_es: "Platos principales",
+    });
+    terms.push(Term {
+        url_en: "/en/recipe-category/snacks",
+        url_es: "/es/recipe-category/tentempiés",
+        title_en: "Snacks",
+        title_es: "Tentempiés",
+    });
+    terms.push(Term {
+        url_en: "/en/recipe-category/starters",
+        url_es: "/es/recipe-category/entrantes",
+        title_en: "Starters",
+        title_es: "Entrantes",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/alcohol-free",
+        url_es: "/es/tags/sin-alcohol",
+        title_en: "Alcohol free",
+        title_es: "Sin alcohol",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/baked",
+        url_es: "/es/tags/horneado",
+        title_en: "Baked",
+        title_es: "Horneado",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/baking",
+        url_es: "/es/tags/cocción",
+        title_en: "Baking",
+        title_es: "Cocción",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/breakfast",
+        url_es: "/es/tags/desayuno",
+        title_en: "Breakfast",
+        title_es: "Desayuno",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/cake",
+        url_es: "/es/tags/pastel",
+        title_en: "Cake",
+        title_es: "Pastel",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/carrots",
+        url_es: "/es/tags/zanahorias",
+        title_en: "Carrots",
+        title_es: "Zanahorias",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/chocolate",
+        url_es: "/es/tags/chocolate",
+        title_en: "Chocolate",
+        title_es: "Chocolate",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/cocktail-party",
+        url_es: "/es/tags/fiesta-de-coctel",
+        title_en: "Cocktail party",
+        title_es: "Fiesta de coctel",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/dairy-free",
+        url_es: "/es/tags/sin-Lactosa",
+        title_en: "Dairy-free",
+        title_es: "Sin Lactosa",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/dessert",
+        url_es: "/es/tags/postre",
+        title_en: "Dessert",
+        title_es: "Postre",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/dinner-party",
+        url_es: "/es/tags/fiesta-de-cena",
+        title_en: "Dinner party",
+        title_es: "Fiesta de cena",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/drinks",
+        url_es: "/es/tags/bebidas",
+        title_en: "Drinks",
+        title_es: "Bebidas",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/egg",
+        url_es: "/es/tags/huevo",
+        title_en: "Egg",
+        title_es: "Huevo",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/grow-your-own",
+        url_es: "/es/tags/cultiva-los-tuyos",
+        title_en: "Grow your own",
+        title_es: "Cultiva los tuyos",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/healthy",
+        url_es: "/es/tags/saludable",
+        title_en: "Healthy",
+        title_es: "Saludable",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/herbs",
+        url_es: "/es/tags/hierbas",
+        title_en: "Herbs",
+        title_es: "Hierbas",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/learn-to-cook",
+        url_es: "/es/tags/aprender-a-cocinar",
+        title_en: "Learn to cook",
+        title_es: "Aprender a cocinar",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/mushrooms",
+        url_es: "/es/tags/champiñones",
+        title_en: "Mushrooms",
+        title_es: "Champiñones",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/oats",
+        url_es: "/es/tags/avena",
+        title_en: "Oats",
+        title_es: "Avena",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/party",
+        url_es: "/es/tags/fiesta",
+        title_en: "Party",
+        title_es: "Fiesta",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/pasta",
+        url_es: "/es/tags/pastas",
+        title_en: "Pasta",
+        title_es: "Pastas",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/pastry",
+        url_es: "/es/tags/repostería",
+        title_en: "Pastry",
+        title_es: "Repostería",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/seasonal",
+        url_es: "/es/tags/estacional",
+        title_en: "Seasonal",
+        title_es: "Estacional",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/shopping",
+        url_es: "/es/tags/compras",
+        title_en: "Shopping",
+        title_es: "Compras",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/soup",
+        url_es: "/es/tags/sopa",
+        title_en: "Soup",
+        title_es: "Sopa",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/supermarkets",
+        url_es: "/es/tags/supermercados",
+        title_en: "Supermarkets",
+        title_es: "Supermercados",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/vegan",
+        url_es: "/es/tags/vegano",
+        title_en: "Vegan",
+        title_es: "Vegano",
+    });
+    terms.push(Term {
+        url_en: "/en/tags/vegetarian",
+        url_es: "/es/tags/vegetariano",
+        title_en: "Vegetarian",
+        title_es: "Vegetariano",
+    });
+
+    terms
+}
+
+/// A valid title on this website starts with "<title>foo", where "foo" is the expected
+/// title text. Returns true if the expected title is set, otherwise returns false.
+pub fn valid_title(html: &str, title: &str) -> bool {
+    html.contains(&("<title>".to_string() + title))
+}
+
+/// Finds all local static elements on the page and loads them asynchronously.
+/// This default profile only has local assets, so we can use simple patterns.
+pub async fn load_static_elements(user: &GooseUser, html: &str) {
+    // Use a regular expression to find all src=<foo> in the HTML, where foo
+    // is the URL to image and js assets.
+    // @TODO: parse HTML5 srcset= also
+    let image = Regex::new(r#"src="(.*?)""#).unwrap();
+    let mut urls = Vec::new();
+    for url in image.captures_iter(&html) {
+        if url[1].starts_with("/sites") || url[1].starts_with("/core") {
+            urls.push(url[1].to_string());
+        }
+    }
+
+    // Use a regular expression to find all href=<foo> in the HTML, where foo
+    // is the URL to css assets.
+    let css = Regex::new(r#"href="(/sites/default/files/css/.*?)""#).unwrap();
+    for url in css.captures_iter(&html) {
+        urls.push(url[1].to_string());
+    }
+
+    // Load all the static assets found on the page.
+    for asset in &urls {
+        let _ = user.get_named(asset, "static asset").await;
+    }
+}
+
+/// Validate the HTML response, confirming the expected title was returned, then load
+/// all static assets found on the page.
+pub async fn validate_and_load_static_assets(
+    user: &GooseUser,
+    mut goose: GooseResponse,
+    title: &str,
+) -> GooseTaskResult {
+    match goose.response {
+        Ok(response) => {
+            // Copy the headers so we have them for logging if there are errors.
+            let headers = &response.headers().clone();
+            match response.text().await {
+                Ok(html) => {
+                    if !valid_title(&html, &title) {
+                        return user.set_failure(
+                            &format!("{}: title not found: {}", goose.request.url, title),
+                            &mut goose.request,
+                            Some(&headers),
+                            Some(&html),
+                        );
+                    }
+
+                    load_static_elements(user, &html).await;
+                }
+                Err(e) => {
+                    return user.set_failure(
+                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &mut goose.request,
+                        Some(&headers),
+                        None,
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            return user.set_failure(
+                &format!("{}: no response from server: {}", goose.request.url, e),
+                &mut goose.request,
+                None,
+                None,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Use regular expression to get the value of a named form element.
+pub fn get_form_value(html: &str, name: &str) -> Option<String> {
+    let re = Regex::new(&format!(r#"name="{}" value=['"](.*?)['"]"#, name)).unwrap();
+    match re.captures(&html) {
+        Some(value) => Some(value[1].to_string()),
+        None => None,
+    }
+}
+
+/// Anonymously load the contact form and POST feedback. The english boolean flag indicates
+/// whether to load the English form or the Spanish form.
+pub async fn anonymous_contact_form(user: &GooseUser, english: bool) -> GooseTaskResult {
+    let contact_form_url = if english {
+        "/en/contact"
+    } else {
+        "/es/contact"
+    };
+    let mut goose = user.get(contact_form_url).await?;
+
+    // We can't invoke common::validate_and_load_static_assets as while it's important
+    // to validate the page and load static elements, we then need to extra form elements
+    // from the HTML of the page. So we duplicate some of the logic, enhancing it for form
+    // processing.
+    let contact_form;
+    match goose.response {
+        Ok(response) => {
+            // Copy the headers so we have them for logging if there are errors.
+            let headers = &response.headers().clone();
+            match response.text().await {
+                Ok(html) => {
+                    // Be sure we've properly loaded the Contact form.
+                    let title = if english {
+                        "Website feedback"
+                    } else {
+                        "Comentarios sobre el sitio web"
+                    };
+                    if !valid_title(&html, title) {
+                        return user.set_failure(
+                            &format!("{}: title not found: {}", goose.request.url, title),
+                            &mut goose.request,
+                            Some(&headers),
+                            Some(&html),
+                        );
+                    }
+
+                    // Load all static elements on the page, as a real user would.
+                    load_static_elements(user, &html).await;
+
+                    // Scrape the HTML to get the values needed in order to POST to the
+                    // contact form.
+                    let form_build_id = get_form_value(&html, "form_build_id");
+                    if form_build_id.is_none() {
+                        return user.set_failure(
+                            &format!("{}: no form_build_id on page", goose.request.url),
+                            &mut goose.request,
+                            Some(&headers),
+                            Some(&html),
+                        );
+                    }
+
+                    // Build contact form parameters.
+                    // @TODO: dynamically generate the content.
+                    let params = [
+                        ("name", "@TODO: name"),
+                        ("mail", "nobody@example.com"),
+                        ("subject[0][value]", "@TODO: subject"),
+                        ("message[0][value]", "@TODO: message"),
+                        ("form_build_id", &form_build_id.unwrap()),
+                        ("form_id", "contact_message_feedback_form"),
+                        ("op", "Send+message"),
+                    ];
+                    let request_builder = user.goose_post(contact_form_url).await?;
+                    contact_form = user.goose_send(request_builder.form(&params), None).await?;
+                }
+                Err(e) => {
+                    return user.set_failure(
+                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &mut goose.request,
+                        Some(&headers),
+                        None,
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            return user.set_failure(
+                &format!("{}: no response from server: {}", goose.request.url, e),
+                &mut goose.request,
+                None,
+                None,
+            );
+        }
+    }
+
+    // Drupal 9 throttles how many times an IP address can submit the contact form, so we
+    // need special handling. We check the response, and issue an info! level message if
+    // the form is throttled. This is a valid event to load test.
+    match contact_form.response {
+        Ok(response) => {
+            // Copy the headers so we have them for logging if there are errors.
+            let headers = &response.headers().clone();
+            match response.text().await {
+                Ok(html) => {
+                    // If the contact form succeeded, we were redirected to the home page.
+                    let error_text = if english {
+                        "You cannot send more than"
+                    } else {
+                        "No le está permitido enviar más"
+                    };
+                    if html.contains(error_text) {
+                        info!(
+                            "post to contact form was throttled: {}",
+                            contact_form.request.url
+                        );
+                    }
+
+                    // Either way, a "real" user would still load all static elements on
+                    // the returned page.
+                    load_static_elements(user, &html).await;
+                }
+                Err(e) => {
+                    return user.set_failure(
+                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &mut goose.request,
+                        Some(&headers),
+                        None,
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            return user.set_failure(
+                &format!("{}: no response from server: {}", goose.request.url, e),
+                &mut goose.request,
+                None,
+                None,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Load the search page and perform a search using one word from one of the node titles
+/// on the site.
+pub async fn search(user: &GooseUser, english: bool) -> GooseTaskResult {
+    let search_form_url = if english {
+        "/en/search/node"
+    } else {
+        "/es/search/node"
+    };
+    let mut goose = user.get(search_form_url).await?;
+
+    // We can't invoke common::validate_and_load_static_assets as while it's important
+    // to validate the page and load static elements, we then need to extra form elements
+    // from the HTML of the page. So we duplicate some of the logic, enhancing it for form
+    // processing.
+    let search_word;
+    let mut search_form;
+    match goose.response {
+        Ok(response) => {
+            // Copy the headers so we have them for logging if there are errors.
+            let headers = &response.headers().clone();
+            match response.text().await {
+                Ok(html) => {
+                    // Be sure we've properly loaded the Search page.
+                    let title = if english { "Search" } else { "Buscar" };
+                    if !valid_title(&html, title) {
+                        return user.set_failure(
+                            &format!("{}: title not found: {}", goose.request.url, title),
+                            &mut goose.request,
+                            Some(&headers),
+                            Some(&html),
+                        );
+                    }
+
+                    // Load all static elements on the page, as a real user would.
+                    load_static_elements(user, &html).await;
+
+                    // Scrape the HTML to get the values needed in order to POST to the
+                    // search form.
+                    let form_build_id = get_form_value(&html, "form_build_id");
+                    if form_build_id.is_none() {
+                        return user.set_failure(
+                            &format!("{}: no form_build_id on page", goose.request.url),
+                            &mut goose.request,
+                            Some(&headers),
+                            Some(&html),
+                        );
+                    }
+
+                    // Randomly select a content type, favoring articles and recipes.
+                    let content_types = vec![
+                        ContentType::Article,
+                        ContentType::Article,
+                        ContentType::Article,
+                        ContentType::BasicPage,
+                        ContentType::Recipe,
+                        ContentType::Recipe,
+                        ContentType::Recipe,
+                    ];
+                    let content_type = content_types.choose(&mut rand::thread_rng());
+                    // Then randomly select a node of this content type.
+                    let nodes = get_nodes(&content_type.unwrap());
+                    let page = nodes.choose(&mut rand::thread_rng());
+                    // Finally randomly select a word from the title to use in our search.
+                    let title = if english {
+                        page.unwrap().title_en
+                    } else {
+                        page.unwrap().title_es
+                    };
+                    let words = title.split_whitespace();
+                    let word = words.choose(&mut rand::thread_rng());
+                    // Save a copy of the word so we can validate the results later.
+                    search_word = word.unwrap().to_string();
+
+                    // Build search form with random word from title.
+                    let params = [
+                        ("keys", search_word.as_str()),
+                        ("form_build_id", &form_build_id.unwrap()),
+                        ("form_id", "search_form"),
+                        ("op", "Search"),
+                    ];
+                    let request_builder = user.goose_post(search_form_url).await?;
+                    search_form = user.goose_send(request_builder.form(&params), None).await?;
+
+                    // A successful search is redirected.
+                    if !search_form.request.redirected {
+                        return user.set_failure(
+                            &format!("{}: search didn't redirect", search_form.request.final_url),
+                            &mut search_form.request,
+                            Some(&headers),
+                            None,
+                        );
+                    }
+                }
+                Err(e) => {
+                    return user.set_failure(
+                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &mut goose.request,
+                        Some(&headers),
+                        None,
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            return user.set_failure(
+                &format!("{}: no response from server: {}", goose.request.url, e),
+                &mut goose.request,
+                None,
+                None,
+            );
+        }
+    }
+
+    match search_form.response {
+        Ok(response) => {
+            // Copy the headers so we have them for logging if there are errors.
+            let headers = &response.headers().clone();
+            match response.text().await {
+                Ok(html) => {
+                    if !html.contains(&search_word) {
+                        return user.set_failure(
+                            &format!(
+                                "{}: search term ({}) not on page",
+                                goose.request.url, &search_word
+                            ),
+                            &mut goose.request,
+                            Some(&headers),
+                            Some(&html),
+                        );
+                    }
+                    load_static_elements(user, &html).await;
+
+                    // @TODO: get all href="" inside class="search-result__title" and load random node
+                }
+                Err(e) => {
+                    return user.set_failure(
+                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &mut goose.request,
+                        Some(&headers),
+                        None,
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            return user.set_failure(
+                &format!("{}: no response from server: {}", goose.request.url, e),
+                &mut goose.request,
+                None,
+                None,
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/examples/umami/english.rs
+++ b/examples/umami/english.rs
@@ -1,0 +1,104 @@
+use goose::prelude::*;
+
+use crate::common;
+
+use rand::seq::SliceRandom;
+
+/// Load the front page in English and all static assets found on the page.
+pub async fn front_page_en(user: &GooseUser) -> GooseTaskResult {
+    let goose = user.get("/").await?;
+    common::validate_and_load_static_assets(user, goose, "Home").await?;
+
+    Ok(())
+}
+
+/// Load recipe listing in English and all static assets found on the page.
+pub async fn recipe_listing_en(user: &GooseUser) -> GooseTaskResult {
+    let goose = user.get("/en/recipes/").await?;
+    common::validate_and_load_static_assets(user, goose, "Recipes").await?;
+
+    Ok(())
+}
+
+/// Load a random recipe in English and all static assets found on the page.
+pub async fn recipe_en(user: &GooseUser) -> GooseTaskResult {
+    let nodes = common::get_nodes(&common::ContentType::Recipe);
+    let recipe = nodes.choose(&mut rand::thread_rng());
+    let goose = user.get(recipe.unwrap().url_en).await?;
+    common::validate_and_load_static_assets(user, goose, recipe.unwrap().title_en).await?;
+
+    Ok(())
+}
+
+/// Load article listing in English and all static assets found on the page.
+pub async fn article_listing_en(user: &GooseUser) -> GooseTaskResult {
+    let goose = user.get("/en/articles/").await?;
+    common::validate_and_load_static_assets(user, goose, "Articles").await?;
+
+    Ok(())
+}
+
+/// Load a random article in English and all static assets found on the page.
+pub async fn article_en(user: &GooseUser) -> GooseTaskResult {
+    let nodes = common::get_nodes(&common::ContentType::Article);
+    let article = nodes.choose(&mut rand::thread_rng());
+    let goose = user.get(article.unwrap().url_en).await?;
+    common::validate_and_load_static_assets(user, goose, article.unwrap().title_en).await?;
+
+    Ok(())
+}
+
+/// Load a random basic page in English and all static assets found on the page.
+pub async fn basic_page_en(user: &GooseUser) -> GooseTaskResult {
+    let nodes = common::get_nodes(&common::ContentType::BasicPage);
+    let page = nodes.choose(&mut rand::thread_rng());
+    let goose = user.get(page.unwrap().url_en).await?;
+    common::validate_and_load_static_assets(user, goose, page.unwrap().title_en).await?;
+
+    Ok(())
+}
+
+/// Load a random node by nid in English and all static assets found on the page.
+pub async fn page_by_nid(user: &GooseUser) -> GooseTaskResult {
+    // Randomly select a content type.
+    let content_types = vec![
+        common::ContentType::Article,
+        common::ContentType::BasicPage,
+        common::ContentType::Recipe,
+    ];
+    let content_type = content_types.choose(&mut rand::thread_rng());
+    // Then randomly select a node of this content type.
+    let nodes = common::get_nodes(&content_type.unwrap());
+    let page = nodes.choose(&mut rand::thread_rng());
+    // Load the page by nid instead of by URL.
+    let goose = user
+        .get(&("/node/".to_string() + &page.unwrap().nid.to_string()))
+        .await?;
+    common::validate_and_load_static_assets(user, goose, page.unwrap().title_en).await?;
+
+    Ok(())
+}
+
+/// Anonymously load the contact form in English and POST feedback.
+pub async fn anonymous_contact_form_en(user: &GooseUser) -> GooseTaskResult {
+    common::anonymous_contact_form(user, true).await?;
+
+    Ok(())
+}
+
+// Pick a random word from the title of a random node and perform a search in English.
+pub async fn search_en(user: &GooseUser) -> GooseTaskResult {
+    common::search(user, true).await?;
+
+    Ok(())
+}
+
+/// Load category listing by a random term in English and all static assets found on the page.
+pub async fn term_listing_en(user: &GooseUser) -> GooseTaskResult {
+    let terms = common::get_terms();
+    let term = terms.choose(&mut rand::thread_rng());
+    let goose = user.get(term.unwrap().url_en).await?;
+    common::validate_and_load_static_assets(user, goose, term.unwrap().title_en).await?;
+
+    Ok(())
+}

--- a/examples/umami/main.rs
+++ b/examples/umami/main.rs
@@ -1,0 +1,71 @@
+mod common;
+mod english;
+mod spanish;
+
+use goose::prelude::*;
+
+use crate::english::*;
+use crate::spanish::*;
+
+/// Defines the actual load test. Each task set simulates a type of user.
+///  - Anonymous English user: loads the English version of all pages
+///  - Anonymous Spanish user: loads the Spanish version of all pages
+fn main() -> Result<(), GooseError> {
+    let _goose_metrics = GooseAttack::initialize()?
+        .register_taskset(
+            taskset!("Anonymous English user")
+                .set_weight(6)?
+                .register_task(task!(front_page_en).set_name("anon /").set_weight(2)?)
+                .register_task(task!(basic_page_en).set_name("anon /en/basicpage"))
+                .register_task(task!(article_listing_en).set_name("anon /en/articles/"))
+                .register_task(
+                    task!(article_en)
+                        .set_name("anon /en/articles/%")
+                        .set_weight(2)?,
+                )
+                .register_task(task!(recipe_listing_en).set_name("anon /en/recipes/"))
+                .register_task(
+                    task!(recipe_en)
+                        .set_name("anon /en/recipes/%")
+                        .set_weight(4)?,
+                )
+                .register_task(task!(page_by_nid).set_name("anon /node/%nid"))
+                .register_task(
+                    task!(term_listing_en)
+                        .set_name("anon /en term")
+                        .set_weight(2)?,
+                )
+                .register_task(task!(search_en).set_name("anon /en/search"))
+                .register_task(task!(anonymous_contact_form_en).set_name("anon /en/contact")),
+        )
+        .register_taskset(
+            taskset!("Anonymous Spanish user")
+                .set_weight(2)?
+                .register_task(task!(front_page_es).set_name("anon /es/").set_weight(2)?)
+                .register_task(task!(basic_page_es).set_name("anon /es/basicpage"))
+                .register_task(task!(article_listing_es).set_name("anon /es/articles/"))
+                .register_task(
+                    task!(article_es)
+                        .set_name("anon /es/articles/%")
+                        .set_weight(2)?,
+                )
+                .register_task(task!(recipe_listing_es).set_name("anon /es/recipes/"))
+                .register_task(
+                    task!(recipe_es)
+                        .set_name("anon /es/recipes/%")
+                        .set_weight(4)?,
+                )
+                .register_task(
+                    task!(term_listing_es)
+                        .set_name("anon /es term")
+                        .set_weight(2)?,
+                )
+                .register_task(task!(search_es).set_name("anon /es/search"))
+                .register_task(task!(anonymous_contact_form_es).set_name("anon /es/contact")),
+        )
+        .set_default(GooseDefault::Host, "https://drupal-9.0.7.ddev.site/")?
+        .execute()?
+        .print();
+
+    Ok(())
+}

--- a/examples/umami/spanish.rs
+++ b/examples/umami/spanish.rs
@@ -1,0 +1,83 @@
+use goose::prelude::*;
+
+use crate::common;
+
+use rand::seq::SliceRandom;
+
+/// Load the front page in Spanish and all static assets found on the page.
+pub async fn front_page_es(user: &GooseUser) -> GooseTaskResult {
+    let goose = user.get("/es").await?;
+    common::validate_and_load_static_assets(user, goose, "Inicio").await?;
+
+    Ok(())
+}
+
+/// Load article listing in Spanish and all static assets found on the page.
+pub async fn recipe_listing_es(user: &GooseUser) -> GooseTaskResult {
+    let goose = user.get("/es/recipes/").await?;
+    common::validate_and_load_static_assets(user, goose, "Recetas").await?;
+
+    Ok(())
+}
+
+/// Load a random recipe in Spanish and all static assets found on the page.
+pub async fn recipe_es(user: &GooseUser) -> GooseTaskResult {
+    let nodes = common::get_nodes(&common::ContentType::Recipe);
+    let recipe = nodes.choose(&mut rand::thread_rng());
+    let goose = user.get(recipe.unwrap().url_es).await?;
+    common::validate_and_load_static_assets(user, goose, recipe.unwrap().title_es).await?;
+
+    Ok(())
+}
+
+/// Load article listing in Spanish and all static assets found on the page.
+pub async fn article_listing_es(user: &GooseUser) -> GooseTaskResult {
+    let goose = user.get("/es/articles/").await?;
+    common::validate_and_load_static_assets(user, goose, "Artículos").await?;
+
+    Ok(())
+}
+
+/// Load a random article in Spanish and all static assets found on the page.
+pub async fn article_es(user: &GooseUser) -> GooseTaskResult {
+    let nodes = common::get_nodes(&common::ContentType::Article);
+    let article = nodes.choose(&mut rand::thread_rng());
+    let goose = user.get(article.unwrap().url_es).await?;
+    common::validate_and_load_static_assets(user, goose, article.unwrap().title_es).await?;
+
+    Ok(())
+}
+
+/// Load a basic page in Spanish and all static assets found on the page.
+pub async fn basic_page_es(user: &GooseUser) -> GooseTaskResult {
+    let nodes = common::get_nodes(&common::ContentType::BasicPage);
+    let page = nodes.choose(&mut rand::thread_rng());
+    let goose = user.get(page.unwrap().url_es).await?;
+    common::validate_and_load_static_assets(user, goose, page.unwrap().title_es).await?;
+
+    Ok(())
+}
+
+/// Anonymously load the contact form in Spanish and POST feedback.
+pub async fn anonymous_contact_form_es(user: &GooseUser) -> GooseTaskResult {
+    common::anonymous_contact_form(user, false).await?;
+
+    Ok(())
+}
+
+// Pick a random word from the title of a random node and perform a search in Spanish.
+pub async fn search_es(user: &GooseUser) -> GooseTaskResult {
+    common::search(user, false).await?;
+
+    Ok(())
+}
+
+/// Load category listing by a random term in Spanish and all static assets found on the page.
+pub async fn term_listing_es(user: &GooseUser) -> GooseTaskResult {
+    let terms = common::get_terms();
+    let term = terms.choose(&mut rand::thread_rng());
+    let goose = user.get(term.unwrap().url_es).await?;
+    common::validate_and_load_static_assets(user, goose, term.unwrap().title_es).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
 - Introduces a new, more complicated example
 - Performs a load test of Drupal 9's Umami demo install profile

# Overview

This is a load test for Drupal's Umami Profile, which is included as part of Drupal 9 core. In order to use this load test, you must first install the Umami Profile as documented here:
https://www.drupal.org/docs/umami-drupal-demonstration-installation-profile

The load test was developed using a locally hosted Drupal 9 install hosted in a DDEV container:
https://www.ddev.com/

By default it will try and load pages from https://drupal-9.0.7.ddev.site/.

## Load Test Implementation

The load test is split into the following files:
 - `main.rs`: This file contains the main() function and defines the actual load test;
 - `common.rs`: This file contains helper functions used by the task functions;
 - `english.rs`: This files contains all task functions loading pages in English;
 - `spanish.rs`: This files contains all task functions loading pages in Spanish.

## Load Test Features

The load test defines the following users:
 - Anonymous English user: this user performs all tasks in English, it runs 3 times as often as the Spanish user;
 - Anonymous Spanish user: this user performs all tasks in Spanish, it runs 1/3 as often as the English user.

Each load test user runs the following tasks in their own language, and also loads all static elements on any pages loaded:
 - Loads the front page;
 - Loads a "basic page";
 - Loads the article listing page;
 - Loads an "article";
 - Loads the recipe listing page;
 - Loads a "recipe";
 - Loads a random node by nid;
 - Loads the term listing page filtered by a random term;
 - Performs a search using a random word from a random node's title;
 - Submits website feedback through the contact form;
