### PR TITLE
display running metrics when enabled during ramp-up, running, and shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     o `GooseTaskSetScheduler::RoundRobin` allocates 1 of each available `GooseTaskSet` at a time (new default)
     o `GooseTaskSetScheduler::Serial` allocates all of each available `GooseTaskSet` in the order they are defined
     o `GooseTaskSetScheduler::Random` allocates 1 random `GooseTaskSet` from all available
- - also display running metrics during ramp-up when enabled
+ - when enabled, display running metrics for the entire duration of test, including ramp-up and shutdown
 
 ## 0.10.5 Nov 5, 2020
  - support floating point hatch rate (ie, hatch 1 user every 2 seconds with `-r .5`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     o `GooseTaskSetScheduler::RoundRobin` allocates 1 of each available `GooseTaskSet` at a time (new default)
     o `GooseTaskSetScheduler::Serial` allocates all of each available `GooseTaskSet` in the order they are defined
     o `GooseTaskSetScheduler::Random` allocates 1 random `GooseTaskSet` from all available
+ - also display running metrics during ramp-up when enabled
 
 ## 0.10.5 Nov 5, 2020
  - support floating point hatch rate (ie, hatch 1 user every 2 seconds with `-r .5`)

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -908,7 +908,7 @@ pub struct GooseUser {
     /// A local copy of the global GooseConfiguration.
     pub config: GooseConfiguration,
     /// Channel to logger.
-    pub logger: Option<mpsc::UnboundedSender<Option<GooseDebug>>>,
+    pub debug_logger: Option<mpsc::UnboundedSender<Option<GooseDebug>>>,
     /// Channel to throttle.
     pub throttle: Option<mpsc::Sender<bool>>,
     /// Normal tasks are optionally throttled, test_start and test_stop tasks are not.
@@ -952,7 +952,7 @@ impl GooseUser {
             min_wait,
             max_wait,
             config: configuration.clone(),
-            logger: None,
+            debug_logger: None,
             throttle: None,
             is_throttled: true,
             channel_to_parent: None,
@@ -1764,8 +1764,8 @@ impl GooseUser {
         if !self.config.debug_file.is_empty() {
             // Logger is not defined when running test_start_task, test_stop_task,
             // and during testing.
-            if let Some(logger) = self.logger.clone() {
-                logger.send(Some(GooseDebug::new(tag, request, headers, body)))?;
+            if let Some(debug_logger) = self.debug_logger.clone() {
+                debug_logger.send(Some(GooseDebug::new(tag, request, headers, body)))?;
             }
         }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -273,7 +273,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
         .initialize_task_metrics(&goose_attack.task_sets, &goose_attack.configuration);
 
     // Update metrics, which doesn't happen automatically on the Master as we don't
-    // invoke launch_users. Hatch rate is required here so unwrap() is safe.
+    // invoke start_attack. Hatch rate is required here so unwrap() is safe.
     let hatch_rate = util::get_hatch_rate(goose_attack.configuration.hatch_rate.clone());
     let maximum_hatched = hatch_rate * goose_attack.run_time as f32;
     if maximum_hatched < goose_attack.configuration.users.unwrap() as f32 {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -259,7 +259,7 @@ impl GooseMetrics {
     /// ```
     pub fn print(&self) {
         if self.display_metrics {
-            info!("printing metrics after {} seconds...", self.duration);
+            info!("printing final metrics after {} seconds...", self.duration);
             print!("{}", self);
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -111,9 +111,16 @@ pub fn truncate_string(str_to_truncate: &str, max_length: u64) -> String {
     string_to_truncate
 }
 
-/// If run_time was specified, detect when it's time to shut down
+/// Determine if timer was set as many or more seconds ago as the timer is
+/// intended to run.
 pub fn timer_expired(started: time::Instant, run_time: usize) -> bool {
     run_time > 0 && started.elapsed().as_secs() >= run_time as u64
+}
+
+/// Determine if timer was set as many or more milliseconds ago as the
+/// timer is intended to run.
+pub fn ms_timer_expired(started: time::Instant, elapsed: usize) -> bool {
+    elapsed > 0 && started.elapsed().as_millis() >= elapsed as u128
 }
 
 pub fn setup_ctrlc_handler(canceled: &Arc<AtomicBool>) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -53,7 +53,7 @@ pub async fn sleep_minus_drift(
 ) -> tokio::time::Instant {
     match duration.checked_sub(drift.elapsed()) {
         Some(delay) if delay.as_nanos() > 0 => tokio::time::delay_for(delay).await,
-        _ => warn!("sleep_minus_drift: drift was greater than or equal to duration, not sleeping"),
+        _ => info!("sleep_minus_drift: drift was greater than or equal to duration, not sleeping"),
     };
     tokio::time::Instant::now()
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -233,7 +233,7 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     worker_goose_attack.defaults = goose_attack.defaults.clone();
 
     worker_goose_attack
-        .launch_users(Some(manager))
+        .start_attack(Some(manager))
         .await
         .map_err(|error| eprintln!("{:?} worker_id({})", error, get_worker_id()))
         .expect("failed to launch GooseAttack")

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -11,7 +11,7 @@ use crate::goose::{GooseUser, GooseUserCommand};
 use crate::manager::GooseUserInitializer;
 use crate::metrics::{GooseRequestMetrics, GooseTaskMetrics};
 use crate::util;
-use crate::{get_worker_id, GooseAttack, GooseConfiguration, GooseMode, WORKER_ID};
+use crate::{get_worker_id, GooseAttack, GooseConfiguration, AttackMode, WORKER_ID};
 
 /// Workers send GaggleMetrics to the Manager process to be aggregated together.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -230,7 +230,7 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     // The throttle_requests option is set on the Worker.
     worker_goose_attack.configuration.throttle_requests =
         goose_attack.configuration.throttle_requests;
-    worker_goose_attack.attack_mode = GooseMode::Worker;
+    worker_goose_attack.attack_mode = AttackMode::Worker;
     worker_goose_attack.defaults = goose_attack.defaults.clone();
 
     // Divide hatch_rate amongst all workers.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -10,8 +10,7 @@ const EMPTY_ARGS: Vec<&str> = vec![];
 use crate::goose::{GooseUser, GooseUserCommand};
 use crate::manager::GooseUserInitializer;
 use crate::metrics::{GooseRequestMetrics, GooseTaskMetrics};
-use crate::util;
-use crate::{get_worker_id, GooseAttack, GooseConfiguration, AttackMode, WORKER_ID};
+use crate::{get_worker_id, AttackMode, GooseAttack, GooseConfiguration, WORKER_ID};
 
 /// Workers send GaggleMetrics to the Manager process to be aggregated together.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -233,19 +232,8 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     worker_goose_attack.attack_mode = AttackMode::Worker;
     worker_goose_attack.defaults = goose_attack.defaults.clone();
 
-    // Divide hatch_rate amongst all workers.
-    let hatch_rate = util::get_hatch_rate(worker_goose_attack.configuration.hatch_rate.clone());
-    let delay = 1.0
-        // Expect workers are required here, so unwrap() is safe.
-        / (hatch_rate / (config.expect_workers.unwrap() as f32));
-    info!(
-        "[{}] prepared to start 1 user every {:.2} seconds",
-        worker_id, hatch_rate,
-    );
-    let sleep_duration = time::Duration::from_secs_f32(delay);
-
     worker_goose_attack
-        .launch_users(sleep_duration, Some(manager))
+        .launch_users(Some(manager))
         .await
         .map_err(|error| eprintln!("{:?} worker_id({})", error, get_worker_id()))
         .expect("failed to launch GooseAttack")

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -441,7 +441,6 @@ fn test_no_defaults_gaggle() {
                 LOG_FORMAT,
                 "--throttle-requests",
                 &THROTTLE_REQUESTS.to_string(),
-                "--verbose",
             ],
         );
         println!("{:#?}", worker_configuration);
@@ -477,7 +476,6 @@ fn test_no_defaults_gaggle() {
             "--running-metrics",
             "30",
             "--sticky-follow",
-            "--verbose",
         ],
     );
 

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -28,8 +28,9 @@ const SERVER2_INDEX_KEY: usize = 3;
 const SERVER2_ABOUT_KEY: usize = 4;
 
 // Load test configuration.
-const EXPECT_WORKERS: usize = 2;
-const USERS: usize = 4;
+const EXPECT_WORKERS: usize = 4;
+const USERS: usize = 9;
+const RUN_TIME: usize = 3;
 
 // There are multiple test variations in this file.
 #[derive(Clone)]
@@ -215,6 +216,8 @@ fn common_build_configuration(
                     &USERS.to_string(),
                     "--hatch-rate",
                     &USERS.to_string(),
+                    "--run-time",
+                    &RUN_TIME.to_string(),
                 ],
             )
         } else {
@@ -228,6 +231,8 @@ fn common_build_configuration(
                     &USERS.to_string(),
                     "--hatch-rate",
                     &USERS.to_string(),
+                    "--run-time",
+                    &RUN_TIME.to_string(),
                 ],
             )
         }
@@ -242,6 +247,8 @@ fn common_build_configuration(
                 &USERS.to_string(),
                 "--hatch-rate",
                 &USERS.to_string(),
+                "--run-time",
+                &RUN_TIME.to_string(),
             ],
         )
     } else {
@@ -252,6 +259,8 @@ fn common_build_configuration(
                 &USERS.to_string(),
                 "--hatch-rate",
                 &USERS.to_string(),
+                "--run-time",
+                &RUN_TIME.to_string(),
             ],
         )
     }
@@ -297,6 +306,21 @@ fn validate_redirect(test_type: &TestType, mock_endpoints: &[MockRef]) {
         }
         TestType::Sticky => {
             // Each GooseUser loads the redirect on Server1 one time.
+            println!(
+                "SERVER1_REDIRECT: {}, USERS: {}",
+                mock_endpoints[SERVER1_REDIRECT_KEY].times_called(),
+                USERS,
+            );
+            println!(
+                "SERVER1_INDEX: {}, SERVER1_ABOUT: {}",
+                mock_endpoints[SERVER1_INDEX_KEY].times_called(),
+                mock_endpoints[SERVER1_ABOUT_KEY].times_called(),
+            );
+            println!(
+                "SERVER2_INDEX: {}, SERVER2_ABOUT: {}",
+                mock_endpoints[SERVER2_INDEX_KEY].times_called(),
+                mock_endpoints[SERVER2_ABOUT_KEY].times_called(),
+            );
             assert!(mock_endpoints[SERVER1_REDIRECT_KEY].times_called() == USERS);
 
             // Redirected to Server2, no user load anything else on Server1.

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -24,7 +24,7 @@ const STOP_ONE_KEY: usize = 3;
 const EXPECT_WORKERS: usize = 4;
 // Users needs to be an even number.
 const USERS: usize = 18;
-const RUN_TIME: usize = 2;
+const RUN_TIME: usize = 3;
 
 // Test task.
 pub async fn one_with_delay(user: &GooseUser) -> GooseTaskResult {


### PR DESCRIPTION
 - when enabled, display running metrics during the entire load test (even when starting up and/or shutting down)
-  split the function that launches the load test into smaller logical pieces, wrapping it all in a loop to allow regular display of metrics
 - put all variables required to run a load test into a GooseAttackRunState structure which can be efficiently passed around
 - fixes #224 
 - fixes #136 