### PR TITLE
Revert "by default reset metrics after all Workers start in Gaggle mode"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## 0.10.5-dev
- - properly reset metrics after all users launch in Gaggle mode (unless --no-reset-metrics is enabled)
 
 ## 0.10.4 Nov 1, 2020
  - add new `examples/umami` for load testing Drupal 9 demo install profile

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2241,36 +2241,6 @@ impl GooseAttack {
         Ok(())
     }
 
-    pub fn reset_metrics(mut self) -> GooseAttack {
-        // Users is required here so unwrap() is safe.
-        let users = self.configuration.users.clone().unwrap();
-        self.metrics.duration = self.started.unwrap().elapsed().as_secs() as usize;
-        self.metrics.print_running();
-
-        if self.metrics.display_metrics {
-            if self.metrics.users < users {
-                println!(
-                    "{} of {} users hatched, timer expired, resetting metrics (disable with --no-reset-metrics).\n", self.metrics.users, users
-                );
-            } else {
-                println!(
-                    "All {} users hatched, resetting metrics (disable with --no-reset-metrics).\n",
-                    users
-                );
-            }
-        }
-
-        // All users started, reset metrics.
-        self.metrics.requests = HashMap::new();
-        self.metrics
-            .initialize_task_metrics(&self.task_sets, &self.configuration);
-
-        // Restart the timer now that all threads are launched.
-        self.started = Some(time::Instant::now());
-
-        self
-    }
-
     /// Called internally in local-mode and gaggle-mode.
     async fn launch_users(
         mut self,
@@ -2459,7 +2429,27 @@ impl GooseAttack {
                     users_launched = true;
                     let users = self.configuration.users.clone().unwrap();
                     if !self.configuration.no_reset_metrics {
-                        self = self.reset_metrics();
+                        self.metrics.duration = self.started.unwrap().elapsed().as_secs() as usize;
+                        self.metrics.print_running();
+
+                        if self.metrics.display_metrics {
+                            // Users is required here so unwrap() is safe.
+                            if self.metrics.users < users {
+                                println!(
+                                    "{} of {} users hatched, timer expired, resetting metrics (disable with --no-reset-metrics).\n", self.metrics.users, users
+                                );
+                            } else {
+                                println!(
+                                    "All {} users hatched, resetting metrics (disable with --no-reset-metrics).\n", users
+                                );
+                            }
+                        }
+
+                        self.metrics.requests = HashMap::new();
+                        self.metrics
+                            .initialize_task_metrics(&self.task_sets, &self.configuration);
+                        // Restart the timer now that all threads are launched.
+                        self.started = Some(time::Instant::now());
                     } else if self.metrics.users < users {
                         println!(
                             "{} of {} users hatched, timer expired.\n",
@@ -2467,23 +2457,6 @@ impl GooseAttack {
                         );
                     } else {
                         println!("All {} users hatched.\n", self.metrics.users);
-                    }
-
-                    // In Gaggle mode, notify Manager the Worker has started all users.
-                    #[cfg(feature = "gaggle")]
-                    {
-                        if self.attack_mode == GooseMode::Worker {
-                            info!(
-                                "[{}] all {} users started...",
-                                get_worker_id(),
-                                self.configuration.users.unwrap(),
-                            );
-                            worker::push_metrics_to_manager(
-                                &socket.clone().unwrap(),
-                                vec![GaggleMetrics::WorkerRunning(true)],
-                                false,
-                            );
-                        }
                     }
                 }
             }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -281,9 +281,6 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
         goose_attack.metrics.users = goose_attack.configuration.users.unwrap();
     }
 
-    // Track how many Workers have started.
-    let mut workers_running = 0;
-
     // Worker control loop.
     loop {
         // While running load test, check if any workers go away.
@@ -497,16 +494,6 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                             // Merge in task metrics from Worker.
                             GaggleMetrics::Tasks(tasks) => {
                                 merge_task_metrics(&mut goose_attack, tasks)
-                            }
-                            // Reset statistics when all users start.
-                            GaggleMetrics::WorkerRunning(_) => {
-                                workers_running += 1;
-                                if workers_running
-                                    == goose_attack.configuration.expect_workers.unwrap()
-                                    && !goose_attack.configuration.no_reset_metrics
-                                {
-                                    goose_attack = goose_attack.reset_metrics();
-                                }
                             }
                             // Ignore Worker heartbeats.
                             GaggleMetrics::WorkerInit(_) => (),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -15,11 +15,8 @@ use crate::{get_worker_id, GooseAttack, GooseConfiguration, GooseMode, WORKER_ID
 /// Workers send GaggleMetrics to the Manager process to be aggregated together.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum GaggleMetrics {
-    /// Notification that a Worker has started, includes load test hash to ensure
-    /// that all Workers are running the same load test.
+    /// Load test hash, used to ensure all Workers are running the same load test.
     WorkerInit(u64),
-    /// Notification that all GooseUsers on a Worker are running.
-    WorkerRunning(bool),
     /// Goose request metrics.
     Requests(GooseRequestMetrics),
     /// Goose task metrics.
@@ -215,8 +212,6 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     worker_goose_attack.task_sets = goose_attack.task_sets.clone();
     // Use the run_time from the Manager so Worker can shut down in a timely manner.
     worker_goose_attack.run_time = run_time;
-    // Each Worker runs a subset of all total users.
-    worker_goose_attack.configuration.users = Some(weighted_users.len());
     worker_goose_attack.weighted_users = weighted_users;
     worker_goose_attack.configuration.worker = true;
     // The metrics_file option is configured on the Worker.

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -304,8 +304,6 @@ fn test_defaults_gaggle() {
         .unwrap()
         .set_default(GooseDefault::NoTaskMetrics, true)
         .unwrap()
-        .set_default(GooseDefault::NoResetMetrics, true)
-        .unwrap()
         .set_default(GooseDefault::StickyFollow, true)
         .unwrap()
         // Manager configuration using defaults instead of run-time options.

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -18,8 +18,6 @@ const ABOUT_KEY: usize = 1;
 
 // Load test configuration.
 const EXPECT_WORKERS: usize = 2;
-const USERS: usize = 3;
-const RUN_TIME: usize = 3;
 
 // There are multiple test variations in this file.
 #[derive(Clone)]
@@ -100,7 +98,7 @@ fn validate_one_taskset(
     // Confirm that we loaded the index roughly three times as much as the about page.
     let one_third_index = mock_endpoints[INDEX_KEY].times_called() / 3;
     let difference = mock_endpoints[ABOUT_KEY].times_called() as i32 - one_third_index as i32;
-    assert!(difference >= -(USERS as i32) && difference <= USERS as i32);
+    assert!(difference >= -2 && difference <= 2);
 
     // Get index and about out of goose metrics.
     let index_metrics = goose_metrics
@@ -123,6 +121,12 @@ fn validate_one_taskset(
         TestType::ResetMetrics => {
             // Statistics were reset after all users were started, so Goose should report
             // fewer page loads than the server actually saw.
+            println!(
+                "response_time_counter: {}, mock_endpoint_called: {}",
+                index_metrics.response_time_counter,
+                mock_endpoints[INDEX_KEY].times_called()
+            );
+
             assert!(index_metrics.response_time_counter < mock_endpoints[INDEX_KEY].times_called());
             assert!(
                 index_metrics.status_code_counts[&status_code]
@@ -224,22 +228,12 @@ fn run_gaggle_test(test_type: TestType) {
                 "--manager",
                 "--expect-workers",
                 &EXPECT_WORKERS.to_string(),
-                "--users",
-                &USERS.to_string(),
                 "--no-reset-metrics",
             ],
         ),
         TestType::ResetMetrics => common_build_configuration(
             &server,
-            &mut vec![
-                "--manager",
-                "--expect-workers",
-                &EXPECT_WORKERS.to_string(),
-                "--users",
-                &USERS.to_string(),
-                "--run-time",
-                &RUN_TIME.to_string(),
-            ],
+            &mut vec!["--manager", "--expect-workers", &EXPECT_WORKERS.to_string()],
         ),
     };
 
@@ -279,6 +273,8 @@ fn test_one_taskset_reset_metrics() {
     run_standalone_test(TestType::ResetMetrics);
 }
 
+/* @TODO: @FIXME: Goose is not resetting metrics when running in Gaggle mode.
+ * Issue: https://github.com/tag1consulting/goose/issues/193
 #[test]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
@@ -287,3 +283,4 @@ fn test_one_taskset_reset_metrics() {
 fn test_one_taskset_reset_metrics_gaggle() {
     run_gaggle_test(TestType::ResetMetrics);
 }
+*/


### PR DESCRIPTION
Reverts tag1consulting/goose#214

Causes intermittent test failures in Github Actions