### PR TITLE
replace TermLogger with SimpleLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.4-dev
  - add new `examples/umami` for load testing Drupal 9 demo install profile
+ - replace TermLogger with SimpleLogger for increased logging flexibility
 
 ## 0.10.3 Oct 14, 2020
  - fixup sticky redirect tests to properly test functionality

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ reqwest = { version = "0.10",  default-features = false, features = ["cookies", 
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"
-simplelog = "0.7"
+simplelog = "0.8"
 tokio = { version = "0.2.20", features = ["fs", "io-util", "macros", "rt-core", "sync", "time"] }
 url = "2.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,13 +814,7 @@ impl GooseAttack {
 
         if let Some(log_to_file) = log_file {
             match CombinedLogger::init(vec![
-                match TermLogger::new(debug_level, Config::default(), TerminalMode::Mixed) {
-                    Some(t) => t,
-                    None => {
-                        eprintln!("failed to initialize TermLogger");
-                        return;
-                    }
-                },
+                SimpleLogger::new(debug_level, Config::default()),
                 WriteLogger::new(
                     log_level,
                     Config::default(),
@@ -834,17 +828,7 @@ impl GooseAttack {
             }
             info!("Writing to log file: {}", log_to_file.display());
         } else {
-            match CombinedLogger::init(vec![match TermLogger::new(
-                debug_level,
-                Config::default(),
-                TerminalMode::Mixed,
-            ) {
-                Some(t) => t,
-                None => {
-                    eprintln!("failed to initialize TermLogger");
-                    return;
-                }
-            }]) {
+            match CombinedLogger::init(vec![SimpleLogger::new(debug_level, Config::default())]) {
                 Ok(_) => (),
                 Err(e) => {
                     info!("failed to initialize CombinedLogger: {}", e);


### PR DESCRIPTION
We have no specific need to use `TermLogger`, and can instead always use `SimpleLogger`. We lose terminal coloring, but afaik that's not an important feature. This also seems to resolve the issues around double-initializing the logger. Attempts to initialize the logger twice result in a friendly INFO log and the process continues without errors:

```
07:13:24 [ INFO] failed to initialize CombinedLogger: attempted to set a logger after the logging system was already initialized
```

 - replace TermLogger with SimpleLogger so Goose can be run with or without a TTY
 - fixes #202 
 - fixes #122 