### PR TITLE
respect hatch rate when launching gaggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.9-dev
  - avoid unnecessary work on Manager when starting a Gaggle
+ - respect `--hatch-rate` when starting a Gaggle mode
 
 ## 0.10.8 Feb 13, 2021
  - introduce `--report-file` (and `GooseDefault::ReportFile`) to optionally generate an HTML report when the load test completes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2967,7 +2967,7 @@ impl GooseAttack {
         Ok(())
     }
 
-    // If metrics are enabled, synchronize metrics from child reads to the parent.
+    // If metrics are enabled, synchronize metrics from child threads to the parent.
     async fn sync_metrics(
         &mut self,
         goose_attack_run_state: &mut GooseAttackRunState,
@@ -3424,10 +3424,10 @@ impl GooseAttack {
 
         // Start a timer to track when to next synchronize the metrics.
         let mut sync_metrics_timer = std::time::Instant::now();
-        // Sync at least as often as we display metrics, or every five seconds.
-        let mut sync_every = self.configuration.running_metrics.unwrap_or(5);
-        if sync_every > 5 {
-            sync_every = 5;
+        // Sync at least as often as we display metrics, or every ten seconds.
+        let mut sync_every = self.configuration.running_metrics.unwrap_or(10);
+        if sync_every > 10 {
+            sync_every = 10;
         }
 
         loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3424,6 +3424,12 @@ impl GooseAttack {
 
         // Start a timer to track when to next synchronize the metrics.
         let mut sync_metrics_timer = std::time::Instant::now();
+        // Sync at least as often as we display metrics, or every five seconds.
+        let mut sync_every = self.configuration.running_metrics.unwrap_or(5);
+        if sync_every > 5 {
+            sync_every = 5;
+        }
+
         loop {
             match self.attack_phase {
                 // Start spawning GooseUser threads.
@@ -3442,8 +3448,8 @@ impl GooseAttack {
                 }
                 _ => panic!("GooseAttack entered an impossible phase"),
             }
-            // If five seconds has elapsed synchronize the metrics.
-            if util::timer_expired(sync_metrics_timer, 5) {
+            // Synchronize metrics if enough time has elapsed.
+            if util::timer_expired(sync_metrics_timer, sync_every) {
                 self.sync_metrics(&mut goose_attack_run_state).await?;
                 sync_metrics_timer = std::time::Instant::now();
             }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -536,8 +536,8 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                         break;
                     }
                     if !load_test_finished {
-                        // Sleep half a second then return to the loop.
-                        thread::sleep(time::Duration::from_millis(500));
+                        // Sleep a tenth of a second then return to the loop.
+                        thread::sleep(time::Duration::from_millis(100));
                     }
                 } else {
                     panic!("error receiving user message: {}", e);


### PR DESCRIPTION
I originally assumed (incorrectly) that we weren't properly setting `hatch_rate` on the Workers. Instead what's happening is we're pushing metrics from the Workers to the Manager too frequently, and when running as a Gaggle we end up blocking waiting for the Manager to reply.

To solve:
- We make the Manager wake every 100ms instead of ever 500ms (so we minimize how often we block)
- We only synchronize the metrics at least as often as we display metrics, or at least once every five seconds
- We optimize serialization with `serde_cbor` by using a BufWriter

Fixes #253 