### PR TITLE
add documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.10.9-dev
  - avoid unnecessary work on Manager when starting a Gaggle
- - respect `--hatch-rate` when starting a Gaggle mode
+ - respect `--hatch-rate` when starting a Gaggle
+ - update httpmock for running tests
+ - remove unnecessary `Result()` types where no error was possible
 
 ## 0.10.8 Feb 13, 2021
  - introduce `--report-file` (and `GooseDefault::ReportFile`) to optionally generate an HTML report when the load test completes

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Have you ever been attacked by a goose?
 
 Goose is a Rust load testing tool inspired by [Locust](https://locust.io/). User behavior is defined with standard Rust code. Load tests are applications that have a dependency on the Goose library. Web requests are made with the [Reqwest](https://docs.rs/reqwest) HTTP Client.
 
+### Documentation
+
+- [README](https://github.com/tag1consulting/goose/blob/main/README.md)
+- [Developer documentation](https://docs.rs/goose/)
+- [Blogs and more](https://tag1.com/goose/)
+  - [Goose vs Locust and jMeter](https://www.tag1consulting.com/blog/jmeter-vs-locust-vs-goose)
+  - [Real-life load testing with Goose](https://www.tag1consulting.com/blog/real-life-goose-load-testing)
+  - [Gaggle: a distributed load test](https://www.tag1consulting.com/blog/show-me-how-flock-flies-working-gaggle-goose)
+  - [Optimizing Goose performance](https://www.tag1consulting.com/blog/golden-goose-egg-compile-time-adventure)
+
 ## Getting Started
 
 The [in-line documentation](https://docs.rs/goose/*/goose/#creating-a-simple-goose-load-test) offers much more detail about Goose specifics. For a general background to help you get started with Rust and Goose, read on.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,16 @@
 //! Goose uses [`reqwest`](https://docs.rs/reqwest/) to provide a convenient HTTP
 //! client.
 //!
+//! ## Documentation
+//!
+//! - [README](https://github.com/tag1consulting/goose/blob/main/README.md)
+//! - [Developer documentation](https://docs.rs/goose/)
+//! - [Blogs and more](https://tag1.com/goose/)
+//!   - [Goose vs Locust and jMeter](https://www.tag1consulting.com/blog/jmeter-vs-locust-vs-goose)
+//!   - [Real-life load testing with Goose](https://www.tag1consulting.com/blog/real-life-goose-load-testing)
+//!   - [Gaggle: a distributed load test](https://www.tag1consulting.com/blog/show-me-how-flock-flies-working-gaggle-goose)
+//!   - [Optimizing Goose performance](https://www.tag1consulting.com/blog/golden-goose-egg-compile-time-adventure)
+//!
 //! ## Creating and running a Goose load test
 //!
 //! ### Creating a simple Goose load test


### PR DESCRIPTION
Fixes #184 

Add links to online documentation.

### Documentation

- [README](https://github.com/tag1consulting/goose/blob/main/README.md)
- [Developer documentation](https://docs.rs/goose/)
- [Blogs and more](https://tag1.com/goose/)
  - [Goose vs Locust and jMeter](https://www.tag1consulting.com/blog/jmeter-vs-locust-vs-goose)
  - [Real-life load testing with Goose](https://www.tag1consulting.com/blog/real-life-goose-load-testing)
  - [Gaggle: a distributed load test](https://www.tag1consulting.com/blog/show-me-how-flock-flies-working-gaggle-goose)
  - [Optimizing Goose performance](https://www.tag1consulting.com/blog/golden-goose-egg-compile-time-adventure)