### PR TITLE
update umami example for any version of Drupal 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.10.8-dev
  - introduce `--report-file` (and `GooseDefault::ReportFile`) to optionally generate an HTML report when the load test completes
  - upgrade to `tokio` 1.x, and switch to `flume` for all multi-producer, multi-consumer channels
+ - make `examples/umami` more generic for easier load testing of any Drupal 9 version of the demo install profile
 
 ## 0.10.7 Nov 16, 2020
  - account for time spent doing things other than sleeping, maintaining more consistency when displaying statistics and shutting down

--- a/examples/umami/README.md
+++ b/examples/umami/README.md
@@ -6,7 +6,7 @@ https://www.drupal.org/docs/umami-drupal-demonstration-installation-profile
 The load test was developed using a locally hosted Drupal 9 install hosted in a DDEV container:
 https://www.ddev.com/
 
-By default it will try and load pages from https://drupal-9.0.7.ddev.site/.
+By default it will try and load pages from https://drupal-9.ddev.site/. Use the `--host` flag to specify a different domain to load test.
 
 ## Load Test Implementation
 
@@ -48,5 +48,5 @@ Each admin load test user logs in one time in English, and then runs the followi
  The load test needs to know what username and password to use to log in. By default it will attempt to log in with the username `admin` and the password `P@ssw0rd1234`. However, you can use the ADMIN_USERNAME and/or ADMIN_PASSWORD environment variables to log in with different values. In the following example, the load test will attempt to log in with the username `foo` and the password `bar`:
 
  ```
- ADMIN_USERNAME=foo ADMIN_PASSWORD=bar cargo run --release --example umami -- -H https://drupal-9.0.7.ddev.site -v -u50
+ ADMIN_USERNAME=foo ADMIN_PASSWORD=bar cargo run --release --example umami -- -H https://drupal-9.ddev.site -v -u150
  ```

--- a/examples/umami/main.rs
+++ b/examples/umami/main.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), GooseError> {
                         .set_weight(2)?,
                 ),
         )
-        .set_default(GooseDefault::Host, "https://drupal-9.0.7.ddev.site/")?
+        .set_default(GooseDefault::Host, "https://drupal-9.ddev.site/")?
         .execute()?
         .print();
 


### PR DESCRIPTION
Update umami example to suggest any version of Drupal 9, not just Drupal 9.0.7. (Changes to later versions of the Umami install profile may require setting a minimum version at some time.)