### PR TITLE
prepare for Rust 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.11.0-dev
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`
- - clippy cleanups:
+ - clippy cleanups (prepare for Rust 2021 https://blog.rust-lang.org/inside-rust/2021/03/04/planning-rust-2021.html):
     o API change: all `GooseMethod`s renamed to enforce Rust naming conventions in regards to case, for example `GooseMethod::GET` becomes `GooseMethod::Get`
     o use `vec![]` macro to avoid unnecessarily pushing data into mutable vectors
     o call `format!` macro directly for improved readability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.10.10-dev
+## 0.11.0-dev
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`
- - enforce Rust naming conventions in regards to case
+ - API change: all `GooseMethod`s renamed to enforce Rust naming conventions in regards to case, for example `GooseMethod::GET` becomes `GooseMethod::Get`
 
 ## 0.10.9 March 23, 2021
  - avoid unnecessary work on Manager when starting a Gaggle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.10-dev
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`
+ - enforce Rust naming conventions in regards to case
 
 ## 0.10.9 March 23, 2021
  - avoid unnecessary work on Manager when starting a Gaggle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 0.11.0-dev
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`
- - API change: all `GooseMethod`s renamed to enforce Rust naming conventions in regards to case, for example `GooseMethod::GET` becomes `GooseMethod::Get`
+ - clippy cleanups:
+    o API change: all `GooseMethod`s renamed to enforce Rust naming conventions in regards to case, for example `GooseMethod::GET` becomes `GooseMethod::Get`
+    o use `vec![]` macro to avoid unnecessarily pushing data into mutable vectors
+    o call `format!` macro directly for improved readability
+    o remove unnecessary `panic!`
 
 ## 0.10.9 March 23, 2021
  - avoid unnecessary work on Manager when starting a Gaggle

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.10.10-dev"
+version = "0.11.0-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing tool inspired by Locust."

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This creates a new directory named `loadtest/` containing `loadtest/Cargo.toml` 
 
 ```toml
 [dependencies]
-goose = "^0.10"
+goose = "^0.11"
 ```
 
 At this point it's possible to compile all dependencies, though the resulting binary only displays "Hello, world!":
@@ -46,9 +46,9 @@ At this point it's possible to compile all dependencies, though the resulting bi
 ```
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.10.9
+  Downloaded goose v0.11.0
       ...
-   Compiling goose v0.10.9
+   Compiling goose v0.11.0
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`
@@ -536,7 +536,7 @@ When writing load test applications, you can default to compiling in the Gaggle 
 
 ```toml
 [dependencies]
-goose = { version = "^0.10", features = ["gaggle"] }
+goose = { version = "^0.11", features = ["gaggle"] }
 ```
 
 ### Gaggle Manager
@@ -596,5 +596,5 @@ By default Reqwest (and therefore Goose) uses the system-native transport layer 
 
 ```toml
 [dependencies]
-goose = { version = "^0.10", default-features = false, features = ["rustls"] }
+goose = { version = "^0.11", default-features = false, features = ["rustls"] }
 ```

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -175,208 +175,206 @@ pub fn get_nodes(content_type: &ContentType) -> Vec<Node> {
 
 /// Returns a vector of all taxonomy terms.
 pub fn get_terms() -> Vec<Term<'static>> {
-    let mut terms: Vec<Term> = Vec::new();
-
-    terms.push(Term {
-        url_en: "/en/recipe-category/accompaniments",
-        url_es: "/es/recipe-category/acompañamientos",
-        title_en: "Accompaniments",
-        title_es: "Acompañamientos",
-    });
-    terms.push(Term {
-        url_en: "/en/recipe-category/desserts",
-        url_es: "/es/recipe-category/postres",
-        title_en: "Desserts",
-        title_es: "Postres",
-    });
-    terms.push(Term {
-        url_en: "/en/recipe-category/main-courses",
-        url_es: "/es/recipe-category/platos-principales",
-        title_en: "Main courses",
-        title_es: "Platos principales",
-    });
-    terms.push(Term {
-        url_en: "/en/recipe-category/snacks",
-        url_es: "/es/recipe-category/tentempiés",
-        title_en: "Snacks",
-        title_es: "Tentempiés",
-    });
-    terms.push(Term {
-        url_en: "/en/recipe-category/starters",
-        url_es: "/es/recipe-category/entrantes",
-        title_en: "Starters",
-        title_es: "Entrantes",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/alcohol-free",
-        url_es: "/es/tags/sin-alcohol",
-        title_en: "Alcohol free",
-        title_es: "Sin alcohol",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/baked",
-        url_es: "/es/tags/horneado",
-        title_en: "Baked",
-        title_es: "Horneado",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/baking",
-        url_es: "/es/tags/cocción",
-        title_en: "Baking",
-        title_es: "Cocción",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/breakfast",
-        url_es: "/es/tags/desayuno",
-        title_en: "Breakfast",
-        title_es: "Desayuno",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/cake",
-        url_es: "/es/tags/pastel",
-        title_en: "Cake",
-        title_es: "Pastel",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/carrots",
-        url_es: "/es/tags/zanahorias",
-        title_en: "Carrots",
-        title_es: "Zanahorias",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/chocolate",
-        url_es: "/es/tags/chocolate",
-        title_en: "Chocolate",
-        title_es: "Chocolate",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/cocktail-party",
-        url_es: "/es/tags/fiesta-de-coctel",
-        title_en: "Cocktail party",
-        title_es: "Fiesta de coctel",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/dairy-free",
-        url_es: "/es/tags/sin-Lactosa",
-        title_en: "Dairy-free",
-        title_es: "Sin Lactosa",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/dessert",
-        url_es: "/es/tags/postre",
-        title_en: "Dessert",
-        title_es: "Postre",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/dinner-party",
-        url_es: "/es/tags/fiesta-de-cena",
-        title_en: "Dinner party",
-        title_es: "Fiesta de cena",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/drinks",
-        url_es: "/es/tags/bebidas",
-        title_en: "Drinks",
-        title_es: "Bebidas",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/egg",
-        url_es: "/es/tags/huevo",
-        title_en: "Egg",
-        title_es: "Huevo",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/grow-your-own",
-        url_es: "/es/tags/cultiva-los-tuyos",
-        title_en: "Grow your own",
-        title_es: "Cultiva los tuyos",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/healthy",
-        url_es: "/es/tags/saludable",
-        title_en: "Healthy",
-        title_es: "Saludable",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/herbs",
-        url_es: "/es/tags/hierbas",
-        title_en: "Herbs",
-        title_es: "Hierbas",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/learn-to-cook",
-        url_es: "/es/tags/aprender-a-cocinar",
-        title_en: "Learn to cook",
-        title_es: "Aprender a cocinar",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/mushrooms",
-        url_es: "/es/tags/champiñones",
-        title_en: "Mushrooms",
-        title_es: "Champiñones",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/oats",
-        url_es: "/es/tags/avena",
-        title_en: "Oats",
-        title_es: "Avena",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/party",
-        url_es: "/es/tags/fiesta",
-        title_en: "Party",
-        title_es: "Fiesta",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/pasta",
-        url_es: "/es/tags/pastas",
-        title_en: "Pasta",
-        title_es: "Pastas",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/pastry",
-        url_es: "/es/tags/repostería",
-        title_en: "Pastry",
-        title_es: "Repostería",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/seasonal",
-        url_es: "/es/tags/estacional",
-        title_en: "Seasonal",
-        title_es: "Estacional",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/shopping",
-        url_es: "/es/tags/compras",
-        title_en: "Shopping",
-        title_es: "Compras",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/soup",
-        url_es: "/es/tags/sopa",
-        title_en: "Soup",
-        title_es: "Sopa",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/supermarkets",
-        url_es: "/es/tags/supermercados",
-        title_en: "Supermarkets",
-        title_es: "Supermercados",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/vegan",
-        url_es: "/es/tags/vegano",
-        title_en: "Vegan",
-        title_es: "Vegano",
-    });
-    terms.push(Term {
-        url_en: "/en/tags/vegetarian",
-        url_es: "/es/tags/vegetariano",
-        title_en: "Vegetarian",
-        title_es: "Vegetariano",
-    });
-
-    terms
+    vec![
+        Term {
+            url_en: "/en/recipe-category/accompaniments",
+            url_es: "/es/recipe-category/acompañamientos",
+            title_en: "Accompaniments",
+            title_es: "Acompañamientos",
+        },
+        Term {
+            url_en: "/en/recipe-category/desserts",
+            url_es: "/es/recipe-category/postres",
+            title_en: "Desserts",
+            title_es: "Postres",
+        },
+        Term {
+            url_en: "/en/recipe-category/main-courses",
+            url_es: "/es/recipe-category/platos-principales",
+            title_en: "Main courses",
+            title_es: "Platos principales",
+        },
+        Term {
+            url_en: "/en/recipe-category/snacks",
+            url_es: "/es/recipe-category/tentempiés",
+            title_en: "Snacks",
+            title_es: "Tentempiés",
+        },
+        Term {
+            url_en: "/en/recipe-category/starters",
+            url_es: "/es/recipe-category/entrantes",
+            title_en: "Starters",
+            title_es: "Entrantes",
+        },
+        Term {
+            url_en: "/en/tags/alcohol-free",
+            url_es: "/es/tags/sin-alcohol",
+            title_en: "Alcohol free",
+            title_es: "Sin alcohol",
+        },
+        Term {
+            url_en: "/en/tags/baked",
+            url_es: "/es/tags/horneado",
+            title_en: "Baked",
+            title_es: "Horneado",
+        },
+        Term {
+            url_en: "/en/tags/baking",
+            url_es: "/es/tags/cocción",
+            title_en: "Baking",
+            title_es: "Cocción",
+        },
+        Term {
+            url_en: "/en/tags/breakfast",
+            url_es: "/es/tags/desayuno",
+            title_en: "Breakfast",
+            title_es: "Desayuno",
+        },
+        Term {
+            url_en: "/en/tags/cake",
+            url_es: "/es/tags/pastel",
+            title_en: "Cake",
+            title_es: "Pastel",
+        },
+        Term {
+            url_en: "/en/tags/carrots",
+            url_es: "/es/tags/zanahorias",
+            title_en: "Carrots",
+            title_es: "Zanahorias",
+        },
+        Term {
+            url_en: "/en/tags/chocolate",
+            url_es: "/es/tags/chocolate",
+            title_en: "Chocolate",
+            title_es: "Chocolate",
+        },
+        Term {
+            url_en: "/en/tags/cocktail-party",
+            url_es: "/es/tags/fiesta-de-coctel",
+            title_en: "Cocktail party",
+            title_es: "Fiesta de coctel",
+        },
+        Term {
+            url_en: "/en/tags/dairy-free",
+            url_es: "/es/tags/sin-Lactosa",
+            title_en: "Dairy-free",
+            title_es: "Sin Lactosa",
+        },
+        Term {
+            url_en: "/en/tags/dessert",
+            url_es: "/es/tags/postre",
+            title_en: "Dessert",
+            title_es: "Postre",
+        },
+        Term {
+            url_en: "/en/tags/dinner-party",
+            url_es: "/es/tags/fiesta-de-cena",
+            title_en: "Dinner party",
+            title_es: "Fiesta de cena",
+        },
+        Term {
+            url_en: "/en/tags/drinks",
+            url_es: "/es/tags/bebidas",
+            title_en: "Drinks",
+            title_es: "Bebidas",
+        },
+        Term {
+            url_en: "/en/tags/egg",
+            url_es: "/es/tags/huevo",
+            title_en: "Egg",
+            title_es: "Huevo",
+        },
+        Term {
+            url_en: "/en/tags/grow-your-own",
+            url_es: "/es/tags/cultiva-los-tuyos",
+            title_en: "Grow your own",
+            title_es: "Cultiva los tuyos",
+        },
+        Term {
+            url_en: "/en/tags/healthy",
+            url_es: "/es/tags/saludable",
+            title_en: "Healthy",
+            title_es: "Saludable",
+        },
+        Term {
+            url_en: "/en/tags/herbs",
+            url_es: "/es/tags/hierbas",
+            title_en: "Herbs",
+            title_es: "Hierbas",
+        },
+        Term {
+            url_en: "/en/tags/learn-to-cook",
+            url_es: "/es/tags/aprender-a-cocinar",
+            title_en: "Learn to cook",
+            title_es: "Aprender a cocinar",
+        },
+        Term {
+            url_en: "/en/tags/mushrooms",
+            url_es: "/es/tags/champiñones",
+            title_en: "Mushrooms",
+            title_es: "Champiñones",
+        },
+        Term {
+            url_en: "/en/tags/oats",
+            url_es: "/es/tags/avena",
+            title_en: "Oats",
+            title_es: "Avena",
+        },
+        Term {
+            url_en: "/en/tags/party",
+            url_es: "/es/tags/fiesta",
+            title_en: "Party",
+            title_es: "Fiesta",
+        },
+        Term {
+            url_en: "/en/tags/pasta",
+            url_es: "/es/tags/pastas",
+            title_en: "Pasta",
+            title_es: "Pastas",
+        },
+        Term {
+            url_en: "/en/tags/pastry",
+            url_es: "/es/tags/repostería",
+            title_en: "Pastry",
+            title_es: "Repostería",
+        },
+        Term {
+            url_en: "/en/tags/seasonal",
+            url_es: "/es/tags/estacional",
+            title_en: "Seasonal",
+            title_es: "Estacional",
+        },
+        Term {
+            url_en: "/en/tags/shopping",
+            url_es: "/es/tags/compras",
+            title_en: "Shopping",
+            title_es: "Compras",
+        },
+        Term {
+            url_en: "/en/tags/soup",
+            url_es: "/es/tags/sopa",
+            title_en: "Soup",
+            title_es: "Sopa",
+        },
+        Term {
+            url_en: "/en/tags/supermarkets",
+            url_es: "/es/tags/supermercados",
+            title_en: "Supermarkets",
+            title_es: "Supermercados",
+        },
+        Term {
+            url_en: "/en/tags/vegan",
+            url_es: "/es/tags/vegano",
+            title_en: "Vegan",
+            title_es: "Vegano",
+        },
+        Term {
+            url_en: "/en/tags/vegetarian",
+            url_es: "/es/tags/vegetariano",
+            title_en: "Vegetarian",
+            title_es: "Vegetariano",
+        },
+    ]
 }
 
 /// Return a vector of random words taken from node titles in the specified

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -32,145 +32,145 @@ pub struct Term<'a> {
 
 /// Returns a vector of all nodes of a specified content type.
 pub fn get_nodes(content_type: &ContentType) -> Vec<Node> {
-    let mut nodes: Vec<Node> = Vec::new();
-
     match content_type {
         ContentType::Article => {
-            nodes.push(Node {
-                nid: 10,
-                url_en: "/en/articles/give-it-a-go-and-grow-your-own-herbs",
-                url_es: "/es/articles/prueba-y-cultiva-tus-propias-hierbas",
-                title_en: "Give it a go and grow your own herbs",
-                title_es: "Prueba y cultiva tus propias hierbas",
-            });
-            nodes.push(Node {
-                nid: 11,
-                url_en: "/en/articles/dairy-free-and-delicious-milk-chocolate",
-                url_es: "/es/articles/delicioso-chocolate-sin-lactosa",
-                title_en: "Dairy-free and delicious milk chocolate",
-                title_es: "Delicioso chocolate sin lactosa",
-            });
-            nodes.push(Node {
-                nid: 12,
-                url_en: "/en/articles/the-real-deal-for-supermarket-savvy-shopping",
-                url_es: "/es/articles/el-verdadeo-negocio-para-comprar-en-el-supermercado",
-                title_en: "The real deal for supermarket savvy shopping",
-                title_es: "El verdadero negocio para comprar en el supermercado",
-            });
-            nodes.push(Node {
-                nid: 13,
-                url_en: "/en/articles/the-umami-guide-to-our-favourite-mushrooms",
-                url_es: "/es/articles/guia-umami-de-nuestras-setas-preferidas",
-                title_en: "The Umami guide to our favorite mushrooms",
-                title_es: "Guía Umami de nuestras setas preferidas",
-            });
-            nodes.push(Node {
-                nid: 14,
-                url_en: "/en/articles/lets-hear-it-for-carrots",
-                url_es: "/es/articles/un-aplauso-para-las-zanahorias",
-                title_en: "Let&#039;s hear it for carrots",
-                title_es: "Un aplauso para las zanahorias",
-            });
-            nodes.push(Node {
-                nid: 15,
-                url_en: "/en/articles/baking-mishaps-our-troubleshooting-tips",
-                url_es:
-                    "/es/articles/percances-al-hornear-nuestros-consejos-para-solucionar-problemas",
-                title_en: "Baking mishaps - our troubleshooting tips",
-                title_es: "Percances al hornear - nuestros consejos para solucionar los problemas",
-            });
-            nodes.push(Node {
-                nid: 16,
-                url_en: "/en/articles/skip-the-spirits-with-delicious-mocktails",
-                url_es: "/es/articles/salta-los-espiritus-con-deliciosos-cocteles-sin-alcohol",
-                title_en: "Skip the spirits with delicious mocktails",
-                title_es: "Salta los espíritus con deliciosos cócteles sin alcohol",
-            });
-            nodes.push(Node {
-                nid: 17,
-                url_en: "/en/articles/give-your-oatmeal-the-ultimate-makeover",
-                url_es: "/es/articles/dale-a-tu-avena-el-cambio-de-imagen-definitivo",
-                title_en: "Give your oatmeal the ultimate makeover",
-                title_es: "Dale a tu avena el cambio de imagen definitivo",
-            });
+            vec![
+                Node {
+                    nid: 10,
+                    url_en: "/en/articles/give-it-a-go-and-grow-your-own-herbs",
+                    url_es: "/es/articles/prueba-y-cultiva-tus-propias-hierbas",
+                    title_en: "Give it a go and grow your own herbs",
+                    title_es: "Prueba y cultiva tus propias hierbas",
+                },
+                Node {
+                    nid: 11,
+                    url_en: "/en/articles/dairy-free-and-delicious-milk-chocolate",
+                    url_es: "/es/articles/delicioso-chocolate-sin-lactosa",
+                    title_en: "Dairy-free and delicious milk chocolate",
+                    title_es: "Delicioso chocolate sin lactosa",
+                },
+                Node {
+                    nid: 12,
+                    url_en: "/en/articles/the-real-deal-for-supermarket-savvy-shopping",
+                    url_es: "/es/articles/el-verdadeo-negocio-para-comprar-en-el-supermercado",
+                    title_en: "The real deal for supermarket savvy shopping",
+                    title_es: "El verdadero negocio para comprar en el supermercado",
+                },
+                Node {
+                    nid: 13,
+                    url_en: "/en/articles/the-umami-guide-to-our-favourite-mushrooms",
+                    url_es: "/es/articles/guia-umami-de-nuestras-setas-preferidas",
+                    title_en: "The Umami guide to our favorite mushrooms",
+                    title_es: "Guía Umami de nuestras setas preferidas",
+                },
+                Node {
+                    nid: 14,
+                    url_en: "/en/articles/lets-hear-it-for-carrots",
+                    url_es: "/es/articles/un-aplauso-para-las-zanahorias",
+                    title_en: "Let&#039;s hear it for carrots",
+                    title_es: "Un aplauso para las zanahorias",
+                },
+                Node {
+                    nid: 15,
+                    url_en: "/en/articles/baking-mishaps-our-troubleshooting-tips",
+                    url_es:
+                        "/es/articles/percances-al-hornear-nuestros-consejos-para-solucionar-problemas",
+                    title_en: "Baking mishaps - our troubleshooting tips",
+                    title_es: "Percances al hornear - nuestros consejos para solucionar los problemas",
+                },
+                Node {
+                    nid: 16,
+                    url_en: "/en/articles/skip-the-spirits-with-delicious-mocktails",
+                    url_es: "/es/articles/salta-los-espiritus-con-deliciosos-cocteles-sin-alcohol",
+                    title_en: "Skip the spirits with delicious mocktails",
+                    title_es: "Salta los espíritus con deliciosos cócteles sin alcohol",
+                },
+                Node {
+                    nid: 17,
+                    url_en: "/en/articles/give-your-oatmeal-the-ultimate-makeover",
+                    url_es: "/es/articles/dale-a-tu-avena-el-cambio-de-imagen-definitivo",
+                    title_en: "Give your oatmeal the ultimate makeover",
+                    title_es: "Dale a tu avena el cambio de imagen definitivo",
+                },
+            ]
         }
         ContentType::BasicPage => {
-            nodes.push(Node {
+            vec![Node {
                 nid: 18,
                 url_en: "/en/about-umami",
                 url_es: "/es/acerca-de-umami",
                 title_en: "About Umami",
                 title_es: "Acerca de Umami",
-            });
+            }]
         }
         ContentType::Recipe => {
-            nodes.push(Node {
-                nid: 1,
-                url_en: "/en/recipes/deep-mediterranean-quiche",
-                url_es: "/es/recipes/quiche-mediterráneo-profundo",
-                title_en: "Deep mediterranean quiche",
-                title_es: "Quiche mediterráneo profundo",
-            });
-            nodes.push(Node {
-                nid: 2,
-                url_en: "/en/recipes/vegan-chocolate-and-nut-brownies",
-                url_es: "/es/recipes/bizcochos-veganos-de-chocolate-y-nueces",
-                title_en: "Vegan chocolate and nut brownies",
-                title_es: "Bizcochos veganos de chocolate y nueces",
-            });
-            nodes.push(Node {
-                nid: 3,
-                url_en: "/en/recipes/super-easy-vegetarian-pasta-bake",
-                url_es: "/es/recipes/pasta-vegetariana-horno-super-facil",
-                title_en: "Super easy vegetarian pasta bake",
-                title_es: "Pasta vegetariana al horno súper fácil",
-            });
-            nodes.push(Node {
-                nid: 4,
-                url_en: "/en/recipes/watercress-soup",
-                url_es: "/es/recipes/sopa-de-berro",
-                title_en: "Watercress soup",
-                title_es: "Sopa de berro",
-            });
-            nodes.push(Node {
-                nid: 5,
-                url_en: "/en/recipes/victoria-sponge-cake",
-                url_es: "/es/recipes/pastel-victoria",
-                title_en: "Victoria sponge cake",
-                title_es: "Pastel Victoria",
-            });
-            nodes.push(Node {
-                nid: 6,
-                url_en: "/en/recipes/gluten-free-pizza",
-                url_es: "/es/recipes/pizza-sin-gluten",
-                title_en: "Gluten free pizza",
-                title_es: "Pizza sin gluten",
-            });
-            nodes.push(Node {
-                nid: 7,
-                url_en: "/en/recipes/thai-green-curry",
-                url_es: "/es/recipes/curry-verde-tailandes",
-                title_en: "Thai green curry",
-                title_es: "Curry verde tailandés",
-            });
-            nodes.push(Node {
-                nid: 8,
-                url_en: "/en/recipes/crema-catalana",
-                url_es: "/es/recipes/crema-catalana",
-                title_en: "Crema catalana",
-                title_es: "Crema catalana",
-            });
-            nodes.push(Node {
-                nid: 9,
-                url_en: "/en/recipes/fiery-chili-sauce",
-                url_es: "/es/recipes/salsa-de-chile-ardiente",
-                title_en: "Fiery chili sauce",
-                title_es: "Salsa de chile ardiente",
-            });
+            vec![
+                Node {
+                    nid: 1,
+                    url_en: "/en/recipes/deep-mediterranean-quiche",
+                    url_es: "/es/recipes/quiche-mediterráneo-profundo",
+                    title_en: "Deep mediterranean quiche",
+                    title_es: "Quiche mediterráneo profundo",
+                },
+                Node {
+                    nid: 2,
+                    url_en: "/en/recipes/vegan-chocolate-and-nut-brownies",
+                    url_es: "/es/recipes/bizcochos-veganos-de-chocolate-y-nueces",
+                    title_en: "Vegan chocolate and nut brownies",
+                    title_es: "Bizcochos veganos de chocolate y nueces",
+                },
+                Node {
+                    nid: 3,
+                    url_en: "/en/recipes/super-easy-vegetarian-pasta-bake",
+                    url_es: "/es/recipes/pasta-vegetariana-horno-super-facil",
+                    title_en: "Super easy vegetarian pasta bake",
+                    title_es: "Pasta vegetariana al horno súper fácil",
+                },
+                Node {
+                    nid: 4,
+                    url_en: "/en/recipes/watercress-soup",
+                    url_es: "/es/recipes/sopa-de-berro",
+                    title_en: "Watercress soup",
+                    title_es: "Sopa de berro",
+                },
+                Node {
+                    nid: 5,
+                    url_en: "/en/recipes/victoria-sponge-cake",
+                    url_es: "/es/recipes/pastel-victoria",
+                    title_en: "Victoria sponge cake",
+                    title_es: "Pastel Victoria",
+                },
+                Node {
+                    nid: 6,
+                    url_en: "/en/recipes/gluten-free-pizza",
+                    url_es: "/es/recipes/pizza-sin-gluten",
+                    title_en: "Gluten free pizza",
+                    title_es: "Pizza sin gluten",
+                },
+                Node {
+                    nid: 7,
+                    url_en: "/en/recipes/thai-green-curry",
+                    url_es: "/es/recipes/curry-verde-tailandes",
+                    title_en: "Thai green curry",
+                    title_es: "Curry verde tailandés",
+                },
+                Node {
+                    nid: 8,
+                    url_en: "/en/recipes/crema-catalana",
+                    url_es: "/es/recipes/crema-catalana",
+                    title_en: "Crema catalana",
+                    title_es: "Crema catalana",
+                },
+                Node {
+                    nid: 9,
+                    url_en: "/en/recipes/fiery-chili-sauce",
+                    url_es: "/es/recipes/salsa-de-chile-ardiente",
+                    title_en: "Fiery chili sauce",
+                    title_es: "Salsa de chile ardiente",
+                },
+            ]
         }
     }
-
-    nodes
 }
 
 /// Returns a vector of all taxonomy terms.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -624,6 +624,19 @@ pub enum GooseMethod {
     Post,
     Put,
 }
+/// Display method in upper case.
+impl fmt::Display for GooseMethod {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            GooseMethod::Delete => write!(f, "{}", "DELETE"),
+            GooseMethod::Get => write!(f, "{}", "GET"),
+            GooseMethod::Head => write!(f, "{}", "HEAD"),
+            GooseMethod::Patch => write!(f, "{}", "PATCH"),
+            GooseMethod::Post => write!(f, "{}", "POST"),
+            GooseMethod::Put => write!(f, "{}", "PUT"),
+        }
+    }
+}
 
 fn goose_method_from_method(method: Method) -> Result<GooseMethod, GooseTaskError> {
     Ok(match method {

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1844,7 +1844,7 @@ impl GooseUser {
     ///
     /// By default, Goose configures two options when building a Reqwest client. The first
     /// configures Goose to report itself as the user agent requesting web pages (ie
-    /// `goose/0.10.9`). The second option configures Reqwest to store cookies, which is
+    /// `goose/0.11.0`). The second option configures Reqwest to store cookies, which is
     /// generally necessary if you aim to simulate logged in users.
     ///
     /// # Default configuration:

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -607,32 +607,32 @@ impl GooseTaskSet {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum GooseUserCommand {
     /// Tell worker process to pause load test.
-    WAIT,
+    Wait,
     /// Tell worker process to start load test.
-    RUN,
+    Run,
     /// Tell user thread to exit.
-    EXIT,
+    Exit,
 }
 
 /// Supported HTTP methods.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum GooseMethod {
-    DELETE,
-    GET,
-    HEAD,
-    PATCH,
-    POST,
-    PUT,
+    Delete,
+    Get,
+    Head,
+    Patch,
+    Post,
+    Put,
 }
 
 fn goose_method_from_method(method: Method) -> Result<GooseMethod, GooseTaskError> {
     Ok(match method {
-        Method::DELETE => GooseMethod::DELETE,
-        Method::GET => GooseMethod::GET,
-        Method::HEAD => GooseMethod::HEAD,
-        Method::PATCH => GooseMethod::PATCH,
-        Method::POST => GooseMethod::POST,
-        Method::PUT => GooseMethod::PUT,
+        Method::DELETE => GooseMethod::Delete,
+        Method::GET => GooseMethod::Get,
+        Method::HEAD => GooseMethod::Head,
+        Method::PATCH => GooseMethod::Patch,
+        Method::POST => GooseMethod::Post,
+        Method::PUT => GooseMethod::Put,
         _ => {
             return Err(GooseTaskError::InvalidMethod { method });
         }
@@ -649,7 +649,7 @@ fn goose_method_from_method(method: Method) -> Result<GooseMethod, GooseTaskErro
 pub struct GooseRawRequest {
     /// How many milliseconds the load test has been running.
     pub elapsed: u64,
-    /// The method being used (ie, GET, POST, etc).
+    /// The method being used (ie, Get, Post, etc).
     pub method: GooseMethod,
     /// The optional name of the request.
     pub name: String,
@@ -2472,8 +2472,8 @@ mod tests {
     #[test]
     fn goose_raw_request() {
         const PATH: &str = "http://127.0.0.1/";
-        let mut raw_request = GooseRawRequest::new(GooseMethod::GET, "/", PATH, 0, 0);
-        assert_eq!(raw_request.method, GooseMethod::GET);
+        let mut raw_request = GooseRawRequest::new(GooseMethod::Get, "/", PATH, 0, 0);
+        assert_eq!(raw_request.method, GooseMethod::Get);
         assert_eq!(raw_request.name, "/".to_string());
         assert_eq!(raw_request.url, PATH.to_string());
         assert_eq!(raw_request.response_time, 0);
@@ -2483,7 +2483,7 @@ mod tests {
 
         let response_time = 123;
         raw_request.set_response_time(response_time);
-        assert_eq!(raw_request.method, GooseMethod::GET);
+        assert_eq!(raw_request.method, GooseMethod::Get);
         assert_eq!(raw_request.name, "/".to_string());
         assert_eq!(raw_request.url, PATH.to_string());
         assert_eq!(raw_request.response_time, response_time as u64);
@@ -2493,7 +2493,7 @@ mod tests {
 
         let status_code = http::StatusCode::OK;
         raw_request.set_status_code(Some(status_code));
-        assert_eq!(raw_request.method, GooseMethod::GET);
+        assert_eq!(raw_request.method, GooseMethod::Get);
         assert_eq!(raw_request.name, "/".to_string());
         assert_eq!(raw_request.url, PATH.to_string());
         assert_eq!(raw_request.response_time, response_time as u64);
@@ -2504,9 +2504,9 @@ mod tests {
 
     #[test]
     fn goose_request() {
-        let mut request = GooseRequest::new("/", GooseMethod::GET, 0);
+        let mut request = GooseRequest::new("/", GooseMethod::Get, 0);
         assert_eq!(request.path, "/".to_string());
-        assert_eq!(request.method, GooseMethod::GET);
+        assert_eq!(request.method, GooseMethod::Get);
         assert_eq!(request.response_times.len(), 0);
         assert_eq!(request.min_response_time, 0);
         assert_eq!(request.max_response_time, 0);
@@ -2532,7 +2532,7 @@ mod tests {
         assert_eq!(request.response_time_counter, 1);
         // Nothing else changes.
         assert_eq!(request.path, "/".to_string());
-        assert_eq!(request.method, GooseMethod::GET);
+        assert_eq!(request.method, GooseMethod::Get);
         assert_eq!(request.status_code_counts.len(), 0);
         assert_eq!(request.success_count, 0);
         assert_eq!(request.fail_count, 0);
@@ -2553,7 +2553,7 @@ mod tests {
         assert_eq!(request.response_time_counter, 2);
         // Nothing else changes.
         assert_eq!(request.path, "/".to_string());
-        assert_eq!(request.method, GooseMethod::GET);
+        assert_eq!(request.method, GooseMethod::Get);
         assert_eq!(request.status_code_counts.len(), 0);
         assert_eq!(request.success_count, 0);
         assert_eq!(request.fail_count, 0);
@@ -2826,7 +2826,7 @@ mod tests {
             .expect("get returned unexpected error");
         let status = goose.response.unwrap().status();
         assert_eq!(status, 200);
-        assert_eq!(goose.request.method, GooseMethod::GET);
+        assert_eq!(goose.request.method, GooseMethod::Get);
         assert_eq!(goose.request.name, INDEX_PATH);
         assert_eq!(goose.request.success, true);
         assert_eq!(goose.request.update, false);
@@ -2848,7 +2848,7 @@ mod tests {
             .expect("get returned unexpected error");
         let status = goose.response.unwrap().status();
         assert_eq!(status, 404);
-        assert_eq!(goose.request.method, GooseMethod::GET);
+        assert_eq!(goose.request.method, GooseMethod::Get);
         assert_eq!(goose.request.name, NO_SUCH_PATH);
         assert_eq!(goose.request.success, false);
         assert_eq!(goose.request.update, false);
@@ -2873,7 +2873,7 @@ mod tests {
         assert_eq!(status, 200);
         let body = unwrapped_response.text().await.unwrap();
         assert_eq!(body, "foo");
-        assert_eq!(goose.request.method, GooseMethod::POST);
+        assert_eq!(goose.request.method, GooseMethod::Post);
         assert_eq!(goose.request.name, COMMENT_PATH);
         assert_eq!(goose.request.success, true);
         assert_eq!(goose.request.update, false);

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -628,12 +628,12 @@ pub enum GooseMethod {
 impl fmt::Display for GooseMethod {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            GooseMethod::Delete => write!(f, "{}", "DELETE"),
-            GooseMethod::Get => write!(f, "{}", "GET"),
-            GooseMethod::Head => write!(f, "{}", "HEAD"),
-            GooseMethod::Patch => write!(f, "{}", "PATCH"),
-            GooseMethod::Post => write!(f, "{}", "POST"),
-            GooseMethod::Put => write!(f, "{}", "PUT"),
+            GooseMethod::Delete => write!(f, "DELETE"),
+            GooseMethod::Get => write!(f, "GET"),
+            GooseMethod::Head => write!(f, "HEAD"),
+            GooseMethod::Patch => write!(f, "PATCH"),
+            GooseMethod::Post => write!(f, "POST"),
+            GooseMethod::Put => write!(f, "PUT"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3773,10 +3773,16 @@ impl GooseDefaultType<&str> for GooseAttack {
             | GooseDefault::StickyFollow
             | GooseDefault::Manager
             | GooseDefault::NoHashCheck
-            | GooseDefault::Worker => panic!(format!(
-                "set_default(GooseDefault::{:?}, {}) expected bool value, received &str",
-                key, value
-            )),
+            | GooseDefault::Worker => {
+                return Err(GooseError::InvalidOption {
+                    option: format!("GooseDefault::{:?}", key),
+                    value: value.to_string(),
+                    detail: format!(
+                        "set_default(GooseDefault::{:?}, {}) expected bool value, received &str",
+                        key, value
+                    ),
+                });
+            }
         }
         Ok(Box::new(self))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! goose = "0.10"
+//! goose = "0.11"
 //! ```
 //!
 //! Add the following boilerplate `use` declaration at the top of your `src/main.rs`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2457,7 +2457,7 @@ impl GooseAttack {
     ) -> String {
         let body = format!(
             // Put quotes around name, url and final_url as they are strings.
-            "{},{:?},\"{}\",\"{}\",\"{}\",{},{},{},{},{},{}",
+            "{},{},\"{}\",\"{}\",\"{}\",{},{},{},{},{},{}",
             raw_request.elapsed,
             raw_request.method,
             raw_request.name,
@@ -3178,12 +3178,12 @@ impl GooseAttack {
             let mut aggregate_response_time_maximum: usize = 0;
             let mut aggregate_response_times: BTreeMap<usize, usize> = BTreeMap::new();
             for (request_key, request) in self.metrics.requests.iter().sorted() {
-                let method = format!("{:?}", request.method);
+                let method = format!("{}", request.method);
                 // The request_key is "{method} {name}", so by stripping the "{method} "
                 // prefix we get the name.
                 // @TODO: consider storing the name as a field in GooseRequest.
                 let name = request_key
-                    .strip_prefix(&format!("{:?} ", request.method))
+                    .strip_prefix(&format!("{} ", request.method))
                     .unwrap()
                     .to_string();
                 let total_request_count = request.success_count + request.fail_count;
@@ -3391,12 +3391,12 @@ impl GooseAttack {
                 let mut status_code_metrics = Vec::new();
                 let mut aggregated_status_code_counts: HashMap<u16, usize> = HashMap::new();
                 for (request_key, request) in self.metrics.requests.iter().sorted() {
-                    let method = format!("{:?}", request.method);
+                    let method = format!("{}", request.method);
                     // The request_key is "{method} {name}", so by stripping the "{method} "
                     // prefix we get the name.
                     // @TODO: consider storing the name as a field in GooseRequest.
                     let name = request_key
-                        .strip_prefix(&format!("{:?} ", request.method))
+                        .strip_prefix(&format!("{} ", request.method))
                         .unwrap()
                         .to_string();
 
@@ -3564,7 +3564,7 @@ impl GooseAttack {
                         self.record_error(&raw_request);
                     }
 
-                    let key = format!("{:?} {}", raw_request.method, raw_request.name);
+                    let key = format!("{} {}", raw_request.method, raw_request.name);
                     let mut merge_request = match self.metrics.requests.get(&key) {
                         Some(m) => m.clone(),
                         None => GooseRequest::new(&raw_request.name, raw_request.method, 0),
@@ -3598,7 +3598,7 @@ impl GooseAttack {
                 GooseMetric::Error(raw_error) => {
                     // Recreate the string used to uniquely identify errors.
                     let error_key = format!(
-                        "{}.{:?}.{}",
+                        "{}.{}.{}",
                         raw_error.error, raw_error.method, raw_error.name
                     );
                     let mut merge_error = match self.metrics.errors.get(&error_key) {
@@ -3635,7 +3635,7 @@ impl GooseAttack {
 
         // Create a string to uniquely identify errors for tracking metrics.
         let error_string = format!(
-            "{}.{:?}.{}",
+            "{}.{}.{}",
             raw_request.error, raw_request.method, raw_request.name
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2935,7 +2935,7 @@ impl GooseAttack {
                 );
             }
             for (index, send_to_user) in goose_attack_run_state.user_channels.iter().enumerate() {
-                match send_to_user.send(GooseUserCommand::EXIT) {
+                match send_to_user.send(GooseUserCommand::Exit) {
                     Ok(_) => {
                         debug!("telling user {} to exit", index);
                     }
@@ -3052,7 +3052,7 @@ impl GooseAttack {
                         ],
                         true,
                     ) {
-                        // EXIT received, cancel.
+                        // GooseUserCommand::Exit received, cancel.
                         goose_attack_run_state
                             .canceled
                             .store(true, Ordering::SeqCst);

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -164,10 +164,10 @@ fn merge_errors_from_worker(
     merged_error
 }
 
-/// Helper to send EXIT command to worker.
+/// Helper to send GooseUserCommand::Exit command to worker.
 fn tell_worker_to_exit(server: &Socket) -> bool {
     let mut message = Message::new();
-    serde_cbor::to_writer(&mut message, &GooseUserCommand::EXIT)
+    serde_cbor::to_writer(&mut message, &GooseUserCommand::Exit)
         .map_err(|error| eprintln!("{:?}", error))
         .expect("failed to serialize user command");
     send_message_to_worker(server, message)
@@ -398,7 +398,8 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                             workers.len() + 1,
                             goose_attack.configuration.expect_workers.unwrap()
                         );
-                        // We already have enough workers, tell this extra one to EXIT.
+                        // We already have enough workers, tell this extra one to
+                        // GooseUserCommand::Exit.
                         if !tell_worker_to_exit(&server) {
                             // All workers have exited, shut down the
                             // load test.
@@ -411,7 +412,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                         // GaggleMetrics::WorkerInit object or it's invalid.
                         if gaggle_metrics.len() != 1 {
                             warn!("invalid message from Worker, exiting load test");
-                            // Invalid message, tell worker to EXIT.
+                            // Invalid message, tell worker to GooseUserCommand::Exit.
                             if !tell_worker_to_exit(&server) {
                                 // All workers have exited, shut down the
                                 // load test.
@@ -430,7 +431,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                             }
                         } else {
                             // Unexpected object received, tell the worker
-                            // to EXIT.
+                            // to GooseUserCommand::Exit.
                             warn!("invalid object from Worker, exiting load test");
                             if !tell_worker_to_exit(&server) {
                                 // All workers have exited, shut down the
@@ -522,7 +523,7 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                     // test is still waiting to start.
                     if !load_test_running {
                         // Assume this is the Worker heartbeat, tell it to keep waiting.
-                        serde_cbor::to_writer(&mut message, &GooseUserCommand::WAIT)
+                        serde_cbor::to_writer(&mut message, &GooseUserCommand::Wait)
                             .map_err(|error| eprintln!("{:?}", error))
                             .expect("failed to serialize user command");
                         if !send_message_to_worker(&server, message) {
@@ -553,13 +554,13 @@ pub async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
 
                     if load_test_finished {
                         debug!("telling worker to exit");
-                        serde_cbor::to_writer(&mut message, &GooseUserCommand::EXIT)
+                        serde_cbor::to_writer(&mut message, &GooseUserCommand::Exit)
                             .map_err(|error| eprintln!("{:?}", error))
                             .expect("failed to serialize user command");
                     }
                     // Notify the worker that the load test is still running.
                     else {
-                        serde_cbor::to_writer(&mut message, &GooseUserCommand::RUN)
+                        serde_cbor::to_writer(&mut message, &GooseUserCommand::Run)
                             .map_err(|error| eprintln!("{:?}", error))
                             .expect("failed to serialize user command");
                     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -991,7 +991,7 @@ impl GooseMetrics {
         for error in self.errors.values() {
             errors.push((
                 error.occurrences,
-                format!("{:?} {}: {}", error.method, error.name, error.error),
+                format!("{} {}: {}", error.method, error.name, error.error),
             ));
         }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -115,7 +115,7 @@ pub async fn user_main(
             while message.is_ok() {
                 match message.unwrap() {
                     // Time to exit.
-                    GooseUserCommand::EXIT => {
+                    GooseUserCommand::Exit => {
                         // No need to reset per-thread counters, we're exiting and memory will be freed
                         thread_continue = false;
                     }

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -167,7 +167,7 @@ fn validate_closer_test(
         let expect_error = format_item("Item does not exist in goose_metrics", &item);
         let endpoint_metrics = goose_metrics
             .requests
-            .get(&format!("Get {}", item.path))
+            .get(&format!("GET {}", item.path))
             .expect(&expect_error);
 
         assert!(

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -167,7 +167,7 @@ fn validate_closer_test(
         let expect_error = format_item("Item does not exist in goose_metrics", &item);
         let endpoint_metrics = goose_metrics
             .requests
-            .get(&format!("GET {}", item.path))
+            .get(&format!("Get {}", item.path))
             .expect(&expect_error);
 
         assert!(
@@ -177,7 +177,7 @@ fn validate_closer_test(
                 &item
             )
         );
-        assert!(endpoint_metrics.method == GooseMethod::GET);
+        assert!(endpoint_metrics.method == GooseMethod::Get);
 
         // Confirm that Goose and the server saw the same number of page loads.
         let status_code: u16 = item.status_code;

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -155,16 +155,12 @@ fn validate_closer_test(
     for (idx, item) in test_endpoints.iter().enumerate() {
         let mock_endpoint = &mock_endpoints[idx];
 
-        let format_item = |message, assert_item| {
-            return format!("{} for item = {:#?}", message, assert_item);
-        };
-
         // Confirm that we loaded the mock endpoint.
         assert!(
             mock_endpoint.hits() > 0,
-            format_item("Endpoint was not called > 0", &item)
+            format!("Endpoint was not called > 0 for item: {:#?}", &item)
         );
-        let expect_error = format_item("Item does not exist in goose_metrics", &item);
+        let expect_error = format!("Item does not exist in goose_metrics: {:#?}", &item);
         let endpoint_metrics = goose_metrics
             .requests
             .get(&format!("GET {}", item.path))
@@ -172,9 +168,9 @@ fn validate_closer_test(
 
         assert!(
             endpoint_metrics.path == item.path,
-            format_item(
-                &format!("{} != {}", endpoint_metrics.path, item.path),
-                &item
+            format!(
+                "{} != {} for item: {:#?}",
+                endpoint_metrics.path, item.path, &item
             )
         );
         assert!(endpoint_metrics.method == GooseMethod::Get);
@@ -184,19 +180,19 @@ fn validate_closer_test(
 
         assert!(
             endpoint_metrics.response_time_counter == mock_endpoint.hits(),
-            format_item("response_time_counter != hits()", &item)
+            format!("response_time_counter != hits() for item: {:#?}", &item)
         );
         assert!(
             endpoint_metrics.status_code_counts[&status_code] == mock_endpoint.hits(),
-            format_item("status_code_counts != hits()", &item)
+            format!("status_code_counts != hits() for item: {:#?}", &item)
         );
         assert!(
             endpoint_metrics.success_count == mock_endpoint.hits(),
-            format_item("success_count != hits()", &item)
+            format!("success_count != hits() for item: {:#?}", &item)
         );
         assert!(
             endpoint_metrics.fail_count == 0,
-            format_item("fail_count != 0", &item)
+            format!("fail_count != 0 for item: {:#?}", &item)
         );
     }
 

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -158,7 +158,8 @@ fn validate_closer_test(
         // Confirm that we loaded the mock endpoint.
         assert!(
             mock_endpoint.hits() > 0,
-            format!("Endpoint was not called > 0 for item: {:#?}", &item)
+            "Endpoint was not called > 0 for item: {:#?}",
+            &item
         );
         let expect_error = format!("Item does not exist in goose_metrics: {:#?}", &item);
         let endpoint_metrics = goose_metrics
@@ -168,10 +169,10 @@ fn validate_closer_test(
 
         assert!(
             endpoint_metrics.path == item.path,
-            format!(
-                "{} != {} for item: {:#?}",
-                endpoint_metrics.path, item.path, &item
-            )
+            "{} != {} for item: {:#?}",
+            endpoint_metrics.path,
+            item.path,
+            &item
         );
         assert!(endpoint_metrics.method == GooseMethod::Get);
 
@@ -180,19 +181,23 @@ fn validate_closer_test(
 
         assert!(
             endpoint_metrics.response_time_counter == mock_endpoint.hits(),
-            format!("response_time_counter != hits() for item: {:#?}", &item)
+            "response_time_counter != hits() for item: {:#?}",
+            &item
         );
         assert!(
             endpoint_metrics.status_code_counts[&status_code] == mock_endpoint.hits(),
-            format!("status_code_counts != hits() for item: {:#?}", &item)
+            "status_code_counts != hits() for item: {:#?}",
+            &item
         );
         assert!(
             endpoint_metrics.success_count == mock_endpoint.hits(),
-            format!("success_count != hits() for item: {:#?}", &item)
+            "success_count != hits() for item: {:#?}",
+            &item
         );
         assert!(
             endpoint_metrics.fail_count == 0,
-            format!("fail_count != 0 for item: {:#?}", &item)
+            "fail_count != 0 for item: {:#?}",
+            &item
         );
     }
 

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -79,11 +79,11 @@ fn validate_test(
 
     let index_metrics = goose_metrics
         .requests
-        .get(&format!("Get {}", INDEX_PATH))
+        .get(&format!("GET {}", INDEX_PATH))
         .unwrap();
     let about_metrics = goose_metrics
         .requests
-        .get(&format!("Get {}", ABOUT_PATH))
+        .get(&format!("GET {}", ABOUT_PATH))
         .unwrap();
 
     // Confirm that Goose and the server saw the same number of page loads.

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -79,11 +79,11 @@ fn validate_test(
 
     let index_metrics = goose_metrics
         .requests
-        .get(&format!("GET {}", INDEX_PATH))
+        .get(&format!("Get {}", INDEX_PATH))
         .unwrap();
     let about_metrics = goose_metrics
         .requests
-        .get(&format!("GET {}", ABOUT_PATH))
+        .get(&format!("Get {}", ABOUT_PATH))
         .unwrap();
 
     // Confirm that Goose and the server saw the same number of page loads.

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -49,20 +49,18 @@ pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
 
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
-    // First, set up INDEX_PATH, store in vector at INDEX_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(INDEX_PATH);
-        then.status(200);
-    }));
-    // Next, set up ABOUT_PATH, store in vector at ABOUT_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(ABOUT_PATH);
-        then.status(200);
-    }));
-
-    endpoints
+    vec![
+        // First, set up INDEX_PATH, store in vector at INDEX_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(INDEX_PATH);
+            then.status(200);
+        }),
+        // Next, set up ABOUT_PATH, store in vector at ABOUT_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(ABOUT_PATH);
+            then.status(200);
+        }),
+    ]
 }
 
 // Helper to confirm all variations generate appropriate results.

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -91,11 +91,11 @@ fn validate_error(
     // Get request metrics.
     let index_metrics = goose_metrics
         .requests
-        .get(&format!("Get {}", INDEX_PATH))
+        .get(&format!("GET {}", INDEX_PATH))
         .unwrap();
     let a_404_metrics = goose_metrics
         .requests
-        .get(&format!("Get {}", A_404_PATH))
+        .get(&format!("GET {}", A_404_PATH))
         .unwrap();
 
     // Get error metrics.

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -41,20 +41,18 @@ pub async fn get_404_path(user: &GooseUser) -> GooseTaskResult {
 
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
-    // First set up INDEX_PATH, store in vector at INDEX_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(INDEX_PATH);
-        then.status(200);
-    }));
-    // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(A_404_PATH);
-        then.status(404);
-    }));
-
-    endpoints
+    vec![
+        // First set up INDEX_PATH, store in vector at INDEX_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(INDEX_PATH);
+            then.status(200);
+        }),
+        // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(A_404_PATH);
+            then.status(404);
+        }),
+    ]
 }
 
 // Build appropriate configuration for these tests.

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -91,11 +91,11 @@ fn validate_error(
     // Get request metrics.
     let index_metrics = goose_metrics
         .requests
-        .get(&format!("GET {}", INDEX_PATH))
+        .get(&format!("Get {}", INDEX_PATH))
         .unwrap();
     let a_404_metrics = goose_metrics
         .requests
-        .get(&format!("GET {}", A_404_PATH))
+        .get(&format!("Get {}", A_404_PATH))
         .unwrap();
 
     // Get error metrics.
@@ -103,9 +103,9 @@ fn validate_error(
 
     // Confirm that the path and method are correct in the metrics.
     assert!(index_metrics.path == INDEX_PATH);
-    assert!(index_metrics.method == GooseMethod::GET);
+    assert!(index_metrics.method == GooseMethod::Get);
     assert!(a_404_metrics.path == A_404_PATH);
-    assert!(a_404_metrics.method == GooseMethod::GET);
+    assert!(a_404_metrics.method == GooseMethod::Get);
 
     // All requests to the index succeeded.
     mock_endpoints[INDEX_KEY].assert_hits(index_metrics.response_time_counter);
@@ -121,7 +121,7 @@ fn validate_error(
             // Extract the error from the BTreeMap.
             for error in a_404_errors {
                 // The captured error was a GET request.
-                assert!(error.1.method == GooseMethod::GET);
+                assert!(error.1.method == GooseMethod::Get);
                 // The captured error was for the 404 path.
                 assert!(error.1.name == A_404_PATH);
                 // The error was captured the number of times we requested the 404 path.

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -67,20 +67,18 @@ pub async fn get_error(user: &GooseUser) -> GooseTaskResult {
 
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
-    // First, set up INDEX_PATH, store in vector at INDEX_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(INDEX_PATH);
-        then.status(200);
-    }));
-    // Next, set up ERROR_PATH, store in vector at ERROR_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(ERROR_PATH);
-        then.status(503);
-    }));
-
-    endpoints
+    vec![
+        // First, set up INDEX_PATH, store in vector at INDEX_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(INDEX_PATH);
+            then.status(200);
+        }),
+        // Next, set up ERROR_PATH, store in vector at ERROR_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(ERROR_PATH);
+            then.status(503);
+        }),
+    ]
 }
 
 // Returns the appropriate taskset, start_task and stop_task needed to build these tests.

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -38,20 +38,18 @@ pub async fn logout(user: &GooseUser) -> GooseTaskResult {
 
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
-    // First set up LOGIN_PATH, store in vector at LOGIN_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(POST).path(LOGIN_PATH);
-        then.status(200);
-    }));
-    // Next set up LOGOUT_PATH, store in vector at LOGOUT_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(LOGOUT_PATH);
-        then.status(200);
-    }));
-
-    endpoints
+    vec![
+        // First set up LOGIN_PATH, store in vector at LOGIN_KEY.
+        server.mock(|when, then| {
+            when.method(POST).path(LOGIN_PATH);
+            then.status(200);
+        }),
+        // Next set up LOGOUT_PATH, store in vector at LOGOUT_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(LOGOUT_PATH);
+            then.status(200);
+        }),
+    ]
 }
 
 // Build appropriate configuration for these tests.

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -96,11 +96,11 @@ fn validate_one_taskset(
     // Get index and about out of goose metrics.
     let index_metrics = goose_metrics
         .requests
-        .get(&format!("Get {}", INDEX_PATH))
+        .get(&format!("GET {}", INDEX_PATH))
         .unwrap();
     let about_metrics = goose_metrics
         .requests
-        .get(&format!("Get {}", ABOUT_PATH))
+        .get(&format!("GET {}", ABOUT_PATH))
         .unwrap();
 
     // Confirm that the path and method are correct in the statistics.

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -41,20 +41,18 @@ pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
 
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
-    // First set up INDEX_PATH, store in vector at INDEX_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(INDEX_PATH);
-        then.status(200);
-    }));
-    // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(ABOUT_PATH);
-        then.status(200);
-    }));
-
-    endpoints
+    vec![
+        // First set up INDEX_PATH, store in vector at INDEX_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(INDEX_PATH);
+            then.status(200);
+        }),
+        // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(ABOUT_PATH);
+            then.status(200);
+        }),
+    ]
 }
 
 // Build appropriate configuration for these tests.

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -96,18 +96,18 @@ fn validate_one_taskset(
     // Get index and about out of goose metrics.
     let index_metrics = goose_metrics
         .requests
-        .get(&format!("GET {}", INDEX_PATH))
+        .get(&format!("Get {}", INDEX_PATH))
         .unwrap();
     let about_metrics = goose_metrics
         .requests
-        .get(&format!("GET {}", ABOUT_PATH))
+        .get(&format!("Get {}", ABOUT_PATH))
         .unwrap();
 
     // Confirm that the path and method are correct in the statistics.
     assert!(index_metrics.path == INDEX_PATH);
-    assert!(index_metrics.method == GooseMethod::GET);
+    assert!(index_metrics.method == GooseMethod::Get);
     assert!(about_metrics.path == ABOUT_PATH);
-    assert!(about_metrics.method == GooseMethod::GET);
+    assert!(about_metrics.method == GooseMethod::Get);
 
     let status_code: u16 = 200;
     match test_type {

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -97,69 +97,69 @@ fn setup_mock_server_endpoints<'a>(
     server: &'a MockServer,
     server2: Option<&'a MockServer>,
 ) -> Vec<MockRef<'a>> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
     match test_type {
         TestType::Chain => {
-            // First set up INDEX_PATH, store in vector at INDEX_KEY.
-            endpoints.push(server.mock(|when, then| {
-                when.method(GET).path(INDEX_PATH);
-                then.status(200);
-            }));
-            // Next set up REDIRECT_PATH, store in vector at REDIRECT_KEY.
-            endpoints.push(server.mock(|when, then| {
-                when.method(GET).path(REDIRECT_PATH);
-                then.status(301).header("Location", REDIRECT2_PATH);
-            }));
-            // Next set up REDIRECT2_PATH, store in vector at REDIRECT2_KEY.
-            endpoints.push(server.mock(|when, then| {
-                when.method(GET).path(REDIRECT2_PATH);
-                then.status(302).header("Location", REDIRECT3_PATH);
-            }));
-            // Next set up REDIRECT3_PATH, store in vector at REDIRECT3_KEY.
-            endpoints.push(server.mock(|when, then| {
-                when.method(GET).path(REDIRECT3_PATH);
-                then.status(303).header("Location", ABOUT_PATH);
-            }));
-            // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
-            endpoints.push(server.mock(|when, then| {
-                when.method(GET).path(ABOUT_PATH);
-                then.status(200)
-                    .body("<HTML><BODY>about page</BODY></HTML>");
-            }));
+            vec![
+                // First set up INDEX_PATH, store in vector at INDEX_KEY.
+                server.mock(|when, then| {
+                    when.method(GET).path(INDEX_PATH);
+                    then.status(200);
+                }),
+                // Next set up REDIRECT_PATH, store in vector at REDIRECT_KEY.
+                server.mock(|when, then| {
+                    when.method(GET).path(REDIRECT_PATH);
+                    then.status(301).header("Location", REDIRECT2_PATH);
+                }),
+                // Next set up REDIRECT2_PATH, store in vector at REDIRECT2_KEY.
+                server.mock(|when, then| {
+                    when.method(GET).path(REDIRECT2_PATH);
+                    then.status(302).header("Location", REDIRECT3_PATH);
+                }),
+                // Next set up REDIRECT3_PATH, store in vector at REDIRECT3_KEY.
+                server.mock(|when, then| {
+                    when.method(GET).path(REDIRECT3_PATH);
+                    then.status(303).header("Location", ABOUT_PATH);
+                }),
+                // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
+                server.mock(|when, then| {
+                    when.method(GET).path(ABOUT_PATH);
+                    then.status(200)
+                        .body("<HTML><BODY>about page</BODY></HTML>");
+                }),
+            ]
         }
         TestType::Domain | TestType::Sticky => {
-            // First set up INDEX_PATH, store in vector at SERVER1_INDEX_KEY.
-            endpoints.push(server.mock(|when, then| {
-                when.method(GET).path(INDEX_PATH);
-                then.status(200);
-            }));
-            // Next set up ABOUT_PATH, store in vector at SERVER1_ABOUT_KEY.
-            endpoints.push(server.mock(|when, then| {
-                when.method(GET).path(ABOUT_PATH);
-                then.status(200)
-                    .body("<HTML><BODY>about page</BODY></HTML>");
-            }));
-            // Next set up REDIRECT_PATH, store in vector at SERVER1_REDIRECT_KEY.
-            endpoints.push(server.mock(|when, then| {
-                when.method(GET).path(REDIRECT_PATH);
-                then.status(301)
-                    .header("Location", &server2.unwrap().url(INDEX_PATH));
-            }));
-            // Next set up INDEX_PATH on server 2, store in vector at SERVER2_INDEX_KEY.
-            endpoints.push(server2.unwrap().mock(|when, then| {
-                when.method(GET).path(INDEX_PATH);
-                then.status(200);
-            }));
-            // Next set up ABOUT_PATH on server 2, store in vector at SERVER2_ABOUT_KEY.
-            endpoints.push(server2.unwrap().mock(|when, then| {
-                when.method(GET).path(ABOUT_PATH);
-                then.status(200);
-            }));
+            vec![
+                // First set up INDEX_PATH, store in vector at SERVER1_INDEX_KEY.
+                server.mock(|when, then| {
+                    when.method(GET).path(INDEX_PATH);
+                    then.status(200);
+                }),
+                // Next set up ABOUT_PATH, store in vector at SERVER1_ABOUT_KEY.
+                server.mock(|when, then| {
+                    when.method(GET).path(ABOUT_PATH);
+                    then.status(200)
+                        .body("<HTML><BODY>about page</BODY></HTML>");
+                }),
+                // Next set up REDIRECT_PATH, store in vector at SERVER1_REDIRECT_KEY.
+                server.mock(|when, then| {
+                    when.method(GET).path(REDIRECT_PATH);
+                    then.status(301)
+                        .header("Location", &server2.unwrap().url(INDEX_PATH));
+                }),
+                // Next set up INDEX_PATH on server 2, store in vector at SERVER2_INDEX_KEY.
+                server2.unwrap().mock(|when, then| {
+                    when.method(GET).path(INDEX_PATH);
+                    then.status(200);
+                }),
+                // Next set up ABOUT_PATH on server 2, store in vector at SERVER2_ABOUT_KEY.
+                server2.unwrap().mock(|when, then| {
+                    when.method(GET).path(ABOUT_PATH);
+                    then.status(200);
+                }),
+            ]
         }
     }
-
-    endpoints
 }
 
 // Build appropriate configuration for these tests.

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -65,30 +65,28 @@ pub async fn stop_one(user: &GooseUser) -> GooseTaskResult {
 
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
-    // First set up ONE_PATH, store in vector at ONE_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(ONE_PATH);
-        then.status(200);
-    }));
-    // Next set up TWO_PATH, store in vector at TWO_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(TWO_PATH);
-        then.status(200);
-    }));
-    // Next set up START_ONE_PATH, store in vector at START_ONE_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(START_ONE_PATH);
-        then.status(200);
-    }));
-    // Next set up STOP_ONE_PATH, store in vector at STOP_ONE_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(STOP_ONE_PATH);
-        then.status(200);
-    }));
-
-    endpoints
+    vec![
+        // First set up ONE_PATH, store in vector at ONE_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(ONE_PATH);
+            then.status(200);
+        }),
+        // Next set up TWO_PATH, store in vector at TWO_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(TWO_PATH);
+            then.status(200);
+        }),
+        // Next set up START_ONE_PATH, store in vector at START_ONE_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(START_ONE_PATH);
+            then.status(200);
+        }),
+        // Next set up STOP_ONE_PATH, store in vector at STOP_ONE_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(STOP_ONE_PATH);
+            then.status(200);
+        }),
+    ]
 }
 
 // Build appropriate configuration for these tests.

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -77,35 +77,33 @@ pub async fn stop_one(user: &GooseUser) -> GooseTaskResult {
 
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
-    // First set up ONE_PATH, store in vector at ONE_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(ONE_PATH);
-        then.status(200);
-    }));
-    // Next set up TWO_PATH, store in vector at TWO_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(TWO_PATH);
-        then.status(200);
-    }));
-    // Next set up THREE_PATH, store in vector at THREE_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(THREE_PATH);
-        then.status(200);
-    }));
-    // Next set up START_ONE_PATH, store in vector at START_ONE_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(START_ONE_PATH);
-        then.status(200);
-    }));
-    // Next set up STOP_ONE_PATH, store in vector at STOP_ONE_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(STOP_ONE_PATH);
-        then.status(200);
-    }));
-
-    endpoints
+    vec![
+        // First set up ONE_PATH, store in vector at ONE_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(ONE_PATH);
+            then.status(200);
+        }),
+        // Next set up TWO_PATH, store in vector at TWO_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(TWO_PATH);
+            then.status(200);
+        }),
+        // Next set up THREE_PATH, store in vector at THREE_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(THREE_PATH);
+            then.status(200);
+        }),
+        // Next set up START_ONE_PATH, store in vector at START_ONE_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(START_ONE_PATH);
+            then.status(200);
+        }),
+        // Next set up STOP_ONE_PATH, store in vector at STOP_ONE_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(STOP_ONE_PATH);
+            then.status(200);
+        }),
+    ]
 }
 
 // Build appropriate configuration for these tests.

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -56,25 +56,23 @@ pub async fn get_index(user: &GooseUser) -> GooseTaskResult {
 
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
-    // First set up INDEX_PATH, store in vector at INDEX_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(INDEX_PATH);
-        then.status(201);
-    }));
-    // Next set up SETUP_PATH, store in vector at SETUP_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(POST).path(SETUP_PATH);
-        then.status(205);
-    }));
-    // Next set up TEARDOWN_PATH, store in vector at TEARDOWN_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(POST).path(TEARDOWN_PATH);
-        then.status(200);
-    }));
-
-    endpoints
+    vec![
+        // First set up INDEX_PATH, store in vector at INDEX_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(INDEX_PATH);
+            then.status(201);
+        }),
+        // Next set up SETUP_PATH, store in vector at SETUP_KEY.
+        server.mock(|when, then| {
+            when.method(POST).path(SETUP_PATH);
+            then.status(205);
+        }),
+        // Next set up TEARDOWN_PATH, store in vector at TEARDOWN_KEY.
+        server.mock(|when, then| {
+            when.method(POST).path(TEARDOWN_PATH);
+            then.status(200);
+        }),
+    ]
 }
 
 // Build appropriate configuration for these tests.

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -34,20 +34,18 @@ pub async fn get_about(user: &GooseUser) -> GooseTaskResult {
 
 // All tests in this file run against common endpoints.
 fn setup_mock_server_endpoints(server: &MockServer) -> Vec<MockRef> {
-    let mut endpoints: Vec<MockRef> = Vec::new();
-
-    // First set up INDEX_PATH, store in vector at INDEX_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(INDEX_PATH);
-        then.status(200);
-    }));
-    // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
-    endpoints.push(server.mock(|when, then| {
-        when.method(GET).path(ABOUT_PATH);
-        then.status(200);
-    }));
-
-    endpoints
+    vec![
+        // First set up INDEX_PATH, store in vector at INDEX_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(INDEX_PATH);
+            then.status(200);
+        }),
+        // Next set up ABOUT_PATH, store in vector at ABOUT_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(ABOUT_PATH);
+            then.status(200);
+        }),
+    ]
 }
 
 // Build appropriate configuration for these tests.


### PR DESCRIPTION
 - fixes #262, following the Rust naming conventions in regards to case as defined in https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case
 - uses a custom display format to display methods so the name continues to be all caps as expected, for example `GET` instead of `Get`
 - removes a lingering `panic!()` that was incorrectly formatted for Rust 2021, replacing it with a correctly formatted error
 - optimize vector creation by avoiding creating a mutable vector then pushing data multiple times, instead using the more performant and easier to read `vec![]` macro (https://rust-lang.github.io/rust-clippy/master/index.html#vec_init_then_push)
 - call `format!` directly in closure test for improved readability