### PR TITLE
increase debug log buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.7-dev
  - account for time spent doing things other than sleeping, maintaining more consistency when displaying statistics and shutting down
+ - start each debug log file with a line feed in case the page is too big for the buffer; increase the debug logger buffer size from 8K to 8M.
 
 ## 0.10.6 Nov 10, 2020
  - replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default


### PR DESCRIPTION
 - increases the buffer size for the debug log from 8K to 8M
 - adds line feed at start of each debug file line instead of the end in case a web page is ever larger than the buffer
 - fixes https://github.com/tag1consulting/goose/issues/220