### PR TITLE
Upgrade to Tokio 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.8-dev
  - introduce `--report-file` (and `GooseDefault::ReportFile`) to optionally generate an HTML report when the load test completes
+ - upgrade to `tokio` 1.x, and switch to `flume` for all multi-producer, multi-consumer channels
 
 ## 0.10.7 Nov 16, 2020
  - account for time spent doing things other than sleeping, maintaining more consistency when displaying statistics and shutting down

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ num_cpus = "1.0"
 num-format = "0.4"
 rand = "0.7"
 regex = "1"
-reqwest = { version = "0.10",  default-features = false, features = ["cookies", "json"] }
+reqwest = { version = "0.11",  default-features = false, features = ["cookies", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"
 simplelog = "0.8"
-tokio = { version = "0.3", features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.0", features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
 url = "2.1"
 
 # optional dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"
 simplelog = "0.8"
-tokio = { version = "0.2.20", features = ["fs", "io-util", "macros", "rt-core", "sync", "time"] }
+tokio = { version = "0.3", features = ["fs", "io-util", "macros", "rt", "sync", "time"] }
 url = "2.1"
 
 # optional dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "Apache-2.0"
 [dependencies]
 chrono = "0.4"
 ctrlc = "3.1"
+flume = "0.10"
 futures = "0.3"
 gumdrop = "0.8"
 http = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"
 simplelog = "0.8"
-tokio = { version = "1.0", features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "rt-multi-thread", "time"] }
 url = "2.1"
 
 # optional dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"
 simplelog = "0.8"
-tokio = { version = "0.3", features = ["fs", "io-util", "macros", "rt", "sync", "time"] }
+tokio = { version = "0.3", features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
 url = "2.1"
 
 # optional dependencies

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -293,7 +293,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::atomic::{self, AtomicUsize};
 use std::sync::Arc;
 use std::{future::Future, pin::Pin, time::Instant};
-use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock};
 use url::Url;
 
 use crate::metrics::GooseMetric;
@@ -334,11 +334,10 @@ pub enum GooseTaskError {
     /// `.raw_request`.
     RequestFailed { raw_request: GooseRawRequest },
     /// The request was canceled (this happens when the throttle is enabled and
-    /// the load test finished). The mpsc SendError can be found in `.source`.
-    /// A `GooseRawRequest` has not yet been constructed, so is not available in
-    /// this error.
+    /// the load test finished). A `GooseRawRequest` has not yet been constructed,
+    // so is not available in this error.
     RequestCanceled {
-        source: mpsc::error::SendError<bool>,
+        source: flume::SendError<bool>,
     },
     /// There was an error sending the metrics for a request to the parent thread.
     /// The `GooseRawRequest` that was not recorded can be extracted from the error
@@ -351,7 +350,7 @@ pub enum GooseTaskError {
     /// `GooseDebug` that was not logged can be extracted from the error chain,
     /// available inside `.source`.
     LoggerFailed {
-        source: mpsc::error::SendError<Option<GooseDebug>>,
+        source: flume::SendError<Option<GooseDebug>>,
     },
     /// Attempted an unrecognized HTTP request method. The unrecognized method
     /// is available in `.method`.
@@ -426,10 +425,10 @@ impl From<url::ParseError> for GooseTaskError {
 }
 
 /// When the throttle is enabled and the load test ends, the throttle channel is
-/// shut down. This causes mpsc SendError, which gets automatically converted to
-/// `RequestCanceled`.
-impl From<mpsc::error::SendError<bool>> for GooseTaskError {
-    fn from(source: mpsc::error::SendError<bool>) -> GooseTaskError {
+/// shut down. This causes a SendError, which gets automatically converted to
+// `RequestCanceled`.
+impl From<flume::SendError<bool>> for GooseTaskError {
+    fn from(source: flume::SendError<bool>) -> GooseTaskError {
         GooseTaskError::RequestCanceled { source }
     }
 }
@@ -442,8 +441,8 @@ impl From<flume::SendError<GooseMetric>> for GooseTaskError {
 }
 
 /// Attempt to send logs to the logger thread failed.
-impl From<mpsc::error::SendError<Option<GooseDebug>>> for GooseTaskError {
-    fn from(source: mpsc::error::SendError<Option<GooseDebug>>) -> GooseTaskError {
+impl From<flume::SendError<Option<GooseDebug>>> for GooseTaskError {
+    fn from(source: flume::SendError<Option<GooseDebug>>) -> GooseTaskError {
         GooseTaskError::LoggerFailed { source }
     }
 }
@@ -908,9 +907,9 @@ pub struct GooseUser {
     /// A local copy of the global GooseConfiguration.
     pub config: GooseConfiguration,
     /// Channel to logger.
-    pub debug_logger: Option<mpsc::UnboundedSender<Option<GooseDebug>>>,
+    pub debug_logger: Option<flume::Sender<Option<GooseDebug>>>,
     /// Channel to throttle.
-    pub throttle: Option<mpsc::Sender<bool>>,
+    pub throttle: Option<flume::Sender<bool>>,
     /// Normal tasks are optionally throttled, test_start and test_stop tasks are not.
     pub is_throttled: bool,
     /// Channel to parent.
@@ -1424,9 +1423,9 @@ impl GooseUser {
     /// metrics.
     ///
     /// Calls to `user.goose_send()` returns a `Result` containing a `GooseResponse` on success,
-    /// and a `tokio::sync::mpsc::error::SendError<bool>` on failure. Failure only happens when
-    /// `--throttle-requests` is enabled and the load test completes. The `GooseResponse` object
-    // contains a copy of the request made
+    /// and a `flume::SendError<bool>` on failure. Failure only happens when `--throttle-requests`
+    /// is enabled and the load test completes. The `GooseResponse` object contains a copy of the
+    /// request made
     /// ([`goose.request`](https://docs.rs/goose/*/goose/goose/struct.GooseRawRequest)), and the
     /// Reqwest response ([`goose.response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
     ///
@@ -1457,7 +1456,7 @@ impl GooseUser {
             // ...wait until there's room to add a token to the throttle channel before proceeding.
             debug!("GooseUser: waiting on throttle");
             // Will result in GooseTaskError::RequestCanceled if this fails.
-            self.throttle.clone().unwrap().send(true).await?;
+            self.throttle.clone().unwrap().send_async(true).await?;
         };
 
         let started = Instant::now();

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -344,7 +344,7 @@ pub enum GooseTaskError {
     /// The `GooseRawRequest` that was not recorded can be extracted from the error
     /// chain, available inside `.source`.
     MetricsFailed {
-        source: mpsc::error::SendError<GooseMetric>,
+        source: flume::SendError<GooseMetric>,
     },
     /// Attempt to send debug detail to logger failed.
     /// There was an error sending debug information to the logger thread. The
@@ -435,8 +435,8 @@ impl From<mpsc::error::SendError<bool>> for GooseTaskError {
 }
 
 /// Attempt to send metrics to the parent thread failed.
-impl From<mpsc::error::SendError<GooseMetric>> for GooseTaskError {
-    fn from(source: mpsc::error::SendError<GooseMetric>) -> GooseTaskError {
+impl From<flume::SendError<GooseMetric>> for GooseTaskError {
+    fn from(source: flume::SendError<GooseMetric>) -> GooseTaskError {
         GooseTaskError::MetricsFailed { source }
     }
 }
@@ -914,7 +914,7 @@ pub struct GooseUser {
     /// Normal tasks are optionally throttled, test_start and test_stop tasks are not.
     pub is_throttled: bool,
     /// Channel to parent.
-    pub channel_to_parent: Option<mpsc::UnboundedSender<GooseMetric>>,
+    pub channel_to_parent: Option<flume::Sender<GooseMetric>>,
     /// An index into the internal `GooseTest.weighted_users, indicating which weighted GooseTaskSet is running.
     pub weighted_users_index: usize,
     /// A weighted list of all tasks that run when the user first starts.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -336,9 +336,7 @@ pub enum GooseTaskError {
     /// The request was canceled (this happens when the throttle is enabled and
     /// the load test finished). A `GooseRawRequest` has not yet been constructed,
     // so is not available in this error.
-    RequestCanceled {
-        source: flume::SendError<bool>,
-    },
+    RequestCanceled { source: flume::SendError<bool> },
     /// There was an error sending the metrics for a request to the parent thread.
     /// The `GooseRawRequest` that was not recorded can be extracted from the error
     /// chain, available inside `.source`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2399,7 +2399,7 @@ impl GooseAttack {
             "".to_string()
         };
         // If the logger isn't configured, return immediately.
-        if self.configuration.debug_file == "" {
+        if self.configuration.debug_file.is_empty() {
             return Ok((None, None));
         }
 
@@ -2760,10 +2760,7 @@ impl GooseAttack {
         } else {
             // If displaying running metrics, be sure we wake up often enough to
             // display them at the configured rate.
-            let running_metrics = match self.configuration.running_metrics {
-                Some(r) => r,
-                None => 0,
-            };
+            let running_metrics = self.configuration.running_metrics.unwrap_or(0);
 
             // Otherwise, sleep until the next time something needs to happen.
             let sleep_duration = if running_metrics > 0
@@ -3343,7 +3340,7 @@ impl GooseAttack {
                 });
             };
             // Be sure the file flushes to disk.
-            report_file.flush();
+            report_file.flush().await?;
 
             info!(
                 "wrote html report file to: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3398,7 +3398,7 @@ impl GooseAttack {
 
         while message.is_some() {
             received_message = true;
-            // @TODO: why double unwrap? @FIXME
+            // Double unwrap because now_or_never() adds an extra some().
             match message.unwrap().unwrap() {
                 GooseMetric::Request(raw_request) => {
                     // Options should appear above, search for formatted_log.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,6 +438,7 @@ use std::{fmt, io, time};
 use tokio::fs::File;
 use tokio::io::BufWriter;
 use tokio::prelude::*;
+use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 use url::Url;
 
@@ -2298,7 +2299,7 @@ impl GooseAttack {
         if self.attack_mode == AttackMode::Manager {
             #[cfg(feature = "gaggle")]
             {
-                let mut rt = tokio::runtime::Runtime::new().unwrap();
+                let rt = Runtime::new().unwrap();
                 self = rt.block_on(manager::manager_main(self));
             }
 
@@ -2313,7 +2314,7 @@ impl GooseAttack {
         else if self.attack_mode == AttackMode::Worker {
             #[cfg(feature = "gaggle")]
             {
-                let mut rt = tokio::runtime::Runtime::new().unwrap();
+                let rt = Runtime::new().unwrap();
                 self = rt.block_on(worker::worker_main(&self));
             }
 
@@ -2327,7 +2328,7 @@ impl GooseAttack {
         }
         // Start goose in single-process mode.
         else {
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
+            let rt = Runtime::new().unwrap();
             self = rt.block_on(self.start_attack(None))?;
         }
 
@@ -2446,7 +2447,7 @@ impl GooseAttack {
             throttle_rx,
         )));
 
-        let mut sender = all_threads_throttle.clone();
+        let sender = all_threads_throttle.clone();
         // We start from 1 instead of 0 to intentionally fill all but one slot in the
         // channel to avoid a burst of traffic during startup. The channel then provides
         // an implementation of the leaky bucket algorithm as a queue. Requests have to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2430,8 +2430,10 @@ impl GooseAttack {
 
         // Create a bounded channel allowing single-sender multi-receiver to throttle
         // GooseUser threads.
-        let (all_threads_throttle, throttle_receiver): (flume::Sender<bool>, flume::Receiver<bool>) =
-            flume::bounded(self.configuration.throttle_requests);
+        let (all_threads_throttle, throttle_receiver): (
+            flume::Sender<bool>,
+            flume::Receiver<bool>,
+        ) = flume::bounded(self.configuration.throttle_requests);
 
         // Create a channel allowing the parent to inform the throttle thread when the
         // load test is finished. Even though we only send one message, we can't use a

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -82,11 +82,12 @@
 //! will still record any custom messages, details about the request (when available), and all
 //! server response headers (when available).
 
+use futures::FutureExt;
 use serde_json::json;
 use tokio::fs::File;
 use tokio::io::BufWriter;
-use tokio::prelude::*;
 use tokio::sync::mpsc;
+use tokio::io::AsyncWriteExt;
 
 use crate::goose::GooseDebug;
 use crate::GooseConfiguration;
@@ -125,7 +126,7 @@ pub async fn logger_main(
     }
 
     // Loop waiting for and writing error logs from GooseUser threads.
-    while let Some(message) = log_receiver.recv().await {
+    while let Some(message) = log_receiver.recv().now_or_never() {
         if let Some(goose_debug) = message {
             // All Options are defined above, search for formatted_log.
             if let Some(file) = debug_file.as_mut() {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -82,7 +82,6 @@
 //! will still record any custom messages, details about the request (when available), and all
 //! server response headers (when available).
 
-use futures::FutureExt;
 use serde_json::json;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
@@ -126,7 +125,7 @@ pub async fn logger_main(
     }
 
     // Loop waiting for and writing error logs from GooseUser threads.
-    while let Some(message) = log_receiver.recv().now_or_never() {
+    while let Some(message) = log_receiver.recv().await {
         if let Some(goose_debug) = message {
             // All Options are defined above, search for formatted_log.
             if let Some(file) = debug_file.as_mut() {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -86,7 +86,6 @@ use serde_json::json;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufWriter;
-use tokio::sync::mpsc;
 
 use crate::goose::GooseDebug;
 use crate::GooseConfiguration;
@@ -95,7 +94,7 @@ use crate::GooseConfiguration;
 /// GooseUser threads. This function is not intended to be invoked manually.
 pub async fn logger_main(
     configuration: GooseConfiguration,
-    mut log_receiver: mpsc::UnboundedReceiver<Option<GooseDebug>>,
+    log_receiver: flume::Receiver<Option<GooseDebug>>,
 ) {
     // Determine if a debug file has been configured.
     let mut debug_file_path: Option<String> = None;
@@ -125,7 +124,7 @@ pub async fn logger_main(
     }
 
     // Loop waiting for and writing error logs from GooseUser threads.
-    while let Some(message) = log_receiver.recv().await {
+    while let Ok(message) = log_receiver.recv_async().await {
         if let Some(goose_debug) = message {
             // All Options are defined above, search for formatted_log.
             if let Some(file) = debug_file.as_mut() {

--- a/src/user.rs
+++ b/src/user.rs
@@ -132,7 +132,7 @@ pub async fn user_main(
                     "user {} from {} sleeping {:?} second...",
                     thread_number, thread_task_set.name, sleep_duration
                 );
-                tokio::time::delay_for(sleep_duration).await;
+                tokio::time::sleep(sleep_duration).await;
                 slept += 1;
                 if slept > wait_time {
                     in_sleep_loop = false;

--- a/src/user.rs
+++ b/src/user.rs
@@ -115,7 +115,7 @@ pub async fn user_main(
         while in_sleep_loop {
             let mut message = thread_receiver.recv().now_or_never();
             while message.is_some() {
-                // @TODO: Why a double unwrap()? @FIXME
+                // Double unwrap because now_or_never() adds an extra some().
                 match message.unwrap().unwrap() {
                     // Time to exit.
                     GooseUserCommand::EXIT => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -52,8 +52,8 @@ pub async fn sleep_minus_drift(
     drift: tokio::time::Instant,
 ) -> tokio::time::Instant {
     match duration.checked_sub(drift.elapsed()) {
-        Some(delay) if delay.as_nanos() > 0 => tokio::time::delay_for(delay).await,
-        _ => info!("sleep_minus_drift: drift was greater than or equal to duration, not sleeping"),
+        Some(delay) if delay.as_nanos() > 0 => tokio::time::sleep(delay).await,
+        _ => warn!("sleep_minus_drift: drift was greater than or equal to duration, not sleeping"),
     };
     tokio::time::Instant::now()
 }

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -1,7 +1,7 @@
 use httpmock::Method::GET;
 use httpmock::{Mock, MockRef, MockServer};
 use serial_test::serial;
-use tokio::time::{delay_for, Duration};
+use tokio::time::{sleep, Duration};
 
 mod common;
 
@@ -33,7 +33,7 @@ pub async fn one_with_delay(user: &GooseUser) -> GooseTaskResult {
     // "Run out the clock" on the load test when this function runs. Sleep for
     // the total duration the test is to run plus 1 second to be sure no
     // additional tasks will run after this one.
-    delay_for(Duration::from_secs(RUN_TIME as u64 + 1)).await;
+    sleep(Duration::from_secs(RUN_TIME as u64 + 1)).await;
 
     Ok(())
 }
@@ -45,7 +45,7 @@ pub async fn two_with_delay(user: &GooseUser) -> GooseTaskResult {
     // "Run out the clock" on the load test when this function runs. Sleep for
     // the total duration the test is to run plus 1 second to be sure no
     // additional tasks will run after this one.
-    delay_for(Duration::from_secs(RUN_TIME as u64 + 1)).await;
+    sleep(Duration::from_secs(RUN_TIME as u64 + 1)).await;
 
     Ok(())
 }

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -1,7 +1,7 @@
 use httpmock::Method::GET;
 use httpmock::{Mock, MockRef, MockServer};
 use serial_test::serial;
-use tokio::time::{delay_for, Duration};
+use tokio::time::{sleep, Duration};
 
 mod common;
 
@@ -50,7 +50,7 @@ pub async fn two_with_delay(user: &GooseUser) -> GooseTaskResult {
     // "Run out the clock" on the load test when this function runs. Sleep for
     // the total duration the test is to run plus 1 second to be sure no
     // additional tasks will run after this one.
-    delay_for(Duration::from_secs(RUN_TIME as u64 + 1)).await;
+    sleep(Duration::from_secs(RUN_TIME as u64 + 1)).await;
 
     Ok(())
 }

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -285,7 +285,12 @@ fn test_throttle_gaggle() {
 
     // Confirm that the load test was actually throttled.
     // Throttle is configured per-worker, so multiply by EXPECT_WORKERS.
-    let test1_lines = validate_test(&mock_endpoints, &requests_files, THROTTLE_REQUESTS * EXPECT_WORKERS, None);
+    let test1_lines = validate_test(
+        &mock_endpoints,
+        &requests_files,
+        THROTTLE_REQUESTS * EXPECT_WORKERS,
+        None,
+    );
 
     // Increase the throttle and run a second load test, so we can compare the difference
     // and confirm the throttle is actually working.

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -284,7 +284,8 @@ fn test_throttle_gaggle() {
     common::run_load_test(manager_goose_attack, Some(worker_handles));
 
     // Confirm that the load test was actually throttled.
-    let test1_lines = validate_test(&mock_endpoints, &requests_files, THROTTLE_REQUESTS, None);
+    // Throttle is configured per-worker, so multiply by EXPECT_WORKERS.
+    let test1_lines = validate_test(&mock_endpoints, &requests_files, THROTTLE_REQUESTS * EXPECT_WORKERS, None);
 
     // Increase the throttle and run a second load test, so we can compare the difference
     // and confirm the throttle is actually working.
@@ -319,10 +320,11 @@ fn test_throttle_gaggle() {
     common::run_load_test(manager_goose_attack, Some(worker_handles));
 
     // Confirm that the load test was actually throttled, at an increased rate.
+    // Throttle is configured per-worker, so multiply by EXPECT_WORKERS.
     let _ = validate_test(
         &mock_endpoints,
         &requests_files,
-        increased_throttle,
+        increased_throttle * EXPECT_WORKERS,
         Some(test1_lines),
     );
 }

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -284,10 +284,10 @@ fn test_throttle_gaggle() {
     common::run_load_test(manager_goose_attack, Some(worker_handles));
 
     // Confirm that the load test was actually throttled.
-    // Throttle is configured per-worker, so multiply by EXPECT_WORKERS.
     let test1_lines = validate_test(
         &mock_endpoints,
         &requests_files,
+        // Throttle is configured per-worker, so multiply by EXPECT_WORKERS.
         THROTTLE_REQUESTS * EXPECT_WORKERS,
         None,
     );
@@ -325,10 +325,10 @@ fn test_throttle_gaggle() {
     common::run_load_test(manager_goose_attack, Some(worker_handles));
 
     // Confirm that the load test was actually throttled, at an increased rate.
-    // Throttle is configured per-worker, so multiply by EXPECT_WORKERS.
     let _ = validate_test(
         &mock_endpoints,
         &requests_files,
+        // Throttle is configured per-worker, so multiply by EXPECT_WORKERS.
         increased_throttle * EXPECT_WORKERS,
         Some(test1_lines),
     );


### PR DESCRIPTION
 - upgrade dependency to [`tokio`](https://docs.rs/tokio/1.2.0/tokio) 1
 - upgrade dependency to [`reqwest`](https://docs.rs/reqwest) 0.11
 - Fixes #204 
 - Re-opens #205 
 - Replaced Tokio's [`mpsc`](https://docs.rs/tokio/*/tokio/sync/mpsc/index.html) sync implementation with [`flume`](https://docs.rs/flume) based on feedback from @Darksonn in https://github.com/tokio-rs/tokio/issues/3350#issuecomment-773952897 (which improved the accuracy of the throttle and required an adjustment to the throttle gaggle test assertions)

I ran some performance comparisons, confirming that updating to Tokio 1.x and switching to Flume didn't cause any performance regressions: https://docs.google.com/spreadsheets/d/1T9SsgveIm1JFRvTcTFWBSPgweBthYiR5apmyHdb92eA/edit#gid=0  (It seems to be consistently slightly faster)