### PR TITLE
account for time spent not sleeping, looping every second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.10.7-dev
+ - account for time spent doing things other than sleeping, maintaining more consistency when displaying statistics and shutting down
 
 ## 0.10.6 Nov 10, 2020
  - replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default


### PR DESCRIPTION
 - when setting `--running-metrics <usize>` the intent is that the running metrics are displayed every usize seconds
 - the Goose parent thread collects metrics from all GooseUser threads, and this takes some time (especially on bigger load tests)
 - it also displays running metrics when enabled
 - this PR subtracts the time spent doing these "other things" before running through the loop and doing it all over again, avoiding all but the most extreme time drifts
 - this also seems to fix some intermittent integration test failures that were inconsistently happening