### PR TITLE
expose GooseScheduler for allocating GooseTaskSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 0.10.6-dev
  - replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default
- - make the algorithm for allocation of GooseTask's to starting GooseUsers configurable
-    o `GooseSchedule::RoundRobin` allocates 1 of each available GooseTaskSet at a time (new default)
-    o `GooseSchedule::Serial` allocates all of each available GooseTaskSet in the order they are defined
-    o `GooseSchedule::Random` allocates 1 GooseTaskSet from all available
+ - allow configuration of the algorithm used when allocating `GooseTaskSet`s to starting `GooseUser`s:
+    o `GooseScheduler::RoundRobin` allocates 1 of each available `GooseTaskSet` at a time (new default)
+    o `GooseScheduler::Serial` allocates all of each available `GooseTaskSet` in the order they are defined
+    o `GooseScheduler::Random` allocates 1 `GooseTaskSet` from all available
 
 ## 0.10.5 Nov 5, 2020
  - support floating point hatch rate (ie, hatch 1 user every 2 seconds with `-r .5`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## 0.10.6-dev
- - Replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default
+ - replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default
+ - make the algorithm for allocation of GooseTask's to starting GooseUsers configurable
+    o `GooseSchedule::RoundRobin` allocates 1 of each available GooseTaskSet at a time (new default)
+    o `GooseSchedule::Serial` allocates all of each available GooseTaskSet in the order they are defined
+    o `GooseSchedule::Random` allocates 1 GooseTaskSet from all available
 
 ## 0.10.5 Nov 5, 2020
  - support floating point hatch rate (ie, hatch 1 user every 2 seconds with `-r .5`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 0.10.6-dev
  - replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default
  - allow configuration of the algorithm used when allocating `GooseTaskSet`s to starting `GooseUser`s:
-    o `GooseScheduler::RoundRobin` allocates 1 of each available `GooseTaskSet` at a time (new default)
-    o `GooseScheduler::Serial` allocates all of each available `GooseTaskSet` in the order they are defined
-    o `GooseScheduler::Random` allocates 1 random `GooseTaskSet` from all available
+    o `GooseTaskSetScheduler::RoundRobin` allocates 1 of each available `GooseTaskSet` at a time (new default)
+    o `GooseTaskSetScheduler::Serial` allocates all of each available `GooseTaskSet` in the order they are defined
+    o `GooseTaskSetScheduler::Random` allocates 1 random `GooseTaskSet` from all available
 
 ## 0.10.5 Nov 5, 2020
  - support floating point hatch rate (ie, hatch 1 user every 2 seconds with `-r .5`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  - allow configuration of the algorithm used when allocating `GooseTaskSet`s to starting `GooseUser`s:
     o `GooseScheduler::RoundRobin` allocates 1 of each available `GooseTaskSet` at a time (new default)
     o `GooseScheduler::Serial` allocates all of each available `GooseTaskSet` in the order they are defined
-    o `GooseScheduler::Random` allocates 1 `GooseTaskSet` from all available
+    o `GooseScheduler::Random` allocates 1 random `GooseTaskSet` from all available
 
 ## 0.10.5 Nov 5, 2020
  - support floating point hatch rate (ie, hatch 1 user every 2 seconds with `-r .5`)

--- a/README.md
+++ b/README.md
@@ -348,21 +348,21 @@ Prior to Goose `0.10.6` `GooseTaskSet`s were allocated in a serial order. To res
 
 ```
     GooseAttack::initialize()?
-        .set_scheduler(GooseScheduler::Serial)
+        .set_scheduler(GooseTaskSetScheduler::Serial)
 ```
 
 Or, to randomize the order `GooseTaskSet`s are allocated to newly launched users, you can instead configure your `GooseAttack` as follows:
 
 ```
     GooseAttack::initialize()?
-        .set_scheduler(GooseScheduler::Random)
+        .set_scheduler(GooseTaskSetScheduler::Random)
 ```
 
 The following configuration is possible but superfluous because it is the scheduling default:
 
 ```
     GooseAttack::initialize()?
-        .set_scheduler(GooseScheduler::RoundRobin)
+        .set_scheduler(GooseTaskSetScheduler::RoundRobin)
 ```
 
 ## Defaults

--- a/README.md
+++ b/README.md
@@ -338,6 +338,33 @@ All 1024 users hatched.
  Aggregated              | 58,518 [200]
 ```
 
+## Scheduling GooseTaskSets
+
+When starting a load test, Goose assigns one `GooseTaskSet` to each `GooseUser` thread. By default, it assigns `GooseTaskSets` in a round robin order. As new `GooseUser` threads are launched, the first will be assigned the first defined `GooseTaskSet`, the next will be assigned the next defined `GooseTaskSet`, and so on, looping through all available `GooseTaskSet`s. Weighting is respected during this process, so if one `GooseTaskSet` is weighted heavier than others, that `GooseTaskSet` will get assigned more at the end of the launching process.
+
+It is also possible to allocate `GooseTaskSet`s in a serial or random order. When allocating `GooseTaskSet`s serially, they are launched in the exact order and weighting as they are defined in the load test. When allocating randomly, running the same load test multiple times can generate different amounts of load.
+
+Prior to Goose `0.10.6` `GooseTaskSet`s were allocated in a serial order. To restore this behavior, you can use the `.set_scheduler()` function as follows:
+
+```
+    GooseAttack::initialize()?
+        .set_scheduler(GooseScheduler::Serial)
+```
+
+Or, to randomize the order `GooseTaskSet`s are allocated to newly launched users, you can instead configure your `GooseAttack` as follows:
+
+```
+    GooseAttack::initialize()?
+        .set_scheduler(GooseScheduler::Random)
+```
+
+The following configuration is possible but superfluous because it is the scheduling default:
+
+```
+    GooseAttack::initialize()?
+        .set_scheduler(GooseScheduler::RoundRobin)
+```
+
 ## Defaults
 
 All run-time options can be configured with custom defaults. For example, you may want to default to the the host name of your local development environment, only requiring that `--host` be set when running against a production environment. Assuming your local development environment is at "http://local.dev/" you can do this as follows:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1062,13 +1062,13 @@ impl GooseAttack {
                 // Allocate task sets round robin.
                 let task_sets_len = available_task_sets.len();
                 loop {
-                    for (i, task_sets) in available_task_sets
+                    for (task_set_index, task_sets) in available_task_sets
                         .iter_mut()
                         .enumerate()
                         .take(task_sets_len)
                     {
                         if let Some(task_set) = task_sets.pop() {
-                            debug!("allocating 1 user from TaskSet {}", i);
+                            debug!("allocating 1 user from TaskSet {}", task_set_index);
                             weighted_task_sets.push(task_set);
                         }
                     }
@@ -1079,11 +1079,11 @@ impl GooseAttack {
             }
             GooseTaskSetScheduler::Serial => {
                 // Allocate task sets serially in the weighted order defined.
-                for (task_set, task_sets) in available_task_sets.iter().enumerate() {
+                for (task_set_index, task_sets) in available_task_sets.iter().enumerate() {
                     debug!(
                         "allocating all {} users from TaskSet {}",
                         task_sets.len(),
-                        task_set
+                        task_set_index
                     );
                     weighted_task_sets.append(&mut task_sets.clone());
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,11 +864,11 @@ impl GooseAttack {
     /// Note that the following pattern is repeated:
     ///  A, B, A, B, A, B, A, A
     ///
-    /// If reconfigured to schedule serially, then in the above configuration they
-    /// will be allocated as follows:
+    /// If reconfigured to schedule serially, then they will instead be allocated in
+    /// the following order:
     /// A, A, A, A, A, B, B, B, A, A, A, A, A, B, B, B, A, A, A, A
     ///
-    /// In this case, the following pattern is repeated:
+    /// In the serial case, the following pattern is repeated:
     /// A, A, A, A, A, B, B, B
     ///
     /// In the following example, GooseTaskSets are allocated to launching GooseUsers
@@ -885,28 +885,27 @@ impl GooseAttack {
     ///         .set_scheduler(GooseTaskSetScheduler::Random)
     ///         .register_taskset(taskset!("A Tasks")
     ///             .set_weight(5)?
-    ///             .register_task(task!(example_task))
+    ///             .register_task(task!(a_task_1))
     ///         )
     ///         .register_taskset(taskset!("B Tasks")
-    ///             .set_weight(4)?
-    ///             .register_task(task!(other_task))
+    ///             .set_weight(3)?
+    ///             .register_task(task!(b_task_1))
     ///         );
     ///
     ///     Ok(())
     /// }
     ///
-    /// async fn example_task(user: &GooseUser) -> GooseTaskResult {
+    /// async fn a_task_1(user: &GooseUser) -> GooseTaskResult {
     ///     let _goose = user.get("/foo").await?;
     ///
     ///     Ok(())
     /// }
     ///
-    /// async fn other_task(user: &GooseUser) -> GooseTaskResult {
+    /// async fn b_task_1(user: &GooseUser) -> GooseTaskResult {
     ///     let _goose = user.get("/bar").await?;
     ///
     ///     Ok(())
     /// }
-    /// ```
     /// ```
     pub fn set_scheduler(mut self, scheduler: GooseTaskSetScheduler) -> Self {
         self.scheduler = scheduler;
@@ -1033,7 +1032,7 @@ impl GooseAttack {
         debug!("gcd: {}", u);
 
         // Build a vector of vectors to be used to schedule users.
-        let mut available_task_sets = Vec::new();
+        let mut available_task_sets = Vec::with_capacity(self.task_sets.len());
         let mut total_task_sets = 0;
         for (index, task_set) in self.task_sets.iter().enumerate() {
             // divide by greatest common divisor so vector is as short as possible

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -857,17 +857,24 @@ impl GooseAttack {
     /// are launched.
     ///
     /// By default, GooseTaskSets are allocated to new GooseUser's in a round robin
-    /// style. For example, if TaskA has a weight of 5, TaskB has a weight of
-    /// 4, and you launch 20 users, they will be launched in the following order:
-    ///  A, B, A, B, A, B, A, B, A, A, B, A, B, A, B, A, B, A, A, B
+    /// style. For example, if TaskSet A has a weight of 5, Task Set B has a weight
+    ///  of 3, and you launch 20 users, they will be launched in the following order:
+    ///  A, B, A, B, A, B, A, A, A, B, A, B, A, B, A, A, A, B, A, B
     ///
-    /// If reconfigured to allocate serially, then in the above configuration they
+    /// Note that the following pattern is repeated:
+    ///  A, B, A, B, A, B, A, A
+    ///
+    /// If reconfigured to schedule serially, then in the above configuration they
     /// will be allocated as follows:
-    /// A, A, A, A, A, B, B, B, B, A, A, A, A, A, B, B, B, B, A, B
+    /// A, A, A, A, A, B, B, B, A, A, A, A, A, B, B, B, A, A, A, A
     ///
-    /// In the following example, GooseTaskSets are allocated to new GooseUser's in
-    /// a random order. This means running the test multiple times can generate
-    /// different amounts of load.
+    /// In this case, the following pattern is repeated:
+    /// A, A, A, A, A, B, B, B
+    ///
+    /// In the following example, GooseTaskSets are allocated to launching GooseUsers
+    /// in a random order. This means running the test multiple times can generate
+    /// different amounts of load, as depending on your weighting rules you may
+    /// have a different number of GooseUsers running each GooseTaskSet each time.
     ///
     /// # Example
     /// ```rust,no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,7 +583,7 @@ pub enum GooseMode {
 
 #[derive(Clone, Debug, PartialEq)]
 /// Defines the order GooseTaskSets are allocated to GooseUsers at startup time.
-pub enum GooseScheduler {
+pub enum GooseTaskSetScheduler {
     /// Allocate one of each available type of GooseTaskSet at a time (default).
     RoundRobin,
     /// Allocate GooseTaskSets in the order and weighting they are defined.
@@ -725,7 +725,7 @@ pub struct GooseAttack {
     /// Which mode this GooseAttack is operating in.
     attack_mode: GooseMode,
     /// Defines the order GooseTaskSets are allocated to GooseUsers at startup time.
-    scheduler: GooseScheduler,
+    scheduler: GooseTaskSetScheduler,
     /// When the load test started.
     started: Option<time::Instant>,
     /// All metrics merged together.
@@ -751,7 +751,7 @@ impl GooseAttack {
             configuration: GooseConfiguration::parse_args_default_or_exit(),
             run_time: 0,
             attack_mode: GooseMode::Undefined,
-            scheduler: GooseScheduler::RoundRobin,
+            scheduler: GooseTaskSetScheduler::RoundRobin,
             started: None,
             metrics: GooseMetrics::default(),
         })
@@ -780,7 +780,7 @@ impl GooseAttack {
             configuration,
             run_time: 0,
             attack_mode: GooseMode::Undefined,
-            scheduler: GooseScheduler::RoundRobin,
+            scheduler: GooseTaskSetScheduler::RoundRobin,
             started: None,
             metrics: GooseMetrics::default(),
         })
@@ -882,7 +882,7 @@ impl GooseAttack {
     ///
     /// fn main() -> Result<(), GooseError> {
     ///     GooseAttack::initialize()?
-    ///         .set_scheduler(GooseScheduler::Random)
+    ///         .set_scheduler(GooseTaskSetScheduler::Random)
     ///         .register_taskset(taskset!("A Tasks")
     ///             .set_weight(5)?
     ///             .register_task(task!(example_task))
@@ -908,7 +908,7 @@ impl GooseAttack {
     /// }
     /// ```
     /// ```
-    pub fn set_scheduler(mut self, scheduler: GooseScheduler) -> Self {
+    pub fn set_scheduler(mut self, scheduler: GooseTaskSetScheduler) -> Self {
         self.scheduler = scheduler;
         self
     }
@@ -1058,7 +1058,7 @@ impl GooseAttack {
         // Now build the weighted list with the appropriate scheduler.
         let mut weighted_task_sets = Vec::new();
         match self.scheduler {
-            GooseScheduler::RoundRobin => {
+            GooseTaskSetScheduler::RoundRobin => {
                 // Allocate task sets round robin.
                 let task_sets_len = available_task_sets.len();
                 loop {
@@ -1077,7 +1077,7 @@ impl GooseAttack {
                     }
                 }
             }
-            GooseScheduler::Serial => {
+            GooseTaskSetScheduler::Serial => {
                 // Allocate task sets serially in the weighted order defined.
                 for (task_set, task_sets) in available_task_sets.iter().enumerate() {
                     debug!(
@@ -1088,7 +1088,7 @@ impl GooseAttack {
                     weighted_task_sets.append(&mut task_sets.clone());
                 }
             }
-            GooseScheduler::Random => {
+            GooseTaskSetScheduler::Random => {
                 // Allocate task sets randomly.
                 loop {
                     let task_set = available_task_sets.choose_mut(&mut rand::thread_rng());

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,5 +3,5 @@ pub use crate::goose::{
 };
 pub use crate::metrics::GooseMetrics;
 pub use crate::{
-    task, taskset, GooseAttack, GooseDefault, GooseDefaultType, GooseError, GooseScheduler,
+    task, taskset, GooseAttack, GooseDefault, GooseDefaultType, GooseError, GooseTaskSetScheduler,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,5 +3,5 @@ pub use crate::goose::{
 };
 pub use crate::metrics::GooseMetrics;
 pub use crate::{
-    task, taskset, GooseAttack, GooseDefault, GooseDefaultType, GooseError, GooseSchedule,
+    task, taskset, GooseAttack, GooseDefault, GooseDefaultType, GooseError, GooseScheduler,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,4 +2,6 @@ pub use crate::goose::{
     GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet, GooseUser,
 };
 pub use crate::metrics::GooseMetrics;
-pub use crate::{task, taskset, GooseAttack, GooseDefault, GooseDefaultType, GooseError};
+pub use crate::{
+    task, taskset, GooseAttack, GooseDefault, GooseDefaultType, GooseError, GooseSchedule,
+};

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -1,0 +1,320 @@
+use httpmock::Method::GET;
+use httpmock::{Mock, MockRef, MockServer};
+use serial_test::serial;
+use tokio::time::{delay_for, Duration};
+
+mod common;
+
+use goose::prelude::*;
+use goose::GooseConfiguration;
+
+// Paths used in load tests performed during these tests.
+const ONE_PATH: &str = "/one";
+const TWO_PATH: &str = "/two";
+const START_ONE_PATH: &str = "/start/one";
+const STOP_ONE_PATH: &str = "/stop/one";
+
+// Indexes to the above paths.
+const ONE_KEY: usize = 0;
+const TWO_KEY: usize = 1;
+const START_ONE_KEY: usize = 2;
+const STOP_ONE_KEY: usize = 3;
+
+// Load test configuration.
+const EXPECT_WORKERS: usize = 3;
+// Users needs to be an even number.
+const USERS: usize = 10;
+const RUN_TIME: usize = 2;
+
+// There are multiple test variations in this file.
+#[derive(Clone)]
+enum TestType {
+    // Launch task sets serially as defined.
+    Serial,
+    // Launch task sets in a round robin fashion.
+    RoundRobin,
+}
+
+// Test task.
+pub async fn one_with_delay(user: &GooseUser) -> GooseTaskResult {
+    let _goose = user.get(ONE_PATH).await?;
+
+    // "Run out the clock" on the load test when this function runs. Sleep for
+    // the total duration the test is to run plus 1 second to be sure no
+    // additional tasks will run after this one.
+    delay_for(Duration::from_secs(RUN_TIME as u64 + 1)).await;
+
+    Ok(())
+}
+
+// Test task.
+pub async fn two_with_delay(user: &GooseUser) -> GooseTaskResult {
+    let _goose = user.get(TWO_PATH).await?;
+
+    // "Run out the clock" on the load test when this function runs. Sleep for
+    // the total duration the test is to run plus 1 second to be sure no
+    // additional tasks will run after this one.
+    delay_for(Duration::from_secs(RUN_TIME as u64 + 1)).await;
+
+    Ok(())
+}
+
+// Used as a test_start() function, which always runs one time.
+pub async fn start_one(user: &GooseUser) -> GooseTaskResult {
+    let _goose = user.get(START_ONE_PATH).await?;
+
+    Ok(())
+}
+
+// Used as a test_stop() function, which always runs one time.
+pub async fn stop_one(user: &GooseUser) -> GooseTaskResult {
+    let _goose = user.get(STOP_ONE_PATH).await?;
+
+    Ok(())
+}
+
+// All tests in this file run against common endpoints.
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
+    let mut endpoints: Vec<MockRef> = Vec::new();
+
+    // First set up ONE_PATH, store in vector at ONE_KEY.
+    endpoints.push(
+        Mock::new()
+            .expect_method(GET)
+            .expect_path(ONE_PATH)
+            .return_status(200)
+            .create_on(&server),
+    );
+    // Next set up TWO_PATH, store in vector at TWO_KEY.
+    endpoints.push(
+        Mock::new()
+            .expect_method(GET)
+            .expect_path(TWO_PATH)
+            .return_status(200)
+            .create_on(&server),
+    );
+    // Next set up START_ONE_PATH, store in vector at START_ONE_KEY.
+    endpoints.push(
+        Mock::new()
+            .expect_method(GET)
+            .expect_path(START_ONE_PATH)
+            .return_status(200)
+            .create_on(&server),
+    );
+    // Next set up STOP_ONE_PATH, store in vector at STOP_ONE_KEY.
+    endpoints.push(
+        Mock::new()
+            .expect_method(GET)
+            .expect_path(STOP_ONE_PATH)
+            .return_status(200)
+            .create_on(&server),
+    );
+
+    endpoints
+}
+
+// Build appropriate configuration for these tests.
+fn common_build_configuration(
+    server: &MockServer,
+    worker: Option<bool>,
+    manager: Option<usize>,
+) -> GooseConfiguration {
+    if let Some(expect_workers) = manager {
+        common::build_configuration(
+            &server,
+            vec![
+                "--manager",
+                "--expect-workers",
+                &expect_workers.to_string(),
+                "--users",
+                &USERS.to_string(),
+                "--hatch-rate",
+                &USERS.to_string(),
+                "--run-time",
+                &RUN_TIME.to_string(),
+                "--no-reset-metrics",
+            ],
+        )
+    } else if worker.is_some() {
+        common::build_configuration(&server, vec!["--worker"])
+    } else {
+        common::build_configuration(
+            &server,
+            vec![
+                "--users",
+                &USERS.to_string(),
+                "--hatch-rate",
+                &USERS.to_string(),
+                "--run-time",
+                &RUN_TIME.to_string(),
+                "--no-reset-metrics",
+            ],
+        )
+    }
+}
+
+// Helper to confirm all variations generate appropriate results.
+fn validate_test(test_type: &TestType, mock_endpoints: &[MockRef]) {
+    // START_ONE_PATH is loaded one and only one time on all variations.
+    assert!(mock_endpoints[START_ONE_KEY].times_called() == 1);
+
+    // Now confirm TestType-specific counters.
+    match test_type {
+        TestType::RoundRobin => {
+            // We launch an equal number of each task set, so we call both endpoints
+            // an equal number of times.
+            assert!(
+                mock_endpoints[TWO_KEY].times_called() == mock_endpoints[ONE_KEY].times_called()
+            );
+            assert!(mock_endpoints[ONE_KEY].times_called() == USERS / 2);
+        }
+        TestType::Serial => {
+            // As we only launch as many users as the weight of the first task set, we only
+            // call the first endpoint, never the second endpoint.
+            assert!(mock_endpoints[ONE_KEY].times_called() == USERS);
+            assert!(mock_endpoints[TWO_KEY].times_called() == 0);
+        }
+    }
+
+    // STOP_ONE_PATH is loaded one and only one time on all variations.
+    assert!(mock_endpoints[STOP_ONE_KEY].times_called() == 1);
+}
+
+// Returns the appropriate taskset, start_task and stop_task needed to build these tests.
+fn get_tasks() -> (GooseTaskSet, GooseTaskSet, GooseTask, GooseTask) {
+    (
+        taskset!("TaskSetOne")
+            .register_task(task!(one_with_delay))
+            .set_weight(USERS)
+            .unwrap(),
+        taskset!("TaskSetTwo")
+            .register_task(task!(two_with_delay))
+            .set_weight(USERS + 1)
+            .unwrap(),
+        // Start runs before all other tasks, regardless of where defined.
+        task!(start_one),
+        // Stop runs after all other tasks, regardless of where defined.
+        task!(stop_one),
+    )
+}
+
+// Helper to run all standalone tests.
+fn run_standalone_test(test_type: TestType) {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    // Setup the mock endpoints needed for this test.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    // Build common configuration.
+    let configuration = common_build_configuration(&server, None, None);
+
+    // Get the taskset, start and stop tasks to build a load test.
+    let (taskset1, taskset2, start_task, stop_task) = get_tasks();
+
+    // First set up the common base configuration.
+    let mut goose_attack = crate::GooseAttack::initialize_with_config(configuration)
+        .unwrap()
+        .register_taskset(taskset1)
+        .register_taskset(taskset2)
+        .test_start(start_task)
+        .test_stop(stop_task);
+
+    // Then configure which scheduler the GooseAttack should launch users with.
+    goose_attack = match test_type {
+        TestType::RoundRobin => goose_attack.set_scheduler(GooseScheduler::RoundRobin),
+        TestType::Serial => goose_attack.set_scheduler(GooseScheduler::Serial),
+    };
+
+    // Run the Goose Attack.
+    common::run_load_test(goose_attack, None);
+
+    // Confirm the load test ran correctly.
+    validate_test(&test_type, &mock_endpoints);
+}
+
+// Helper to run all gaggle tests.
+fn run_gaggle_test(test_type: TestType) {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    // Setup the mock endpoints needed for this test.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    // Build common configuration.
+    let worker_configuration = common_build_configuration(&server, Some(true), None);
+
+    // Get the taskset, start and stop tasks to build a load test.
+    let (taskset1, taskset2, start_task, stop_task) = get_tasks();
+
+    // First set up the common base configuration.
+    let mut goose_attack = crate::GooseAttack::initialize_with_config(worker_configuration)
+        .unwrap()
+        .register_taskset(taskset1.clone())
+        .register_taskset(taskset2.clone())
+        .test_start(start_task.clone())
+        .test_stop(stop_task.clone());
+
+    // Then configure which scheduler the GooseAttack should launch users with.
+    goose_attack = match test_type {
+        TestType::RoundRobin => goose_attack.set_scheduler(GooseScheduler::RoundRobin),
+        TestType::Serial => goose_attack.set_scheduler(GooseScheduler::Serial),
+    };
+
+    // Workers launched in own threads, store thread handles.
+    let worker_handles = common::launch_gaggle_workers(goose_attack, EXPECT_WORKERS);
+
+    // Build Manager configuration.
+    let manager_configuration = common_build_configuration(&server, None, Some(EXPECT_WORKERS));
+
+    // Build the load test for the Manager.
+    let mut manager_goose_attack =
+        crate::GooseAttack::initialize_with_config(manager_configuration)
+            .unwrap()
+            .register_taskset(taskset1)
+            .register_taskset(taskset2)
+            .test_start(start_task)
+            .test_stop(stop_task);
+
+    // Then configure which scheduler the GooseAttack should launch users with.
+    manager_goose_attack = match test_type {
+        TestType::RoundRobin => manager_goose_attack.set_scheduler(GooseScheduler::RoundRobin),
+        TestType::Serial => manager_goose_attack.set_scheduler(GooseScheduler::Serial),
+    };
+
+    // Run the Goose Attack.
+    common::run_load_test(manager_goose_attack, Some(worker_handles));
+
+    // Confirm the load test ran correctly.
+    validate_test(&test_type, &mock_endpoints);
+}
+
+#[test]
+// Load test with multiple tasks allocating GooseTaskSets in round robin order.
+fn test_round_robin() {
+    run_standalone_test(TestType::RoundRobin);
+}
+
+#[test]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+#[serial]
+// Load test with multiple tasks allocating GooseTaskSets in round robin order, in
+// Gaggle mode.
+fn test_round_robin_gaggle() {
+    run_gaggle_test(TestType::RoundRobin);
+}
+
+#[test]
+// Load test with multiple tasks allocating GooseTaskSets in serial order.
+fn test_serial() {
+    run_standalone_test(TestType::Serial);
+}
+
+#[test]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+#[serial]
+// Load test with multiple tasks allocating GooseTaskSets in serial order, in
+// Gaggle mode.
+fn test_serial_gaggle() {
+    run_gaggle_test(TestType::Serial);
+}

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -222,8 +222,8 @@ fn run_standalone_test(test_type: TestType) {
 
     // Then configure which scheduler the GooseAttack should launch users with.
     goose_attack = match test_type {
-        TestType::RoundRobin => goose_attack.set_scheduler(GooseScheduler::RoundRobin),
-        TestType::Serial => goose_attack.set_scheduler(GooseScheduler::Serial),
+        TestType::RoundRobin => goose_attack.set_scheduler(GooseTaskSetScheduler::RoundRobin),
+        TestType::Serial => goose_attack.set_scheduler(GooseTaskSetScheduler::Serial),
     };
 
     // Run the Goose Attack.
@@ -257,8 +257,8 @@ fn run_gaggle_test(test_type: TestType) {
 
     // Then configure which scheduler the GooseAttack should launch users with.
     goose_attack = match test_type {
-        TestType::RoundRobin => goose_attack.set_scheduler(GooseScheduler::RoundRobin),
-        TestType::Serial => goose_attack.set_scheduler(GooseScheduler::Serial),
+        TestType::RoundRobin => goose_attack.set_scheduler(GooseTaskSetScheduler::RoundRobin),
+        TestType::Serial => goose_attack.set_scheduler(GooseTaskSetScheduler::Serial),
     };
 
     // Workers launched in own threads, store thread handles.
@@ -278,8 +278,10 @@ fn run_gaggle_test(test_type: TestType) {
 
     // Then configure which scheduler the GooseAttack should launch users with.
     manager_goose_attack = match test_type {
-        TestType::RoundRobin => manager_goose_attack.set_scheduler(GooseScheduler::RoundRobin),
-        TestType::Serial => manager_goose_attack.set_scheduler(GooseScheduler::Serial),
+        TestType::RoundRobin => {
+            manager_goose_attack.set_scheduler(GooseTaskSetScheduler::RoundRobin)
+        }
+        TestType::Serial => manager_goose_attack.set_scheduler(GooseTaskSetScheduler::Serial),
     };
 
     // Run the Goose Attack.


### PR DESCRIPTION
 - allow configuration of the algorithm used when allocating `GooseTaskSet`s to starting `GooseUser`s:
   - `GooseScheduler::RoundRobin` allocates 1 of each available `GooseTaskSet` at a time (new default)
   - `GooseScheduler::Serial` allocates all of each available `GooseTaskSet` in the order they are defined
   - `GooseScheduler::Random` randomly allocates 1 `GooseTaskSet` at a time from all available
 - fixes #221 