### PR TITLE
optimize time it takes to start a Gaggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.10.9-dev
+ - avoid unnecessary work on Manager when starting a Gaggle
 
 ## 0.10.8 Feb 13, 2021
  - introduce `--report-file` (and `GooseDefault::ReportFile`) to optionally generate an HTML report when the load test completes

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -883,6 +883,44 @@ impl GooseDebug {
     }
 }
 
+/// The elements needed to build an individual user state on a Gaggle Worker.
+#[derive(Debug, Clone)]
+pub struct GaggleUser {
+    /// An index into the internal `GooseTest.task_sets` vector, indicating which GooseTaskSet is running.
+    pub task_sets_index: usize,
+    /// The base URL to prepend to all relative paths.
+    pub base_url: Arc<RwLock<Url>>,
+    /// Minimum amount of time to sleep after running a task.
+    pub min_wait: usize,
+    /// Maximum amount of time to sleep after running a task.
+    pub max_wait: usize,
+    /// A local copy of the global GooseConfiguration.
+    pub config: GooseConfiguration,
+    /// Load test hash.
+    pub load_test_hash: u64,
+}
+impl GaggleUser {
+    /// Create a new user state.
+    pub fn new(
+        task_sets_index: usize,
+        base_url: Url,
+        min_wait: usize,
+        max_wait: usize,
+        configuration: &GooseConfiguration,
+        load_test_hash: u64,
+    ) -> Self {
+        trace!("new gaggle user");
+        GaggleUser {
+            task_sets_index,
+            base_url: Arc::new(RwLock::new(base_url)),
+            min_wait,
+            max_wait,
+            config: configuration.clone(),
+            load_test_hash,
+        }
+    }
+}
+
 /// An individual user state, repeatedly running all GooseTasks in a specific GooseTaskSet.
 #[derive(Debug, Clone)]
 pub struct GooseUser {


### PR DESCRIPTION
Fixes #252 

The Manager process allocates a bunch of GooseUser objects that are never actually used, they are re-allocated on the Workers. This PR is an optimization to avoid doing duplicate/wasted work.

- Don't allocate unnecessary GooseUser objects when determining which users get sent to Workers
- Thanks to [this thread](https://users.rust-lang.org/t/serde-cbor-very-slow-when-used-for-saving-and-loading-game-maps/36308/7) perform serde_cbor serialization in a BufWriter, drastically optimizing it
