### PR TITLE
replace `--only-summary` with `--running-metrics`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.6-dev
+ - Replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default
+
 ## 0.10.5 Nov 5, 2020
  - support floating point hatch rate (ie, hatch 1 user every 2 seconds with `-r .5`)
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Optional arguments:
   -v, --verbose              Sets debug level (-v, -vv, etc)
 
 Metrics:
-  --only-summary             Only prints final summary metrics
+  --running-metrics TIME     How often to optionally print running metrics
   --no-reset-metrics         Doesn't reset metrics after all users have started
   --no-metrics               Doesn't track metrics
   --no-task-metrics          Doesn't track task metrics
@@ -367,6 +367,7 @@ The following defaults can be configured with a `&str`:
 The following defaults can be configured with a `usize` integer:
  - total users to start: `GooseDefault::Users`
  - users to start per second: `GooseDefault::HatchRate`
+ - how often to print running statistics: `GooseDefault::RunningStatistics`
  - number of seconds for test to run: `GooseDefault::RunTime`
  - log level: `GooseDefault::LogLevel`
  - verbosity: `GooseDefault::Verbose`
@@ -376,7 +377,6 @@ The following defaults can be configured with a `usize` integer:
  - port for Worker to connect to: `GooseDefault::ManagerPort`
 
 The following defaults can be configured with a `bool`:
- - only print final summary metrics: `GooseDefault::OnlySummary`
  - do not reset metrics after all users start: `GooseDefault::NoResetMetrics`
  - do not track metrics: `GooseDefault::NoMetrics`
  - do not track task metrics: `GooseDefault::NoTaskMetrics`
@@ -386,7 +386,7 @@ The following defaults can be configured with a `bool`:
  - ignore load test checksum: `GooseDefault::NoHashCheck`
  - enable Worker mode: `GooseDefault::Worker`
 
-For example, without any run-time options the following load test would automatically run against `local.dev`, logging metrics to `goose-metrics.log` and debug to `goose-debug.log`. It will automatically launch 20 users in 4 seconds, and run the load test for 15 minutes. Metrics will only be displayed when the load test completes, and will include additional status code metrics. The order the defaults are set is not important.
+For example, without any run-time options the following load test would automatically run against `local.dev`, logging metrics to `goose-metrics.log` and debug to `goose-debug.log`. It will automatically launch 20 users in 4 seconds, and run the load test for 15 minutes. Metrics will be displayed every minute during the test and will include additional status code metrics. The order the defaults are set is not important.
 
 ```
     GooseAttack::initialize()?
@@ -399,7 +399,7 @@ For example, without any run-time options the following load test would automati
         .set_default(GooseDefault::Users, 20)?
         .set_default(GooseDefault::HatchRate, 4)?
         .set_default(GooseDefault::RunTime, 900)?
-        .set_default(GooseDefault::OnlySummary, true)?
+        .set_default(GooseDefault::RunningStatistics, 60)?
         .set_default(GooseDefault::StatusCodes, true)?
         .execute()?
         .print();

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -325,14 +325,14 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
             }
 
             // When displaying running metrics, sync data from user threads first.
-            if !goose_attack.configuration.only_summary
-                && util::timer_expired(running_metrics_timer, crate::RUNNING_METRICS_EVERY)
-            {
-                // Reset timer each time we display metrics.
-                running_metrics_timer = time::Instant::now();
-                goose_attack.metrics.duration =
-                    goose_attack.started.unwrap().elapsed().as_secs() as usize;
-                goose_attack.metrics.print_running();
+            if let Some(running_metrics) = goose_attack.configuration.running_metrics {
+                if util::timer_expired(running_metrics_timer, running_metrics) {
+                    // Reset timer each time we display metrics.
+                    running_metrics_timer = time::Instant::now();
+                    goose_attack.metrics.duration =
+                        goose_attack.started.unwrap().elapsed().as_secs() as usize;
+                    goose_attack.metrics.print_running();
+                }
             }
         } else if canceled.load(Ordering::SeqCst) {
             info!("load test canceled, exiting");

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -197,7 +197,7 @@ fn test_defaults() {
         .unwrap()
         .set_default(GooseDefault::StatusCodes, true)
         .unwrap()
-        .set_default(GooseDefault::OnlySummary, true)
+        .set_default(GooseDefault::RunningMetrics, 0)
         .unwrap()
         .set_default(GooseDefault::NoTaskMetrics, true)
         .unwrap()
@@ -300,7 +300,7 @@ fn test_defaults_gaggle() {
         .unwrap()
         .set_default(GooseDefault::StatusCodes, true)
         .unwrap()
-        .set_default(GooseDefault::OnlySummary, true)
+        .set_default(GooseDefault::RunningMetrics, 0)
         .unwrap()
         .set_default(GooseDefault::NoTaskMetrics, true)
         .unwrap()
@@ -373,7 +373,8 @@ fn test_no_defaults() {
             "--no-reset-metrics",
             "--no-task-metrics",
             "--status-codes",
-            "--only-summary",
+            "--running-metrics",
+            "30",
             "--sticky-follow",
         ],
     );
@@ -473,7 +474,8 @@ fn test_no_defaults_gaggle() {
             "--no-reset-metrics",
             "--no-task-metrics",
             "--status-codes",
-            "--only-summary",
+            "--running-metrics",
+            "30",
             "--sticky-follow",
             "--verbose",
         ],


### PR DESCRIPTION
Disables running metrics by default.
Makes time between running metrics configurable.

For example, to display running statistics every 2 seconds:
`--running-metrics 2`

Or to make this the default in your load test:

```rust
    GooseAttack::initialize()?
        .register_taskset(taskset!("LoadtestTasks")
            .register_task(task!(loadtest_task))
        )
        .set_default(GooseDefault::RunningStatistics, 2)?
        .execute()?
```