### PR TITLE
optionally don't log response body in debug log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.10.7-dev
  - account for time spent doing things other than sleeping, maintaining more consistency when displaying statistics and shutting down
  - start each debug log file with a line feed in case the page is too big for the buffer; increase the debug logger buffer size from 8K to 8M.
+ - introduce `--no-debug-body` flag to optionally prevent debug log from including the response body
 
 ## 0.10.6 Nov 10, 2020
  - replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Metrics:
   --metrics-format FORMAT    Sets metrics log format (csv, json, raw)
   -d, --debug-file NAME      Sets debug log file name
   --debug-format FORMAT      Sets debug log format (json, raw)
+  --no-debug-body            Do not include the response body in the debug log
   --status-codes             Tracks additional status code metrics
 
 Advanced:

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1691,7 +1691,12 @@ impl GooseUser {
     /// is running. This can be especially helpful when writing a load test. Each entry
     /// must include a tag, which is an arbitrary string identifying the debug message.
     /// It may also optionally include references to the GooseRawRequest made, the headers
-    /// returned by the server, and the text returned by the server,
+    /// returned by the server, and the response body returned by the server,
+    ///
+    /// As the response body can be large, the `--no-debug-body` option (or
+    /// `GooseDefault::NoDebugBody` default) can be set to prevent the debug log from
+    /// including the response body. When this option is enabled, the body will always
+    /// show up as `null` in the debug log.
     ///
     /// Calls to
     /// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_failure)
@@ -1765,7 +1770,11 @@ impl GooseUser {
             // Logger is not defined when running test_start_task, test_stop_task,
             // and during testing.
             if let Some(debug_logger) = self.debug_logger.clone() {
-                debug_logger.send(Some(GooseDebug::new(tag, request, headers, body)))?;
+                if self.config.no_debug_body {
+                    debug_logger.send(Some(GooseDebug::new(tag, request, headers, None)))?;
+                } else {
+                    debug_logger.send(Some(GooseDebug::new(tag, request, headers, body)))?;
+                }
             }
         }
 

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -193,6 +193,8 @@ fn test_defaults() {
         .unwrap()
         .set_default(GooseDefault::DebugFormat, LOG_FORMAT)
         .unwrap()
+        .set_default(GooseDefault::NoDebugBody, true)
+        .unwrap()
         .set_default(GooseDefault::ThrottleRequests, THROTTLE_REQUESTS)
         .unwrap()
         .set_default(GooseDefault::StatusCodes, true)
@@ -266,6 +268,8 @@ fn test_defaults_gaggle() {
                 .set_default(GooseDefault::DebugFile, worker_debug_file.as_str())
                 .unwrap()
                 .set_default(GooseDefault::DebugFormat, LOG_FORMAT)
+                .unwrap()
+                .set_default(GooseDefault::NoDebugBody, true)
                 .unwrap()
                 .set_default(GooseDefault::MetricsFile, worker_metrics_file.as_str())
                 .unwrap()
@@ -368,6 +372,7 @@ fn test_no_defaults() {
             &debug_file,
             "--debug-format",
             LOG_FORMAT,
+            "--no-debug-body",
             "--throttle-requests",
             &THROTTLE_REQUESTS.to_string(),
             "--no-reset-metrics",
@@ -439,6 +444,7 @@ fn test_no_defaults_gaggle() {
                 &worker_debug_file,
                 "--debug-format",
                 LOG_FORMAT,
+                "--no-debug-body",
                 "--throttle-requests",
                 &THROTTLE_REQUESTS.to_string(),
             ],


### PR DESCRIPTION
 - introduce `--no-debug-body` to optionally not log the response body in the debug log
 - allocate less memory to the debug log buffer when not logging response bodies (64K versus 8M)
 - fixes https://github.com/tag1consulting/goose/issues/230