### PR TITLE
count and aggregate errors, display with metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.10.10-dev
+ - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`
 
 ## 0.10.9 March 23, 2021
  - avoid unnecessary work on Manager when starting a Gaggle

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1532,6 +1532,7 @@ impl GooseUser {
                 // @TODO: match/handle all is_foo() https://docs.rs/http/0.2.1/http/status/struct.StatusCode.html
                 if !status_code.is_success() {
                     raw_request.success = false;
+                    raw_request.error = format!("{}: {}", status_code, &path);
                 }
                 raw_request.set_status_code(Some(status_code));
                 raw_request.set_final_url(r.url().as_str());

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1665,6 +1665,11 @@ impl GooseUser {
     /// parameters, `header` and `body`, are optional and used to provide more detail in
     /// logs.
     ///
+    /// The value of `tag` will normally be collected into the errors summary table if
+    /// metrics are being displayed. However, if `set_failure` is called multiple times,
+    /// or is called on a request that was already an error, only the first error will
+    /// be collected.
+    ///
     /// This also calls
     /// [`log_debug`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.log_debug).
     ///
@@ -1711,6 +1716,7 @@ impl GooseUser {
         if request.success {
             request.success = false;
             request.update = true;
+            request.error = tag.to_string();
             self.send_to_parent(GooseMetric::Request(request.clone()))?;
         }
         // Write failure to log, converting `&mut request` to `&request` as needed by `log_debug()`.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -669,6 +669,8 @@ pub struct GooseRawRequest {
     pub update: bool,
     /// Which GooseUser thread processed the request.
     pub user: usize,
+    /// The optional error caused by this request.
+    pub error: String,
 }
 impl GooseRawRequest {
     pub fn new(method: GooseMethod, name: &str, url: &str, elapsed: u128, user: usize) -> Self {
@@ -684,6 +686,7 @@ impl GooseRawRequest {
             success: true,
             update: false,
             user,
+            error: "".to_string(),
         }
     }
 
@@ -1556,6 +1559,7 @@ impl GooseUser {
                 warn!("{:?}: {}", &path, e);
                 raw_request.success = false;
                 raw_request.set_status_code(None);
+                raw_request.error = e.to_string();
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3145,8 +3145,8 @@ impl GooseAttack {
             );
             let _ = file.flush().await;
         };
-        // Only display percentile once the load test is finished.
-        self.metrics.display_percentile = true;
+        // Percentile and errors are only displayed when the load test is finished.
+        self.metrics.final_metrics = true;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3444,11 +3444,13 @@ impl GooseAttack {
                 &start_time,
                 &end_time,
                 &host,
-                &requests_rows.join("\n"),
-                &responses_rows.join("\n"),
-                &tasks_template,
-                &status_code_template,
-                &errors_template,
+                report::GooseReportTemplates {
+                    requests_template: &requests_rows.join("\n"),
+                    responses_template: &responses_rows.join("\n"),
+                    tasks_template: &tasks_template,
+                    status_codes_template: &status_code_template,
+                    errors_template: &errors_template,
+                },
             );
 
             // Write the report to file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3545,7 +3545,6 @@ impl GooseAttack {
 
                     // If there was an error, store it.
                     if !raw_request.error.is_empty() {
-                        // Add or update the GooseErrorMetric
                         self.record_error(&raw_request);
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3373,6 +3373,18 @@ impl GooseAttack {
                 tasks_template = "".to_string();
             }
 
+            // Only build the tasks template if --no-task-metrics isn't enabled.
+            let errors_template: String;
+            if !self.metrics.errors.is_empty() {
+                let mut error_rows = Vec::new();
+                for error in self.metrics.errors.values() {
+                    error_rows.push(report::error_row(error));
+                }
+                errors_template = report::errors_template(&error_rows.join("\n"));
+            } else {
+                errors_template = "".to_string();
+            }
+
             // Only build the status_code template if --status-codes is enabled.
             let status_code_template: String;
             if self.configuration.status_codes {
@@ -3436,6 +3448,7 @@ impl GooseAttack {
                 &responses_rows.join("\n"),
                 &tasks_template,
                 &status_code_template,
+                &errors_template,
             );
 
             // Write the report to file.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -219,9 +219,9 @@ pub struct GooseMetrics {
     pub tasks: GooseTaskMetrics,
     /// Error-related metrics.
     pub errors: BTreeMap<String, GooseErrorMetric>,
-    /// Flag indicating whether or not to display percentile. Because we're deriving Default,
-    /// this defaults to false.
-    pub display_percentile: bool,
+    /// Flag indicating whether or not these are the final metrics. Because we're deriving
+    /// Default, this defaults to false.
+    pub final_metrics: bool,
     /// Flag indicating whether or not to display status_codes. Because we're deriving Default,
     /// this defaults to false.
     pub display_status_codes: bool,
@@ -783,8 +783,8 @@ impl GooseMetrics {
 
     /// Optionally prepares a table of slowest response times within several percentiles.
     pub fn fmt_percentiles(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // If there's nothing to display, exit immediately.
-        if !self.display_percentile {
+        // Only include percentiles when displaying the final metrics report.
+        if !self.final_metrics {
             return Ok(());
         }
 
@@ -980,8 +980,9 @@ impl GooseMetrics {
 
     /// Optionally prepares a table of errors.
     pub fn fmt_errors(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // If there's nothing to display, exit immediately.
-        if self.errors.is_empty() {
+        // Only include errors when displaying the final metrics report, and if there are
+        // errors to display.
+        if !self.final_metrics || self.errors.is_empty() {
             return Ok(());
         }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -981,7 +981,7 @@ impl GooseMetrics {
             return Ok(());
         }
 
-        //pub errors: BTreeMap<String, GooseErrorMetric>,
+        // Write the errors into a vector which can then be sorted by occurrences.
         let mut errors: Vec<(usize, String)> = Vec::new();
         for (_description, error) in &self.errors {
             errors.push((
@@ -992,10 +992,10 @@ impl GooseMetrics {
 
         writeln!(
             fmt,
-            " ------------------------------------------------------------------------------"
+            "\n === ERRORS ===\n ------------------------------------------------------------------------------"
         )?;
-        writeln!(fmt, " {:<14} | {} ", "Count", "Error")?;
-        writeln!(
+        writeln!(fmt, " {:<14} | Error ", "Count")?;
+        write!(
             fmt,
             " ------------------------------------------------------------------------------"
         )?;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1002,12 +1002,7 @@ impl GooseMetrics {
 
         // Reverse sort errors to display the error occuring the most first.
         for (occurrences, error) in errors.iter().sorted().rev() {
-            writeln!(
-                fmt,
-                " {:<12}  {}",
-                format_number(occurrences.clone()),
-                error
-            )?;
+            writeln!(fmt, " {:<12}  {}", format_number(*occurrences), error)?;
         }
 
         writeln!(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -983,7 +983,7 @@ impl GooseMetrics {
 
         // Write the errors into a vector which can then be sorted by occurrences.
         let mut errors: Vec<(usize, String)> = Vec::new();
-        for (_description, error) in &self.errors {
+        for error in self.errors.values() {
             errors.push((
                 error.occurrences,
                 format!("{:?} {}: {}", error.method, error.name, error.error),
@@ -994,19 +994,25 @@ impl GooseMetrics {
             fmt,
             "\n === ERRORS ===\n ------------------------------------------------------------------------------"
         )?;
-        writeln!(fmt, " {:<14} | Error ", "Count")?;
-        write!(
+        writeln!(fmt, " {:<11} | Error", "Count")?;
+        writeln!(
             fmt,
             " ------------------------------------------------------------------------------"
         )?;
 
+        // Reverse sort errors to display the error occuring the most first.
         for (occurrences, error) in errors.iter().sorted().rev() {
-            print!("\n {:<14}  {}", occurrences, error);
+            writeln!(
+                fmt,
+                " {:<12}  {}",
+                format_number(occurrences.clone()),
+                error
+            )?;
         }
 
         writeln!(
             fmt,
-            "\n ------------------------------------------------------------------------------"
+            " ------------------------------------------------------------------------------"
         )?;
 
         Ok(())

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -19,6 +19,7 @@ use crate::GooseConfiguration;
 pub enum GooseMetric {
     Request(GooseRawRequest),
     Task(GooseRawTask),
+    Error(GooseErrorMetric),
 }
 
 /// Goose optionally tracks metrics about requests made during a load test.
@@ -26,6 +27,9 @@ pub type GooseRequestMetrics = HashMap<String, GooseRequest>;
 
 /// Goose optionally tracks metrics about tasks run during a load test.
 pub type GooseTaskMetrics = Vec<Vec<GooseTaskMetric>>;
+
+/// Goose optionally tracks errors generated during a load test.
+pub type GooseErrorMetrics = BTreeMap<String, GooseErrorMetric>;
 
 /// The per-task metrics collected each time a task is invoked.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/report.rs
+++ b/src/report.rs
@@ -246,6 +246,39 @@ pub fn task_metrics_row(metric: TaskMetric) -> String {
     }
 }
 
+/// If there are errors, add an errors table to the html report.
+pub fn errors_template(error_rows: &str) -> String {
+    format!(
+        r#"<div class="errors">
+        <h2>Errors</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th colspan="3">Error</th>
+                </tr>
+            </thead>
+            <tbody>
+                {error_rows}
+            </tbody>
+        </table>
+    </div>"#,
+        error_rows = error_rows,
+    )
+}
+
+/// Build an individual error row in the html report.
+pub fn error_row(error: &metrics::GooseErrorMetric) -> String {
+    format!(
+        r#"<tr>
+        <td>{occurrences}</td>
+        <td colspan="4">{error}</strong></td>
+    </tr>"#,
+        occurrences = error.occurrences,
+        error = error.error,
+    )
+}
+
 /// Build the html report.
 pub fn build_report(
     start_time: &str,
@@ -255,6 +288,7 @@ pub fn build_report(
     responses_template: &str,
     tasks_template: &str,
     status_codes_template: &str,
+    errors_template: &str,
 ) -> String {
     format!(
         r#"<!DOCTYPE html>
@@ -374,6 +408,8 @@ pub fn build_report(
 
         {tasks_template}
 
+        {errors_template}
+
     </div>
 </body>
 </html>"#,
@@ -384,5 +420,6 @@ pub fn build_report(
         responses_template = responses_template,
         tasks_template = tasks_template,
         status_codes_template = status_codes_template,
+        errors_template = errors_template,
     )
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,6 +7,16 @@ use std::mem;
 
 use serde::Serialize;
 
+/// The following templates are necessary to build an html-formatted summary report.
+#[derive(Debug)]
+pub struct GooseReportTemplates<'a> {
+    pub requests_template: &'a str,
+    pub responses_template: &'a str,
+    pub tasks_template: &'a str,
+    pub status_codes_template: &'a str,
+    pub errors_template: &'a str,
+}
+
 /// Defines the metrics reported about requests.
 #[derive(Debug, Clone, Serialize)]
 pub struct RequestMetric {
@@ -284,11 +294,7 @@ pub fn build_report(
     start_time: &str,
     end_time: &str,
     host: &str,
-    requests_template: &str,
-    responses_template: &str,
-    tasks_template: &str,
-    status_codes_template: &str,
-    errors_template: &str,
+    templates: GooseReportTemplates,
 ) -> String {
     format!(
         r#"<!DOCTYPE html>
@@ -416,10 +422,10 @@ pub fn build_report(
         start_time = start_time,
         end_time = end_time,
         host = host,
-        requests_template = requests_template,
-        responses_template = responses_template,
-        tasks_template = tasks_template,
-        status_codes_template = status_codes_template,
-        errors_template = errors_template,
+        requests_template = templates.requests_template,
+        responses_template = templates.responses_template,
+        tasks_template = templates.tasks_template,
+        status_codes_template = templates.status_codes_template,
+        errors_template = templates.errors_template,
     )
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -10,7 +10,7 @@ const EMPTY_ARGS: Vec<&str> = vec![];
 
 use crate::goose::{GooseUser, GooseUserCommand};
 use crate::manager::GooseUserInitializer;
-use crate::metrics::{GooseRequestMetrics, GooseTaskMetrics};
+use crate::metrics::{GooseErrorMetrics, GooseRequestMetrics, GooseTaskMetrics};
 use crate::{get_worker_id, AttackMode, GooseAttack, GooseConfiguration, WORKER_ID};
 
 /// Workers send GaggleMetrics to the Manager process to be aggregated together.
@@ -22,6 +22,8 @@ pub enum GaggleMetrics {
     Requests(GooseRequestMetrics),
     /// Goose task metrics.
     Tasks(GooseTaskMetrics),
+    /// Goose error metrics.
+    Errors(GooseErrorMetrics),
 }
 
 // If pipe closes unexpectedly, panic.

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,0 +1,257 @@
+use httpmock::{Method::GET, MockRef, MockServer};
+use serial_test::serial;
+
+mod common;
+
+use goose::goose::GooseMethod;
+use goose::prelude::*;
+use goose::GooseConfiguration;
+
+// Paths used in load tests performed during these tests.
+const INDEX_PATH: &str = "/";
+const A_404_PATH: &str = "/404";
+
+// Indexes to the above paths.
+const INDEX_KEY: usize = 0;
+const A_404_KEY: usize = 1;
+
+// Load test configuration.
+const EXPECT_WORKERS: usize = 2;
+
+// There are multiple test variations in this file.
+#[derive(Clone)]
+enum TestType {
+    // Enable --no-error-summary.
+    NoErrorSummary,
+    // Do not enable --no-error-summary.
+    ErrorSummary,
+}
+
+// Test task.
+pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
+    let _goose = user.get(INDEX_PATH).await?;
+    Ok(())
+}
+
+// Test task.
+pub async fn get_404_path(user: &GooseUser) -> GooseTaskResult {
+    let _goose = user.get(A_404_PATH).await?;
+    Ok(())
+}
+
+// All tests in this file run against common endpoints.
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
+    let mut endpoints: Vec<MockRef> = Vec::new();
+
+    // First set up INDEX_PATH, store in vector at INDEX_KEY.
+    endpoints.push(server.mock(|when, then| {
+        when.method(GET).path(INDEX_PATH);
+        then.status(200);
+    }));
+    // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
+    endpoints.push(server.mock(|when, then| {
+        when.method(GET).path(A_404_PATH);
+        then.status(404);
+    }));
+
+    endpoints
+}
+
+// Build appropriate configuration for these tests.
+fn common_build_configuration(server: &MockServer, custom: &mut Vec<&str>) -> GooseConfiguration {
+    // Common elements in all our tests.
+    let mut configuration = vec![
+        "--users",
+        "2",
+        "--hatch-rate",
+        "4",
+        "--run-time",
+        "2",
+        "--no-reset-metrics",
+    ];
+
+    // Custom elements in some tests.
+    configuration.append(custom);
+
+    // Return the resulting configuration.
+    common::build_configuration(&server, configuration)
+}
+
+// Helper to confirm all variations generate appropriate results.
+fn validate_error(
+    goose_metrics: &GooseMetrics,
+    mock_endpoints: &[MockRef],
+    configuration: &GooseConfiguration,
+    test_type: TestType,
+) {
+    // Confirm that we loaded the mock endpoints.
+    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
+    assert!(mock_endpoints[A_404_KEY].hits() > 0);
+
+    // Get request metrics.
+    let index_metrics = goose_metrics
+        .requests
+        .get(&format!("GET {}", INDEX_PATH))
+        .unwrap();
+    let a_404_metrics = goose_metrics
+        .requests
+        .get(&format!("GET {}", A_404_PATH))
+        .unwrap();
+
+    // Get error metrics.
+    let a_404_errors = goose_metrics.errors.clone();
+
+    // Confirm that the path and method are correct in the metrics.
+    assert!(index_metrics.path == INDEX_PATH);
+    assert!(index_metrics.method == GooseMethod::GET);
+    assert!(a_404_metrics.path == A_404_PATH);
+    assert!(a_404_metrics.method == GooseMethod::GET);
+
+    // All requests to the index succeeded.
+    mock_endpoints[INDEX_KEY].assert_hits(index_metrics.response_time_counter);
+    mock_endpoints[INDEX_KEY].assert_hits(index_metrics.success_count);
+    // All requests to the 404 page failed.
+    mock_endpoints[A_404_KEY].assert_hits(a_404_metrics.response_time_counter);
+    mock_endpoints[A_404_KEY].assert_hits(a_404_metrics.fail_count);
+
+    match test_type {
+        TestType::ErrorSummary => {
+            // The 404 path was captured as an error.
+            assert!(a_404_errors.len() == 1);
+            // Extract the error from the BTreeMap.
+            for error in a_404_errors {
+                // The captured error was a GET request.
+                assert!(error.1.method == GooseMethod::GET);
+                // The captured error was for the 404 path.
+                assert!(error.1.name == A_404_PATH);
+                // The error was captured the number of times we requested the 404 path.
+                assert!(error.1.occurrences == a_404_metrics.fail_count);
+            }
+        }
+        TestType::NoErrorSummary => {
+            // Goose was configured to not capture any errors.
+            assert!(a_404_errors.is_empty());
+        }
+    }
+
+    // The index always loaded successfully.
+    assert!(index_metrics.fail_count == 0);
+
+    // The 404 path was always an error.
+    assert!(a_404_metrics.success_count == 0);
+
+    // Verify that Goose started the correct number of users.
+    assert!(goose_metrics.users == configuration.users.unwrap());
+}
+
+// Returns the appropriate taskset needed to build these tests.
+fn get_tasks() -> GooseTaskSet {
+    taskset!("LoadTest")
+        .register_task(task!(get_index))
+        .register_task(task!(get_404_path))
+}
+
+// Helper to run all standalone tests.
+fn run_standalone_test(test_type: TestType) {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    let mut configuration_flags = match test_type {
+        TestType::NoErrorSummary => vec!["--no-error-summary"],
+        TestType::ErrorSummary => vec![],
+    };
+
+    // Build common configuration elements.
+    let configuration = common_build_configuration(&server, &mut configuration_flags);
+
+    // Run the Goose Attack.
+    let goose_metrics = common::run_load_test(
+        common::build_load_test(configuration.clone(), &get_tasks(), None, None),
+        None,
+    );
+
+    // Confirm that the load test ran correctly.
+    validate_error(&goose_metrics, &mock_endpoints, &configuration, test_type);
+}
+
+// Helper to run all standalone tests.
+fn run_gaggle_test(test_type: TestType) {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    // Each worker has the same identical configuration.
+    let worker_configuration = common::build_configuration(&server, vec!["--worker"]);
+
+    // Build the load test for the Workers.
+    let goose_attack = common::build_load_test(worker_configuration, &get_tasks(), None, None);
+
+    // Workers launched in own threads, store thread handles.
+    let worker_handles = common::launch_gaggle_workers(goose_attack, EXPECT_WORKERS);
+
+    // Build common configuration elements, adding Manager Gaggle flags.
+    let manager_configuration = match test_type {
+        TestType::NoErrorSummary => common_build_configuration(
+            &server,
+            &mut vec![
+                "--manager",
+                "--expect-workers",
+                &EXPECT_WORKERS.to_string(),
+                "--no-error-summary",
+            ],
+        ),
+        TestType::ErrorSummary => common_build_configuration(
+            &server,
+            &mut vec!["--manager", "--expect-workers", &EXPECT_WORKERS.to_string()],
+        ),
+    };
+
+    // Build the load test for the Manager.
+    let manager_goose_attack =
+        common::build_load_test(manager_configuration.clone(), &get_tasks(), None, None);
+
+    // Run the Goose Attack.
+    let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles));
+
+    // Confirm that the load test ran correctly.
+    validate_error(
+        &goose_metrics,
+        &mock_endpoints,
+        &manager_configuration,
+        test_type,
+    );
+}
+
+#[test]
+// Confirm that errors show up in the summary when enabled.
+fn test_error_summary() {
+    run_standalone_test(TestType::ErrorSummary);
+}
+
+#[test]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+#[serial]
+// Confirm that errors show up in the summary when enabled, in Gaggle mode.
+fn test_error_summary_gaggle() {
+    run_gaggle_test(TestType::ErrorSummary);
+}
+
+#[test]
+// Confirm that errors do not show up in the summary when --no-error-summary is enabled.
+fn test_no_error_summary() {
+    run_standalone_test(TestType::NoErrorSummary);
+}
+
+#[test]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+#[serial]
+// Confirm that errors do not show up in the summary when --no-error-summary is enabled,
+// in Gaggle mode.
+fn test_no_error_summary_gaggle() {
+    run_gaggle_test(TestType::NoErrorSummary);
+}


### PR DESCRIPTION
Capture errors and display an error summary in the metrics report at the end of the load test. (Example below). Enabled by default, can be disabled with `--no-error-summary` or by setting `GooseDefault::NoErrorSummary` to `true`.

If there are any error when `--report--file` is configured, errors are included in the HTML report.

When running in Gaggle mode, errors triggered by Workers are aggregated by the Manager and included in any reports.

 Fixes #245 

Example:

```
 === PER TASK METRICS ===
 ------------------------------------------------------------------------------
 Name                     |   # times run |        # fails |   task/s |  fail/s
 ------------------------------------------------------------------------------
 1: AnonBrowsingUser      |
   1: (Anon) front page   |           150 |         0 (0%) |    50.00 |    0.00
   2: (Anon) node page    |            18 |         0 (0%) |     6.00 |    0.00
   3: (Anon) user page    |             3 |         0 (0%) |     1.00 |    0.00
 2: AuthBrowsingUser      |
   1: (Auth) login        |             6 |         0 (0%) |     2.00 |    0.00
   2: (Auth) front page   |            60 |         0 (0%) |    20.00 |    0.00
   3: (Auth) node page    |            18 |         0 (0%) |     6.00 |    0.00
   4: (Auth) user page    |             3 |         0 (0%) |     1.00 |    0.00
   5: (Auth) comment form |             3 |         0 (0%) |     1.00 |    0.00
 -------------------------+---------------+----------------+----------+--------
 Aggregated               |           261 |         0 (0%) |    87.00 |    0.00
 ------------------------------------------------------------------------------
 Name                     |    Avg (ms) |        Min |         Max |     Median
 ------------------------------------------------------------------------------
 1: AnonBrowsingUser      |
   1: (Anon) front page   |      234.78 |         65 |         746 |        190
   2: (Anon) node page    |       40.06 |         10 |         106 |         27
   3: (Anon) user page    |       23.33 |         14 |          33 |         23
 2: AuthBrowsingUser      |
   1: (Auth) login        |      118.00 |         62 |         194 |         78
   2: (Auth) front page   |      125.78 |         11 |         752 |         36
   3: (Auth) node page    |       60.94 |         14 |         172 |         60
   4: (Auth) user page    |       82.00 |         16 |         198 |         32
   5: (Auth) comment form |      172.33 |        138 |         236 |        140
 -------------------------+-------------+------------+-------------+-----------
 Aggregated               |      176.72 |         10 |         752 |        120

 === PER REQUEST METRICS ===
 ------------------------------------------------------------------------------
 Name                     |        # reqs |        # fails |    req/s |  fail/s
 ------------------------------------------------------------------------------
 GET (Anon) front page    |           172 |         0 (0%) |    57.33 |    0.00
 GET (Anon) node page     |            18 |      9 (50.0%) |     6.00 |    3.00
 GET (Anon) user page     |             3 |       3 (100%) |     1.00 |    1.00
 GET (Auth) comment form  |             3 |         0 (0%) |     1.00 |    0.00
 GET (Auth) front page    |            67 |     32 (47.8%) |    22.33 |   10.67
 GET (Auth) node page     |            18 |      7 (38.9%) |     6.00 |    2.33
 GET (Auth) user page     |             3 |         0 (0%) |     1.00 |    0.00
 GET static asset         |         1,122 |         0 (0%) |   374.00 |    0.00
 POST (Auth) comment form |             3 |         0 (0%) |     1.00 |    0.00
 POST (Auth) front page   |             6 |         0 (0%) |     2.00 |    0.00
 -------------------------+---------------+----------------+----------+--------
 Aggregated               |         1,415 |      51 (3.6%) |   471.67 |   17.00
 ------------------------------------------------------------------------------
 Name                     |    Avg (ms) |        Min |        Max |      Median
 ------------------------------------------------------------------------------
 GET (Anon) front page    |       24.97 |          5 |         400 |         17
 GET (Anon) node page     |       40.06 |         10 |         106 |         27
 GET (Anon) user page     |       23.33 |         14 |          33 |         23
 GET (Auth) comment form  |       35.33 |         33 |          38 |         35
 GET (Auth) front page    |       39.33 |         11 |         453 |         25
 GET (Auth) node page     |       60.94 |         14 |         172 |         60
 GET (Auth) user page     |       82.00 |         16 |         198 |         32
 GET static asset         |       30.55 |          4 |         449 |         21
 POST (Auth) comment form |       79.33 |         61 |          97 |         80
 POST (Auth) front page   |       78.83 |         49 |         120 |         53
 -------------------------+-------------+------------+-------------+-----------
 Aggregated               |       31.21 |          4 |         453 |         21
 ------------------------------------------------------------------------------
 Slowest page load within specified percentile of requests (in ms):
 ------------------------------------------------------------------------------
 Name                     |    50% |    75% |    98% |    99% |  99.9% | 99.99%
 ------------------------------------------------------------------------------
 GET (Anon) front page    |     17 |     24 |     93 |    180 |    400 |    400
 GET (Anon) node page     |     27 |     53 |    106 |    106 |    106 |    106
 GET (Anon) user page     |     23 |     23 |     33 |     33 |     33 |     33
 GET (Auth) comment form  |     35 |     35 |     38 |     38 |     38 |     38
 GET (Auth) front page    |     25 |     35 |    170 |    170 |    450 |    450
 GET (Auth) node page     |     60 |     77 |    170 |    170 |    170 |    170
 GET (Auth) user page     |     32 |     32 |    198 |    198 |    198 |    198
 GET static asset         |     21 |     35 |    190 |    220 |    449 |    449
 POST (Auth) comment form |     80 |     80 |     97 |     97 |     97 |     97
 POST (Auth) front page   |     53 |    110 |    120 |    120 |    120 |    120
 -------------------------+--------+--------+--------+--------+--------+-------
 Aggregated               |     21 |     34 |    170 |    220 |    450 |    450

 === ERRORS ===
 ------------------------------------------------------------------------------
 Count       | Error
 ------------------------------------------------------------------------------
 32            GET (Auth) front page: 503 Service Unavailable: /
 1             GET (Auth) node page: 503 Service Unavailable: /node/7577
 1             GET (Auth) node page: 503 Service Unavailable: /node/705
 1             GET (Auth) node page: 503 Service Unavailable: /node/6839
 1             GET (Auth) node page: 503 Service Unavailable: /node/6693
 1             GET (Auth) node page: 503 Service Unavailable: /node/5681
 1             GET (Auth) node page: 503 Service Unavailable: /node/3081
 1             GET (Auth) node page: 503 Service Unavailable: /node/12
 1             GET (Anon) user page: 503 Service Unavailable: /user/925
 1             GET (Anon) user page: 503 Service Unavailable: /user/2969
 1             GET (Anon) user page: 503 Service Unavailable: /user/2132
 1             GET (Anon) node page: 503 Service Unavailable: /node/9279
 1             GET (Anon) node page: 503 Service Unavailable: /node/9268
 1             GET (Anon) node page: 503 Service Unavailable: /node/866
 1             GET (Anon) node page: 503 Service Unavailable: /node/6152
 1             GET (Anon) node page: 503 Service Unavailable: /node/593
 1             GET (Anon) node page: 503 Service Unavailable: /node/3827
 1             GET (Anon) node page: 503 Service Unavailable: /node/2660
 1             GET (Anon) node page: 503 Service Unavailable: /node/1843
 1             GET (Anon) node page: 503 Service Unavailable: /node/174
 ------------------------------------------------------------------------------
```

And at the end of the HTML report:
<img width="1048" alt="Screen Shot 2021-03-29 at 3 12 02 PM" src="https://user-images.githubusercontent.com/402892/112867723-89cb0580-90bb-11eb-865c-6dde58c82e39.png">
