### PR TITLE
rename metrics file to requests file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - account for time spent doing things other than sleeping, maintaining more consistency when displaying statistics and shutting down
  - start each debug log file with a line feed in case the page is too big for the buffer; increase the debug logger buffer size from 8K to 8M.
  - introduce `--no-debug-body` flag to optionally prevent debug log from including the response body
+ - rename `--metrics-file` to `--requests-file`, and `MetricsFile` to `RequestsFile` to better reflect what it is
 
 ## 0.10.6 Nov 10, 2020
  - replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
  - account for time spent doing things other than sleeping, maintaining more consistency when displaying statistics and shutting down
  - start each debug log file with a line feed in case the page is too big for the buffer; increase the debug logger buffer size from 8K to 8M.
  - introduce `--no-debug-body` flag to optionally prevent debug log from including the response body
- - rename `--metrics-file` to `--requests-file`, and `MetricsFile` to `RequestsFile` to better reflect what it is
+ - rename the metrics file to requests file to better reflect what it is
+    o `--metrics-file` becomes `--requests-file`
+    o `--metrics-format` becomes `--requests-format`
+    o `GooseDebug::MetricsFile` becomes `GooseDebug::RequestsFile`
+    o `GooseDebug::MetricsFormat` becomes `GooseDebug::RequestsFormat`
 
 ## 0.10.6 Nov 10, 2020
  - replace `--only-summary` with `--running-metrics <usize>`, running metrics are disabled by default

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Metrics:
   --no-metrics               Doesn't track metrics
   --no-task-metrics          Doesn't track task metrics
   -m, --requests-file NAME   Sets requests log file name
-  --metrics-format FORMAT    Sets metrics log format (csv, json, raw)
+  --requests-format FORMAT   Sets requests log format (csv, json, raw)
   -d, --debug-file NAME      Sets debug log file name
   --debug-format FORMAT      Sets debug log format (json, raw)
   --no-debug-body            Do not include the response body in the debug log
@@ -386,7 +386,7 @@ The following defaults can be configured with a `&str`:
  - host: `GooseDefault::Host`
  - log file name: `GooseDefault::LogFile`
  - requests log file name: `GooseDefault::RequestsFile`
- - metrics log file format: `GooseDefault::MetricsFormat`
+ - requests log file format: `GooseDefault::RequestsFormat`
  - debug log file name: `GooseDefault::DebugFile`
  - debug log file format: `GooseDefault::DebugFormat`
  - host to bind Manager to: `GooseDefault::ManagerBindHost`

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Metrics:
   --no-reset-metrics         Doesn't reset metrics after all users have started
   --no-metrics               Doesn't track metrics
   --no-task-metrics          Doesn't track task metrics
-  -m, --metrics-file NAME    Sets metrics log file name
+  -m, --requests-file NAME   Sets requests log file name
   --metrics-format FORMAT    Sets metrics log format (csv, json, raw)
   -d, --debug-file NAME      Sets debug log file name
   --debug-format FORMAT      Sets debug log format (json, raw)
@@ -385,7 +385,7 @@ All run-time options can be configured with custom defaults. For example, you ma
 The following defaults can be configured with a `&str`:
  - host: `GooseDefault::Host`
  - log file name: `GooseDefault::LogFile`
- - metrics log file name: `GooseDefault::MetricsFile`
+ - requests log file name: `GooseDefault::RequestsFile`
  - metrics log file format: `GooseDefault::MetricsFormat`
  - debug log file name: `GooseDefault::DebugFile`
  - debug log file format: `GooseDefault::DebugFormat`
@@ -422,7 +422,7 @@ For example, without any run-time options the following load test would automati
             .register_task(task!(loadtest_index))
         )
         .set_default(GooseDefault::Host, "local.dev")?
-        .set_default(GooseDefault::MetricsFile, "goose-metrics.log")?
+        .set_default(GooseDefault::RequestsFile, "goose-requests.log")?
         .set_default(GooseDefault::DebugFile, "goose-debug.log")?
         .set_default(GooseDefault::Users, 20)?
         .set_default(GooseDefault::HatchRate, 4)?
@@ -447,11 +447,11 @@ $ cargo run --example simple -- --host http://local.dev/ -u100 -r20 -v --throttl
 
 In this example, Goose will launch 100 GooseUser threads, but the throttle will prevent them from generating a combined total of more than 5 requests per second. The `--throttle-requests` command line option imposes a maximum number of requests, not a minimum number of requests.
 
-## Logging Load Test Metrics
+## Logging Load Test Requests
 
-Goose can optionally log details about all load test requests to a file. To enable, add the `--metrics-log-file=foo` command line option, where `foo` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
+Goose can optionally log details about all load test requests to a file. To enable, add the `--requests-file=foo` command line option, where `foo` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
 
-When operating in Gaggle-mode, the `--metrics-log-file` option can only be enabled on the Worker processes, configuring Goose to spread out the overhead of writing logs.
+When operating in Gaggle-mode, the `--requests--file` option can only be enabled on the Worker processes, configuring Goose to spread out the overhead of writing logs.
 
 By default, logs are written in JSON Lines format. For example:
 
@@ -477,7 +477,7 @@ Logs include the entire `GooseRawRequest` object as defined in `src/goose.rs`, w
 
 In the first line of the above example, `GooseUser` thread 0 made a `POST` request to `/login` and was successfully redirected to `/user/42` in 220 milliseconds. The second line is the same `GooseUser` thread which then made a `GET` request to `/` in 3 milliseconds. The third and fourth lines are a second `GooseUser` thread doing the same thing, first logging in and then loading the front page.
 
-By default Goose logs metrics in JSON Lines format. The `--metrics-log-format` option can be used to log in `csv`, `json` or `raw` format. The `raw` format is Rust's debug output of the entire `GooseRawRequest` object.
+By default Goose logs requests in JSON Lines format. The `--metrics-log-format` option can be used to log in `csv`, `json` or `raw` format. The `raw` format is Rust's debug output of the entire `GooseRawRequest` object.
 
 For example, `csv` output of the same requests logged above would look like:
 ```csv

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,7 +631,7 @@ pub struct GooseDefaults {
     /// An optional default for not tracking task metrics.
     no_task_metrics: Option<bool>,
     /// An optional default for the metrics log file name.
-    metrics_file: Option<String>,
+    requests_file: Option<String>,
     /// An optional default for the metrics log file format.
     metrics_format: Option<String>,
     /// An optional default for the debug log file name.
@@ -689,7 +689,7 @@ pub enum GooseDefault {
     /// An optional default for not tracking task metrics.
     NoTaskMetrics,
     /// An optional default for the metrics log file name.
-    MetricsFile,
+    RequestsFile,
     /// An optional default for the metrics log file format.
     MetricsFormat,
     /// An optional default for the debug log file name.
@@ -750,7 +750,7 @@ pub struct GooseAttackRunState {
     /// Optional sender for throttle thread, if enabled.
     parent_to_throttle_tx: Option<mpsc::Sender<bool>>,
     /// Optional buffered writer for metrics log file, if enabled.
-    metrics_file: Option<BufWriter<File>>,
+    requests_file: Option<BufWriter<File>>,
     /// A flag tracking whether or not the header has been written when the metrics
     /// log is enabled.
     metrics_header_displayed: bool,
@@ -1842,12 +1842,12 @@ impl GooseAttack {
             }
 
             // There is nothing to log if metrics are disabled.
-            if !self.configuration.metrics_file.is_empty() {
+            if !self.configuration.requests_file.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: key.to_string(),
                     value: value.to_string(),
                     detail: format!(
-                        "{} can not be set together with the --metrics-file option.",
+                        "{} can not be set together with the --requests-file option.",
                         key
                     ),
                 });
@@ -1920,25 +1920,25 @@ impl GooseAttack {
         Ok(())
     }
 
-    // If enabled, returns the path of the metrics_file, otherwise returns None.
-    fn get_metrics_file_path(&mut self) -> Result<Option<&str>, GooseError> {
+    // If enabled, returns the path of the requests_file, otherwise returns None.
+    fn get_requests_file_path(&mut self) -> Result<Option<&str>, GooseError> {
         // If metrics are disabled, or running in Manager mode, there is no
-        // metrics file, exit immediately.
+        // requests file, exit immediately.
         if self.configuration.no_metrics || self.attack_mode == AttackMode::Manager {
             return Ok(None);
         }
 
-        // If --metrics-file is set, return it.
-        if !self.configuration.metrics_file.is_empty() {
-            return Ok(Some(&self.configuration.metrics_file));
+        // If --requests-file is set, return it.
+        if !self.configuration.requests_file.is_empty() {
+            return Ok(Some(&self.configuration.requests_file));
         }
 
         // If GooseDefault::MetricFile is set, return it.
-        if let Some(default_metrics_file) = &self.defaults.metrics_file {
-            return Ok(Some(default_metrics_file));
+        if let Some(default_requests_file) = &self.defaults.requests_file {
+            return Ok(Some(default_requests_file));
         }
 
-        // Otherwise there is no metrics file.
+        // Otherwise there is no requests file.
         Ok(None)
     }
 
@@ -1960,11 +1960,11 @@ impl GooseAttack {
                 });
             }
             // Log format isn't relevant if log not enabled.
-            else if self.get_metrics_file_path()?.is_none() {
+            else if self.get_requests_file_path()?.is_none() {
                 return Err(GooseError::InvalidOption {
                     option: "--metrics-format".to_string(),
                     value: self.configuration.metrics_format.clone(),
-                    detail: "The --metrics-file option must be set together with the --metrics-format option.".to_string(),
+                    detail: "The --requests-file option must be set together with the --metrics-format option.".to_string(),
                 });
             }
         }
@@ -1984,7 +1984,7 @@ impl GooseAttack {
         Ok(())
     }
 
-    // If enabled, returns the path of the metrics_file, otherwise returns None.
+    // If enabled, returns the path of the requests_file, otherwise returns None.
     fn get_debug_file_path(&self) -> Result<Option<&str>, GooseError> {
         // If running in Manager mode there is no debug file, exit immediately.
         if self.attack_mode == AttackMode::Manager {
@@ -2409,11 +2409,11 @@ impl GooseAttack {
         (Some(all_threads_throttle), Some(parent_to_throttle_tx))
     }
 
-    // Prepare an asynchronous buffered file writer for metrics_file (if enabled).
-    async fn prepare_metrics_file(&mut self) -> Result<Option<BufWriter<File>>, GooseError> {
-        if let Some(metrics_file_path) = self.get_metrics_file_path()? {
+    // Prepare an asynchronous buffered file writer for requests_file (if enabled).
+    async fn prepare_requests_file(&mut self) -> Result<Option<BufWriter<File>>, GooseError> {
+        if let Some(requests_file_path) = self.get_requests_file_path()? {
             Ok(Some(BufWriter::new(
-                File::create(&metrics_file_path).await?,
+                File::create(&requests_file_path).await?,
             )))
         } else {
             Ok(None)
@@ -2513,7 +2513,7 @@ impl GooseAttack {
             all_threads_debug_logger_tx,
             throttle_threads_tx,
             parent_to_throttle_tx,
-            metrics_file: self.prepare_metrics_file().await.unwrap(),
+            requests_file: self.prepare_requests_file().await.unwrap(),
             metrics_header_displayed: false,
             users: Vec::new(),
             user_channels: Vec::new(),
@@ -2951,12 +2951,12 @@ impl GooseAttack {
         self.run_test_stop().await?;
 
         // If metrics logging is enabled, flush all metrics before we exit.
-        if let Some(file) = goose_attack_run_state.metrics_file.as_mut() {
+        if let Some(file) = goose_attack_run_state.requests_file.as_mut() {
             info!(
-                "flushing metrics_file: {}",
-                // Unwrap is safe as we can't get here unless a metrics file path
+                "flushing requests_file: {}",
+                // Unwrap is safe as we can't get here unless a requests file path
                 // is defined.
-                self.get_metrics_file_path()?.unwrap()
+                self.get_requests_file_path()?.unwrap()
             );
             let _ = file.flush().await;
         };
@@ -3024,15 +3024,15 @@ impl GooseAttack {
                         "raw" => format!("{:?}", raw_request),
                         _ => unreachable!(),
                     };
-                    if let Some(file) = goose_attack_run_state.metrics_file.as_mut() {
+                    if let Some(file) = goose_attack_run_state.requests_file.as_mut() {
                         match file.write(format!("{}\n", formatted_log).as_ref()).await {
                             Ok(_) => (),
                             Err(e) => {
                                 warn!(
                                     "failed to write metrics to {}: {}",
-                                    // Unwrap is safe as we can't get here unless a metrics file path
+                                    // Unwrap is safe as we can't get here unless a requests file path
                                     // is defined.
-                                    self.get_metrics_file_path()?.unwrap(),
+                                    self.get_requests_file_path()?.unwrap(),
                                     e
                                 );
                             }
@@ -3107,7 +3107,7 @@ impl GooseAttack {
 /// borrowed string slice (`&str`):
 ///  - GooseDefault::Host
 ///  - GooseDefault::LogFile
-///  - GooseDefault::MetricsFile
+///  - GooseDefault::RequestsFile
 ///  - GooseDefault::MetricsFormat
 ///  - GooseDefault::DebugFile
 ///  - GooseDefault::DebugFormat
@@ -3147,7 +3147,7 @@ impl GooseAttack {
 ///     GooseAttack::initialize()?
 ///         .set_default(GooseDefault::NoResetMetrics, true)?
 ///         .set_default(GooseDefault::Verbose, 1)?
-///         .set_default(GooseDefault::MetricsFile, "goose-metrics.log")?;
+///         .set_default(GooseDefault::RequestsFile, "goose-metrics.log")?;
 ///
 ///     Ok(())
 /// }
@@ -3162,7 +3162,7 @@ impl GooseDefaultType<&str> for GooseAttack {
             GooseDefault::HatchRate => self.defaults.hatch_rate = Some(value.to_string()),
             GooseDefault::Host => self.defaults.host = Some(value.to_string()),
             GooseDefault::LogFile => self.defaults.log_file = Some(value.to_string()),
-            GooseDefault::MetricsFile => self.defaults.metrics_file = Some(value.to_string()),
+            GooseDefault::RequestsFile => self.defaults.requests_file = Some(value.to_string()),
             GooseDefault::MetricsFormat => self.defaults.metrics_format = Some(value.to_string()),
             GooseDefault::DebugFile => self.defaults.debug_file = Some(value.to_string()),
             GooseDefault::DebugFormat => self.defaults.debug_format = Some(value.to_string()),
@@ -3221,7 +3221,7 @@ impl GooseDefaultType<usize> for GooseAttack {
             GooseDefault::Host
             | GooseDefault::HatchRate
             | GooseDefault::LogFile
-            | GooseDefault::MetricsFile
+            | GooseDefault::RequestsFile
             | GooseDefault::MetricsFormat
             | GooseDefault::DebugFile
             | GooseDefault::DebugFormat
@@ -3273,7 +3273,7 @@ impl GooseDefaultType<bool> for GooseAttack {
             // Otherwise display a helpful and explicit error.
             GooseDefault::Host
             | GooseDefault::LogFile
-            | GooseDefault::MetricsFile
+            | GooseDefault::RequestsFile
             | GooseDefault::MetricsFormat
             | GooseDefault::RunningMetrics
             | GooseDefault::DebugFile
@@ -3363,9 +3363,9 @@ pub struct GooseConfiguration {
     /// Doesn't track task metrics
     #[options(no_short)]
     pub no_task_metrics: bool,
-    /// Sets metrics log file name
+    /// Sets requests log file name
     #[options(short = "m", meta = "NAME")]
-    pub metrics_file: String,
+    pub requests_file: String,
     /// Sets metrics log format (csv, json, raw)
     #[options(no_short, meta = "FORMAT")]
     pub metrics_format: String,
@@ -3669,7 +3669,7 @@ mod test {
         let log_level: usize = 1;
         let log_file = "custom-goose.log".to_string();
         let verbose: usize = 0;
-        let metrics_file = "custom-goose-metrics.log".to_string();
+        let requests_file = "custom-goose-metrics.log".to_string();
         let metrics_format = "raw".to_string();
         let debug_file = "custom-goose-debug.log".to_string();
         let debug_format = "raw".to_string();
@@ -3704,7 +3704,7 @@ mod test {
             .unwrap()
             .set_default(GooseDefault::NoTaskMetrics, true)
             .unwrap()
-            .set_default(GooseDefault::MetricsFile, metrics_file.as_str())
+            .set_default(GooseDefault::RequestsFile, requests_file.as_str())
             .unwrap()
             .set_default(GooseDefault::MetricsFormat, metrics_format.as_str())
             .unwrap()
@@ -3749,7 +3749,7 @@ mod test {
         assert!(goose_attack.defaults.no_reset_metrics == Some(true));
         assert!(goose_attack.defaults.no_metrics == Some(true));
         assert!(goose_attack.defaults.no_task_metrics == Some(true));
-        assert!(goose_attack.defaults.metrics_file == Some(metrics_file));
+        assert!(goose_attack.defaults.requests_file == Some(requests_file));
         assert!(goose_attack.defaults.metrics_format == Some(metrics_format));
         assert!(goose_attack.defaults.debug_file == Some(debug_file));
         assert!(goose_attack.defaults.debug_format == Some(debug_format));

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -214,9 +214,9 @@ pub async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     worker_goose_attack.run_time = run_time;
     worker_goose_attack.weighted_users = weighted_users;
     worker_goose_attack.configuration.worker = true;
-    // The metrics_file option is configured on the Worker.
-    worker_goose_attack.configuration.metrics_file =
-        goose_attack.configuration.metrics_file.to_string();
+    // The requests_file option is configured on the Worker.
+    worker_goose_attack.configuration.requests_file =
+        goose_attack.configuration.requests_file.to_string();
     // The metrics_format option is configured on the Worker.
     worker_goose_attack.configuration.metrics_format =
         goose_attack.configuration.metrics_format.to_string();

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -187,7 +187,7 @@ fn test_defaults() {
         .unwrap()
         .set_default(GooseDefault::RequestsFile, requests_file.as_str())
         .unwrap()
-        .set_default(GooseDefault::MetricsFormat, LOG_FORMAT)
+        .set_default(GooseDefault::RequestsFormat, LOG_FORMAT)
         .unwrap()
         .set_default(GooseDefault::DebugFile, debug_file.as_str())
         .unwrap()
@@ -273,7 +273,7 @@ fn test_defaults_gaggle() {
                 .unwrap()
                 .set_default(GooseDefault::RequestsFile, worker_requests_file.as_str())
                 .unwrap()
-                .set_default(GooseDefault::MetricsFormat, LOG_FORMAT)
+                .set_default(GooseDefault::RequestsFormat, LOG_FORMAT)
                 .unwrap()
                 // Worker configuration using defaults instead of run-time options.
                 .set_default(GooseDefault::Worker, true)

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -76,7 +76,7 @@ fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
 fn validate_test(
     goose_metrics: GooseMetrics,
     mock_endpoints: &[MockRef],
-    metrics_files: &[String],
+    requests_files: &[String],
     debug_files: &[String],
 ) {
     // Confirm that we loaded the mock endpoints. This confirms that we started
@@ -113,9 +113,9 @@ fn validate_test(
 
     // Verify that the metrics file was created and has the correct number of lines.
     let mut metrics_lines = 0;
-    for metrics_file in metrics_files {
-        assert!(std::path::Path::new(metrics_file).exists());
-        metrics_lines += common::file_length(metrics_file);
+    for requests_file in requests_files {
+        assert!(std::path::Path::new(requests_file).exists());
+        metrics_lines += common::file_length(requests_file);
     }
     assert!(
         metrics_lines
@@ -135,11 +135,11 @@ fn validate_test(
     // Be sure there were no more requests made than the throttle should allow.
     // In the case of a gaggle, there's multiple processes running with the same
     // throttle.
-    let number_of_processes = metrics_files.len();
+    let number_of_processes = requests_files.len();
     assert!(metrics_lines <= (RUN_TIME + 1) * THROTTLE_REQUESTS * number_of_processes);
 
     // Cleanup from test.
-    for file in metrics_files {
+    for file in requests_files {
         common::cleanup_files(vec![file]);
     }
     for file in debug_files {
@@ -151,11 +151,11 @@ fn validate_test(
 // Configure load test with set_default.
 fn test_defaults() {
     // Multiple tests run together, so set a unique name.
-    let metrics_file = "defaults-".to_string() + METRICS_FILE;
+    let requests_file = "defaults-".to_string() + METRICS_FILE;
     let debug_file = "defaults-".to_string() + DEBUG_FILE;
 
     // Be sure there's no files left over from an earlier test.
-    common::cleanup_files(vec![&metrics_file, &debug_file]);
+    common::cleanup_files(vec![&requests_file, &debug_file]);
 
     let server = MockServer::start();
 
@@ -185,7 +185,7 @@ fn test_defaults() {
         .unwrap()
         .set_default(GooseDefault::LogLevel, LOG_LEVEL)
         .unwrap()
-        .set_default(GooseDefault::MetricsFile, metrics_file.as_str())
+        .set_default(GooseDefault::RequestsFile, requests_file.as_str())
         .unwrap()
         .set_default(GooseDefault::MetricsFormat, LOG_FORMAT)
         .unwrap()
@@ -213,7 +213,7 @@ fn test_defaults() {
     validate_test(
         goose_metrics,
         &mock_endpoints,
-        &[metrics_file],
+        &[requests_file],
         &[debug_file],
     );
 }
@@ -224,12 +224,12 @@ fn test_defaults() {
 // Configure load test with set_default, run as Gaggle.
 fn test_defaults_gaggle() {
     // Multiple tests run together, so set a unique name.
-    let metrics_file = "gaggle-defaults".to_string() + METRICS_FILE;
+    let requests_file = "gaggle-defaults".to_string() + METRICS_FILE;
     let debug_file = "gaggle-defaults".to_string() + DEBUG_FILE;
 
     // Be sure there's no files left over from an earlier test.
     for i in 0..EXPECT_WORKERS {
-        let file = metrics_file.to_string() + &i.to_string();
+        let file = requests_file.to_string() + &i.to_string();
         common::cleanup_files(vec![&file]);
         let file = debug_file.to_string() + &i.to_string();
         common::cleanup_files(vec![&file]);
@@ -255,7 +255,7 @@ fn test_defaults_gaggle() {
     let mut worker_handles = Vec::new();
     for i in 0..EXPECT_WORKERS {
         let worker_configuration = configuration.clone();
-        let worker_metrics_file = metrics_file.clone() + &i.to_string();
+        let worker_requests_file = requests_file.clone() + &i.to_string();
         let worker_debug_file = debug_file.clone() + &i.to_string();
         worker_handles.push(std::thread::spawn(move || {
             let _ = crate::GooseAttack::initialize_with_config(worker_configuration)
@@ -271,7 +271,7 @@ fn test_defaults_gaggle() {
                 .unwrap()
                 .set_default(GooseDefault::NoDebugBody, true)
                 .unwrap()
-                .set_default(GooseDefault::MetricsFile, worker_metrics_file.as_str())
+                .set_default(GooseDefault::RequestsFile, worker_requests_file.as_str())
                 .unwrap()
                 .set_default(GooseDefault::MetricsFormat, LOG_FORMAT)
                 .unwrap()
@@ -329,26 +329,31 @@ fn test_defaults_gaggle() {
         let _ = worker_handle.join();
     }
 
-    let mut metrics_files: Vec<String> = vec![];
+    let mut requests_files: Vec<String> = vec![];
     let mut debug_files: Vec<String> = vec![];
     for i in 0..EXPECT_WORKERS {
-        let file = metrics_file.to_string() + &i.to_string();
-        metrics_files.push(file);
+        let file = requests_file.to_string() + &i.to_string();
+        requests_files.push(file);
         let file = debug_file.to_string() + &i.to_string();
         debug_files.push(file);
     }
-    validate_test(goose_metrics, &mock_endpoints, &metrics_files, &debug_files);
+    validate_test(
+        goose_metrics,
+        &mock_endpoints,
+        &requests_files,
+        &debug_files,
+    );
 }
 
 #[test]
 // Configure load test with run time options (not with defaults).
 fn test_no_defaults() {
     // Multiple tests run together, so set a unique name.
-    let metrics_file = "nodefaults-".to_string() + METRICS_FILE;
+    let requests_file = "nodefaults-".to_string() + METRICS_FILE;
     let debug_file = "nodefaults-".to_string() + DEBUG_FILE;
 
     // Be sure there's no files left over from an earlier test.
-    common::cleanup_files(vec![&metrics_file, &debug_file]);
+    common::cleanup_files(vec![&requests_file, &debug_file]);
 
     let server = MockServer::start();
 
@@ -364,8 +369,8 @@ fn test_no_defaults() {
             &HATCH_RATE.to_string(),
             "--run-time",
             &RUN_TIME.to_string(),
-            "--metrics-file",
-            &metrics_file,
+            "--requests-file",
+            &requests_file,
             "--metrics-format",
             LOG_FORMAT,
             "--debug-file",
@@ -394,7 +399,7 @@ fn test_no_defaults() {
     validate_test(
         goose_metrics,
         &mock_endpoints,
-        &[metrics_file],
+        &[requests_file],
         &[debug_file],
     );
 }
@@ -404,12 +409,12 @@ fn test_no_defaults() {
 #[serial]
 // Configure load test with run time options (not with defaults), run as Gaggle.
 fn test_no_defaults_gaggle() {
-    let metrics_file = "gaggle-nodefaults".to_string() + METRICS_FILE;
+    let requests_file = "gaggle-nodefaults".to_string() + METRICS_FILE;
     let debug_file = "gaggle-nodefaults".to_string() + DEBUG_FILE;
 
     // Be sure there's no files left over from an earlier test.
     for i in 0..EXPECT_WORKERS {
-        let file = metrics_file.to_string() + &i.to_string();
+        let file = requests_file.to_string() + &i.to_string();
         common::cleanup_files(vec![&file]);
         let file = debug_file.to_string() + &i.to_string();
         common::cleanup_files(vec![&file]);
@@ -426,7 +431,7 @@ fn test_no_defaults_gaggle() {
     // Launch workers in their own threads, storing the thread handle.
     let mut worker_handles = Vec::new();
     for i in 0..EXPECT_WORKERS {
-        let worker_metrics_file = metrics_file.to_string() + &i.to_string();
+        let worker_requests_file = requests_file.to_string() + &i.to_string();
         let worker_debug_file = debug_file.to_string() + &i.to_string();
         let worker_configuration = common::build_configuration(
             &server,
@@ -436,8 +441,8 @@ fn test_no_defaults_gaggle() {
                 &HOST.to_string(),
                 "--manager-port",
                 &PORT.to_string(),
-                "--metrics-file",
-                &worker_metrics_file,
+                "--requests-file",
+                &worker_requests_file,
                 "--metrics-format",
                 LOG_FORMAT,
                 "--debug-file",
@@ -497,15 +502,20 @@ fn test_no_defaults_gaggle() {
         let _ = worker_handle.join();
     }
 
-    let mut metrics_files: Vec<String> = vec![];
+    let mut requests_files: Vec<String> = vec![];
     let mut debug_files: Vec<String> = vec![];
     for i in 0..EXPECT_WORKERS {
-        let file = metrics_file.to_string() + &i.to_string();
-        metrics_files.push(file);
+        let file = requests_file.to_string() + &i.to_string();
+        requests_files.push(file);
         let file = debug_file.to_string() + &i.to_string();
         debug_files.push(file);
     }
-    validate_test(goose_metrics, &mock_endpoints, &metrics_files, &debug_files);
+    validate_test(
+        goose_metrics,
+        &mock_endpoints,
+        &requests_files,
+        &debug_files,
+    );
 }
 
 #[test]


### PR DESCRIPTION
 - Goose can optionally generate a log of all requests it makes, which is confusingly referred to as the "metrics file"; this PR renames it more accurately to the "requests file"
 - rename `--metrics-file` to `--requests-file`
 - rename `--metrics-format` to `--requests-format`
 - fixes #226 