### PR TITLE
support f32 hatch rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.10.5-dev
+ - support floating point hatch rate (ie, hatch 1 user every 2 seconds with `-r .5`)
 
 ## 0.10.4 Nov 1, 2020
  - add new `examples/umami` for load testing Drupal 9 demo install profile

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -274,9 +274,10 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
 
     // Update metrics, which doesn't happen automatically on the Master as we don't
     // invoke launch_users. Hatch rate is required here so unwrap() is safe.
-    let maximum_hatched = goose_attack.configuration.hatch_rate.unwrap() * goose_attack.run_time;
-    if maximum_hatched < goose_attack.configuration.users.unwrap() {
-        goose_attack.metrics.users = maximum_hatched;
+    let hatch_rate = util::get_hatch_rate(goose_attack.configuration.hatch_rate.clone());
+    let maximum_hatched = hatch_rate * goose_attack.run_time as f32;
+    if maximum_hatched < goose_attack.configuration.users.unwrap() as f32 {
+        goose_attack.metrics.users = maximum_hatched as usize;
     } else {
         goose_attack.metrics.users = goose_attack.configuration.users.unwrap();
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -290,4 +290,21 @@ mod tests {
         let expired = timer_expired(started, 1);
         assert_eq!(expired, true);
     }
+
+    #[test]
+    fn hatch_rate() {
+        //  https://rust-lang.github.io/rust-clippy/master/index.html#float_cmp
+        assert!((get_hatch_rate(Some("1".to_string())) - 1.0).abs() < f32::EPSILON);
+        assert!((get_hatch_rate(Some("1.0".to_string())) - 1.0).abs() < f32::EPSILON);
+        assert!((get_hatch_rate(Some(".5".to_string())) - 0.5).abs() < f32::EPSILON);
+        assert!((get_hatch_rate(Some("0.5".to_string())) - 0.5).abs() < f32::EPSILON);
+        assert!((get_hatch_rate(Some(".12345".to_string())) - 0.12345).abs() < f32::EPSILON);
+        assert!((get_hatch_rate(Some("12.345".to_string())) - 12.345).abs() < f32::EPSILON);
+        // Defaults to 1.0.
+        assert!((get_hatch_rate(None) - 1.0).abs() < f32::EPSILON);
+        // Also on invalid input, defaults to 1.0.
+        assert!((get_hatch_rate(Some("g".to_string())) - 1.0).abs() < f32::EPSILON);
+        assert!((get_hatch_rate(Some("2.1f".to_string())) - 1.0).abs() < f32::EPSILON);
+        assert!((get_hatch_rate(Some("1.1.1".to_string())) - 1.0).abs() < f32::EPSILON);
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -135,6 +135,23 @@ pub fn setup_ctrlc_handler(canceled: &Arc<AtomicBool>) {
     }
 }
 
+// Convert optional string hatch rate to f32.
+pub fn get_hatch_rate(hatch_rate: Option<String>) -> f32 {
+    match hatch_rate {
+        Some(h) => match h.parse::<f32>() {
+            Ok(rate) => rate,
+            Err(e) => {
+                warn!(
+                    "failed to convert hatch rate {} to float: {}, defaulting to 1.0",
+                    h, e
+                );
+                1.0
+            }
+        },
+        None => 1.0,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -17,7 +17,7 @@ const ABOUT_KEY: usize = 1;
 // Load test configuration.
 const USERS: usize = 3;
 const RUN_TIME: usize = 3;
-const HATCH_RATE: usize = 10;
+const HATCH_RATE: &str = "10";
 const LOG_LEVEL: usize = 0;
 const METRICS_FILE: &str = "metrics-test.log";
 const DEBUG_FILE: &str = "debug-test.log";


### PR DESCRIPTION
Currently the slowest rate to hatch users is 1 per second. With this PR, hatch rate can be specified as a f32, so for example you can say `-r.5` and it will launch 1 user every 2 seconds.