### PR TITLE
respect GooseScheduler when allocating GooseTasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  - update dependencies: `itertools` to `0.10`, `simplelog` to `0.10`, `url` to `2`
  - update `nng` dependency for optional `gaggle` feature
  - simplify `examples/umami` regex when parsing form
- - allow configuration of algorithm used when allocating `GooseTask`s, in addition to when allocating `GooseTaskSet`s; `GooseTaskSetScheduler` becomes more generically `GooseScheduler`
+ - allow configuration of algorithm for allocating `GooseTask`s the same as `GooseTaskSet`s; `GooseTaskSetScheduler` becomes more generically `GooseScheduler`
 
 ## 0.11.0 April 9, 2021
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - update dependencies: `itertools` to `0.10`, `simplelog` to `0.10`, `url` to `2`
  - update `nng` dependency for optional `gaggle` feature
  - simplify `examples/umami` regex when parsing form
+ - allow configuration of algorithm used when allocating `GooseTask`s, in addition to when allocating `GooseTaskSet`s; `GooseTaskSetScheduler` becomes more generically `GooseScheduler`
 
 ## 0.11.0 April 9, 2021
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`

--- a/README.md
+++ b/README.md
@@ -352,38 +352,81 @@ All 1024 users hatched.
 
 ## Scheduling GooseTaskSets
 
-When starting a load test, Goose assigns one `GooseTaskSet` to each `GooseUser` thread. By default, it assigns `GooseTaskSet`s (and `GooseTask`s within the task set) in a round robin order. As new `GooseUser` threads are launched, the first will be assigned the first defined `GooseTaskSet`, the next will be assigned the next defined `GooseTaskSet`, and so on, looping through all available `GooseTaskSet`s. Weighting is respected during this process, so if one `GooseTaskSet` is weighted heavier than others, that `GooseTaskSet` will get assigned more at the end of the launching process.
+When starting a load test, Goose assigns one `GooseTaskSet` to each `GooseUser` thread. By default, it assigns `GooseTaskSet`s (and then `GooseTask`s within the task set) in a round robin order. As new `GooseUser` threads are launched, the first will be assigned the first defined `GooseTaskSet`, the next will be assigned the next defined `GooseTaskSet`, and so on, looping through all available `GooseTaskSet`s. Weighting is respected during this process, so if one `GooseTaskSet` is weighted heavier than others, that `GooseTaskSet` will get assigned to `GooseUser`s more at the end of the launching process.
 
-It is also possible to allocate `GooseTaskSet`s and `GooseTask`s in a serial or random order. When allocating `GooseTaskSet`s and `GooseTask`s serially, they are launched in the exact order and weighting as they are defined in the load test. When allocating randomly, running the same load test multiple times can generate different amounts of load.
+The `GooseScheduler` can be configured to instead launch `GooseTaskSet`s and `GooseTask`s in a `Serial` or a `Random order`. When configured to allocate in a `Serial` order, `GooseTaskSet`s and `GooseTask`s are launched in the extact order they are defined in the load test (see below for more detail on how this works). When configured to allocate in a `Random` order, running the same load test multiple times can lead to different amounts of load being generated.
 
-Prior to Goose `0.10.6` `GooseTaskSet`s were allocated in a serial order. To restore this behavior, you can use the `.set_scheduler()` function as follows:
+Prior to Goose `0.10.6` `GooseTaskSet`s were allocated in a serial order. Prior to Goose `0.11.1` `GooseTask`s were allocated in a serial order. To restore the old behavior, you can use the `GooseAttack::set_scheduler()` method as follows:
 
-```
+```rust
     GooseAttack::initialize()?
         .set_scheduler(GooseScheduler::Serial)
 ```
 
-Or, to randomize the order `GooseTaskSet`s are allocated to newly launched users, you can instead configure your `GooseAttack` as follows:
+To instead randomize the order that `GooseTaskSet`s and `GooseTask`s are allocated, you can instead configure as follows:
 
-```
+```rust
     GooseAttack::initialize()?
         .set_scheduler(GooseScheduler::Random)
 ```
 
-The following configuration is possible but superfluous because it is the scheduling default:
+The following configuration is possible but superfluous because it is the scheduling default, and is therefor how Goose behaves even if the `.set_scheduler()` method is not called at all:
 
-```
+```rust
     GooseAttack::initialize()?
         .set_scheduler(GooseScheduler::RoundRobin)
 ```
 
-Prior to Goose `0.11.1` `GooseTask`s were allocated in a random order regardless of what `GooseScheduler` was configured. Starting with `0.11.1` Goose respects the configured `GooseScheduler` both when scheduling `GooseTaskSet`s and `GooseTask`s.
+### Scheduling Example
+
+The following simple example helps illustrate how the different schedulers work.
+
+```rust
+    GooseAttack::initialize()?
+        .register_taskset(taskset!("TaskSet1")
+            .register_task(task!(task1).set_weight(2)?)
+            .register_task(task!(task2))
+            .set_weight(2)?
+        )
+        .register_taskset(taskset!("TaskSet2")
+            .register_task(task!(task1))
+            .register_task(task!(task2).set_weight(2)?)
+        )
+        .execute()?
+        .print();
+    
+    Ok(())
+```
+
+### Round Robin
+
+This first example assumes the default of `.set_scheduler(GooseScheduler::RoundRobin)`.
+
+If Goose is told to launch only two users, the first GooseUser will run `TaskSet1` and the second user will run `TaskSet2`. Even though `TaskSet1` has a weight of 2 `GooseUser`s are allocated round-robin so with only two users the second instance of `TaskSet1` is never launched.
+
+The `GooseUser` running `TaskSet1` will then launch tasks repeatedly in the following order: `task1`, `task2`, `task1`. If it runs through twice, then it runs all of the following tasks in the following order: `task1`, `task2`, `task1`, `task1`, `task2`, `task1`.
+
+### Serial
+
+This second example assumes the manual configuration of `.set_scheduler(GooseScheduler::Serial)`.
+
+If Goose is told to launch only two users, then both `GooseUser`s will launch `TaskSet1` as it has a weight of 2. `TaskSet2` will not get assigned to either of the users.
+
+Both `GooseUser`s running `TaskSet1` will then launch tasks repeatedly in the following order: `task1`, `task1`, `task2`. If it runs through twice, then it runs all of the following tasks in the following order: `task1`, `task1`, `task2`, `task1`, `task1`, `task2`.
+
+### Random
+
+This third example assumes the manual configuration of `.set_scheduler(GooseScheduler::Random)`.
+
+If Goose is told to launch only two users, the first will be randomly assigned either `TaskSet1` or `TaskSet2`. Regardless of which is assigned to the first user, the second will again be randomly assigned either `TaskSet1` or `TaskSet2`. If the load test is stopped and run again, there users are randomly re-assigned, there is no consistency between load test runs.
+
+Each `GooseUser` will run tasks in a random order. The random order will be determined at start time and then will run repeatedly in this random order as long as the user runs.
 
 ## Defaults
 
 All run-time options can be configured with custom defaults. For example, you may want to default to the the host name of your local development environment, only requiring that `--host` be set when running against a production environment. Assuming your local development environment is at "http://local.dev/" you can do this as follows:
 
-```
+```rust
     GooseAttack::initialize()?
         .register_taskset(taskset!("LoadtestTasks")
             .register_task(task!(loadtest_index))
@@ -430,7 +473,7 @@ The following defaults can be configured with a `bool`:
 
 For example, without any run-time options the following load test would automatically run against `local.dev`, logging metrics to `goose-metrics.log` and debug to `goose-debug.log`. It will automatically launch 20 users in 4 seconds, and run the load test for 15 minutes. Metrics will be displayed every minute during the test and will include additional status code metrics. The order the defaults are set is not important.
 
-```
+```rust
     GooseAttack::initialize()?
         .register_taskset(taskset!("LoadtestTasks")
             .register_task(task!(loadtest_index))

--- a/README.md
+++ b/README.md
@@ -352,30 +352,32 @@ All 1024 users hatched.
 
 ## Scheduling GooseTaskSets
 
-When starting a load test, Goose assigns one `GooseTaskSet` to each `GooseUser` thread. By default, it assigns `GooseTaskSets` in a round robin order. As new `GooseUser` threads are launched, the first will be assigned the first defined `GooseTaskSet`, the next will be assigned the next defined `GooseTaskSet`, and so on, looping through all available `GooseTaskSet`s. Weighting is respected during this process, so if one `GooseTaskSet` is weighted heavier than others, that `GooseTaskSet` will get assigned more at the end of the launching process.
+When starting a load test, Goose assigns one `GooseTaskSet` to each `GooseUser` thread. By default, it assigns `GooseTaskSet`s (and `GooseTask`s within the task set) in a round robin order. As new `GooseUser` threads are launched, the first will be assigned the first defined `GooseTaskSet`, the next will be assigned the next defined `GooseTaskSet`, and so on, looping through all available `GooseTaskSet`s. Weighting is respected during this process, so if one `GooseTaskSet` is weighted heavier than others, that `GooseTaskSet` will get assigned more at the end of the launching process.
 
-It is also possible to allocate `GooseTaskSet`s in a serial or random order. When allocating `GooseTaskSet`s serially, they are launched in the exact order and weighting as they are defined in the load test. When allocating randomly, running the same load test multiple times can generate different amounts of load.
+It is also possible to allocate `GooseTaskSet`s and `GooseTask`s in a serial or random order. When allocating `GooseTaskSet`s and `GooseTask`s serially, they are launched in the exact order and weighting as they are defined in the load test. When allocating randomly, running the same load test multiple times can generate different amounts of load.
 
 Prior to Goose `0.10.6` `GooseTaskSet`s were allocated in a serial order. To restore this behavior, you can use the `.set_scheduler()` function as follows:
 
 ```
     GooseAttack::initialize()?
-        .set_scheduler(GooseTaskSetScheduler::Serial)
+        .set_scheduler(GooseScheduler::Serial)
 ```
 
 Or, to randomize the order `GooseTaskSet`s are allocated to newly launched users, you can instead configure your `GooseAttack` as follows:
 
 ```
     GooseAttack::initialize()?
-        .set_scheduler(GooseTaskSetScheduler::Random)
+        .set_scheduler(GooseScheduler::Random)
 ```
 
 The following configuration is possible but superfluous because it is the scheduling default:
 
 ```
     GooseAttack::initialize()?
-        .set_scheduler(GooseTaskSetScheduler::RoundRobin)
+        .set_scheduler(GooseScheduler::RoundRobin)
 ```
+
+Prior to Goose `0.11.1` `GooseTask`s were allocated in a random order regardless of what `GooseScheduler` was configured. Starting with `0.11.1` Goose respects the configured `GooseScheduler` both when scheduling `GooseTaskSet`s and `GooseTask`s.
 
 ## Defaults
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4170,7 +4170,7 @@ fn allocate_tasks(
 fn weight_unsequenced_tasks(unsequenced_tasks: &[GooseTask], u: usize) -> (Vec<Vec<usize>>, usize) {
     // Build a vector of vectors to be used to schedule users.
     let mut available_unsequenced_tasks = Vec::with_capacity(unsequenced_tasks.len());
-    let mut total_tasks = 1;
+    let mut total_tasks = 0;
     for task in unsequenced_tasks.iter() {
         // divide by greatest common divisor so vector is as short as possible
         let weight = task.weight / u;
@@ -4213,7 +4213,7 @@ fn schedule_sequenced_tasks(
     let mut weighted_tasks: Vec<usize> = Vec::new();
 
     for (_sequence, tasks) in available_sequenced_tasks.iter() {
-        let scheduled_tasks = schedule_unsequenced_tasks(tasks, tasks[0].len() + 1, scheduler);
+        let scheduled_tasks = schedule_unsequenced_tasks(tasks, tasks[0].len(), scheduler);
         weighted_tasks.extend(scheduled_tasks);
     }
 
@@ -4244,7 +4244,7 @@ fn schedule_unsequenced_tasks(
                         weighted_tasks.push(task);
                     }
                 }
-                if weighted_tasks.len() + 1 >= total_tasks {
+                if weighted_tasks.len() >= total_tasks {
                     break;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,6 +436,7 @@ use lazy_static::lazy_static;
 #[cfg(feature = "gaggle")]
 use nng::Socket;
 use rand::seq::SliceRandom;
+use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use simplelog::*;
@@ -470,7 +471,12 @@ lazy_static! {
 }
 
 /// Internal representation of a weighted task list.
-type WeightedGooseTasks = Vec<Vec<(usize, String)>>;
+type WeightedGooseTasks = Vec<(usize, String)>;
+
+/// Internal representation of unsequenced tasks.
+type UnsequencedGooseTasks = Vec<GooseTask>;
+/// Internal representation of sequenced tasks.
+type SequencedGooseTasks = BTreeMap<usize, Vec<GooseTask>>;
 
 type DebugLoggerHandle = Option<tokio::task::JoinHandle<()>>;
 type DebugLoggerChannel = Option<flume::Sender<Option<GooseDebug>>>;
@@ -818,7 +824,7 @@ pub struct GooseAttack {
     attack_mode: AttackMode,
     /// Which mode this GooseAttack is operating in.
     attack_phase: AttackPhase,
-    /// Defines the order GooseTaskSets are allocated to GooseUsers at startup time.
+    /// Defines the order GooseTaskSets and GooseTasks are allocated.
     scheduler: GooseScheduler,
     /// When the load test started.
     started: Option<time::Instant>,
@@ -1112,8 +1118,8 @@ impl GooseAttack {
 
     /// Use configured GooseScheduler to build out a properly
     /// weighted list of TaskSets to be assigned to GooseUsers.
-    fn allocate_tasks(&mut self) -> Vec<usize> {
-        trace!("allocate_tasks");
+    fn allocate_task_sets(&mut self) -> Vec<usize> {
+        trace!("allocate_task_sets");
 
         let mut u: usize = 0;
         let mut v: usize;
@@ -1211,7 +1217,7 @@ impl GooseAttack {
     fn weight_task_set_users(&mut self) -> Result<Vec<GooseUser>, GooseError> {
         trace!("weight_task_set_users");
 
-        let weighted_task_sets = self.allocate_tasks();
+        let weighted_task_sets = self.allocate_task_sets();
 
         // Allocate a state for each user that will be hatched.
         info!("initializing user states...");
@@ -1251,7 +1257,7 @@ impl GooseAttack {
     fn prepare_worker_task_set_users(&mut self) -> Result<Vec<GaggleUser>, GooseError> {
         trace!("prepare_worker_task_set_users");
 
-        let weighted_task_sets = self.allocate_tasks();
+        let weighted_task_sets = self.allocate_task_sets();
 
         // Determine the users sent to each Worker.
         info!("preparing users for Workers...");
@@ -2370,7 +2376,7 @@ impl GooseAttack {
         // Apply weights to tasks in each task set.
         for task_set in &mut self.task_sets {
             let (weighted_on_start_tasks, weighted_tasks, weighted_on_stop_tasks) =
-                weight_tasks(&task_set);
+                allocate_tasks(&task_set, &self.scheduler);
             task_set.weighted_on_start_tasks = weighted_on_start_tasks;
             task_set.weighted_tasks = weighted_tasks;
             task_set.weighted_on_stop_tasks = weighted_on_stop_tasks;
@@ -4012,23 +4018,32 @@ pub struct GooseConfiguration {
     pub manager_port: u16,
 }
 
-/// Returns sequenced buckets of weighted usize pointers to and names of Goose Tasks
-fn weight_tasks(
+/// Use the configured GooseScheduler to allocate all GooseTasks within the
+/// GooseTaskSet in the appropriate order. Returns three set of ordered tasks:
+/// `on_start_tasks`, `tasks`, and `on_stop_tasks`. The `on_start_tasks` are
+/// only run once when the GooseAttack first starts. Normal `tasks` are then
+/// run for the duration of the GooseAttack. The `on_stop_tasks` finally are
+/// only run once when the GooseAttack stops.
+fn allocate_tasks(
     task_set: &GooseTaskSet,
+    scheduler: &GooseScheduler,
 ) -> (WeightedGooseTasks, WeightedGooseTasks, WeightedGooseTasks) {
-    trace!("weight_tasks for {}", task_set.name);
+    info!(
+        "allocating GooseTasks on GooseUsers with {:?} scheduler",
+        scheduler
+    );
 
     // A BTreeMap of Vectors allows us to group and sort tasks per sequence value.
-    let mut sequenced_tasks: BTreeMap<usize, Vec<GooseTask>> = BTreeMap::new();
-    let mut sequenced_on_start_tasks: BTreeMap<usize, Vec<GooseTask>> = BTreeMap::new();
-    let mut sequenced_on_stop_tasks: BTreeMap<usize, Vec<GooseTask>> = BTreeMap::new();
-    let mut unsequenced_tasks: Vec<GooseTask> = Vec::new();
-    let mut unsequenced_on_start_tasks: Vec<GooseTask> = Vec::new();
-    let mut unsequenced_on_stop_tasks: Vec<GooseTask> = Vec::new();
+    let mut sequenced_tasks: SequencedGooseTasks = BTreeMap::new();
+    let mut sequenced_on_start_tasks: SequencedGooseTasks = BTreeMap::new();
+    let mut sequenced_on_stop_tasks: SequencedGooseTasks = BTreeMap::new();
+    let mut unsequenced_tasks: UnsequencedGooseTasks = Vec::new();
+    let mut unsequenced_on_start_tasks: UnsequencedGooseTasks = Vec::new();
+    let mut unsequenced_on_stop_tasks: UnsequencedGooseTasks = Vec::new();
     let mut u: usize = 0;
     let mut v: usize;
 
-    // Handle ordering of tasks.
+    // Find the greatest common divisor of all tasks in the task_set.
     for task in &task_set.tasks {
         if task.sequence > 0 {
             if task.on_start {
@@ -4083,140 +4098,192 @@ fn weight_tasks(
     // 'u' will always be the greatest common divisor
     debug!("gcd: {}", u);
 
-    // First apply weights to sequenced tasks.
-    let mut weighted_tasks: WeightedGooseTasks = Vec::new();
-    for (_sequence, tasks) in sequenced_tasks.iter() {
-        let mut sequence_weighted_tasks = Vec::new();
-        for task in tasks {
-            // divide by greatest common divisor so bucket is as small as possible
-            let weight = task.weight / u;
-            trace!(
-                "{}: {} has weight of {} (reduced with gcd to {})",
-                task.tasks_index,
-                task.name,
-                task.weight,
-                weight
-            );
-            // Weighted list of tuples holding the id and name of the task.
-            let mut tasks = vec![(task.tasks_index, task.name.to_string()); weight];
-            sequence_weighted_tasks.append(&mut tasks);
-        }
-        // Add in vectors grouped by sequence value, ordered lowest to highest value.
-        weighted_tasks.push(sequence_weighted_tasks);
+    // Apply weights to sequenced tasks.
+    let (weighted_sequenced_on_start_tasks, total_sequenced_on_start_tasks) =
+        weight_sequenced_tasks(&sequenced_on_start_tasks, u);
+    let (weighted_sequenced_tasks, total_sequenced_tasks) =
+        weight_sequenced_tasks(&sequenced_tasks, u);
+    let (weighted_sequenced_on_stop_tasks, total_sequenced_on_stop_tasks) =
+        weight_sequenced_tasks(&sequenced_on_stop_tasks, u);
+
+    // Apply weights to unsequenced tasks.
+    let (weighted_unsequenced_on_start_tasks, total_unsequenced_on_start_tasks) =
+        weight_unsequenced_tasks(&unsequenced_on_start_tasks, u);
+    let (weighted_unsequenced_tasks, total_unsequenced_tasks) =
+        weight_unsequenced_tasks(&unsequenced_tasks, u);
+    let (weighted_unsequenced_on_stop_tasks, total_unsequenced_on_stop_tasks) =
+        weight_unsequenced_tasks(&unsequenced_on_stop_tasks, u);
+
+    // Schedule sequenced tasks.
+    let scheduled_sequenced_on_start_tasks = schedule_sequenced_tasks(
+        &weighted_sequenced_on_start_tasks,
+        total_sequenced_on_start_tasks,
+        scheduler,
+    );
+    let scheduled_sequenced_tasks =
+        schedule_sequenced_tasks(&weighted_sequenced_tasks, total_sequenced_tasks, scheduler);
+    let scheduled_sequenced_on_stop_tasks = schedule_sequenced_tasks(
+        &weighted_sequenced_on_stop_tasks,
+        total_sequenced_on_stop_tasks,
+        scheduler,
+    );
+
+    // Schedule unsequenced tasks.
+    let scheduled_unsequenced_on_start_tasks = schedule_unsequenced_tasks(
+        &weighted_unsequenced_on_start_tasks,
+        total_unsequenced_on_start_tasks,
+        scheduler,
+    );
+    let scheduled_unsequenced_tasks = schedule_unsequenced_tasks(
+        &weighted_unsequenced_tasks,
+        total_unsequenced_tasks,
+        scheduler,
+    );
+    let scheduled_unsequenced_on_stop_tasks = schedule_unsequenced_tasks(
+        &weighted_unsequenced_on_stop_tasks,
+        total_unsequenced_on_stop_tasks,
+        scheduler,
+    );
+
+    // Finally build a Vector of tuples: (task id, task name)
+    let mut on_start_tasks = Vec::new();
+    let mut tasks = Vec::new();
+    let mut on_stop_tasks = Vec::new();
+
+    // Sequenced tasks come first.
+    for task in scheduled_sequenced_on_start_tasks.iter() {
+        on_start_tasks.extend(vec![(*task, task_set.tasks[*task].name.to_string())])
+    }
+    for task in scheduled_sequenced_tasks.iter() {
+        tasks.extend(vec![(*task, task_set.tasks[*task].name.to_string())])
+    }
+    for task in scheduled_sequenced_on_stop_tasks.iter() {
+        on_stop_tasks.extend(vec![(*task, task_set.tasks[*task].name.to_string())])
     }
 
-    // Next apply weights to unsequenced tasks.
-    trace!("created weighted_tasks: {:?}", weighted_tasks);
-    let mut weighted_unsequenced_tasks = Vec::new();
-    for task in unsequenced_tasks {
-        // divide by greatest common divisor so bucket is as small as possible
-        let weight = task.weight / u;
-        trace!(
-            "{}: {} has weight of {} (reduced with gcd to {})",
-            task.tasks_index,
-            task.name,
-            task.weight,
-            weight
-        );
-        // Weighted list of tuples holding the id and name of the task.
-        let mut tasks = vec![(task.tasks_index, task.name.to_string()); weight];
-        weighted_unsequenced_tasks.append(&mut tasks);
+    // Unsequenced tasks come last.
+    for task in scheduled_unsequenced_on_start_tasks.iter() {
+        on_start_tasks.extend(vec![(*task, task_set.tasks[*task].name.to_string())])
     }
-    // Add final vector of unsequenced tasks last.
-    if !weighted_unsequenced_tasks.is_empty() {
-        weighted_tasks.push(weighted_unsequenced_tasks);
+    for task in scheduled_unsequenced_tasks.iter() {
+        tasks.extend(vec![(*task, task_set.tasks[*task].name.to_string())])
     }
-
-    // Next apply weights to on_start sequenced tasks.
-    let mut weighted_on_start_tasks: WeightedGooseTasks = Vec::new();
-    for (_sequence, tasks) in sequenced_on_start_tasks.iter() {
-        let mut sequence_on_start_weighted_tasks = Vec::new();
-        for task in tasks {
-            // divide by greatest common divisor so bucket is as small as possible
-            let weight = task.weight / u;
-            trace!(
-                "{}: {} has weight of {} (reduced with gcd to {})",
-                task.tasks_index,
-                task.name,
-                task.weight,
-                weight
-            );
-            // Weighted list of tuples holding the id and name of the task.
-            let mut tasks = vec![(task.tasks_index, task.name.to_string()); weight];
-            sequence_on_start_weighted_tasks.append(&mut tasks);
-        }
-        // Add in vectors grouped by sequence value, ordered lowest to highest value.
-        weighted_on_start_tasks.push(sequence_on_start_weighted_tasks);
+    for task in scheduled_unsequenced_on_stop_tasks.iter() {
+        on_stop_tasks.extend(vec![(*task, task_set.tasks[*task].name.to_string())])
     }
-
-    // Next apply weights to unsequenced on_start tasks.
-    trace!("created weighted_on_start_tasks: {:?}", weighted_tasks);
-    let mut weighted_on_start_unsequenced_tasks = Vec::new();
-    for task in unsequenced_on_start_tasks {
-        // divide by greatest common divisor so bucket is as small as possible
-        let weight = task.weight / u;
-        trace!(
-            "{}: {} has weight of {} (reduced with gcd to {})",
-            task.tasks_index,
-            task.name,
-            task.weight,
-            weight
-        );
-        // Weighted list of tuples holding the id and name of the task.
-        let mut tasks = vec![(task.tasks_index, task.name.to_string()); weight];
-        weighted_on_start_unsequenced_tasks.append(&mut tasks);
-    }
-    // Add final vector of unsequenced on_start tasks last.
-    weighted_on_start_tasks.push(weighted_on_start_unsequenced_tasks);
-
-    // Apply weight to on_stop sequenced tasks.
-    let mut weighted_on_stop_tasks: WeightedGooseTasks = Vec::new();
-    for (_sequence, tasks) in sequenced_on_stop_tasks.iter() {
-        let mut sequence_on_stop_weighted_tasks = Vec::new();
-        for task in tasks {
-            // divide by greatest common divisor so bucket is as small as possible
-            let weight = task.weight / u;
-            trace!(
-                "{}: {} has weight of {} (reduced with gcd to {})",
-                task.tasks_index,
-                task.name,
-                task.weight,
-                weight
-            );
-            // Weighted list of tuples holding the id and name of the task.
-            let mut tasks = vec![(task.tasks_index, task.name.to_string()); weight];
-            sequence_on_stop_weighted_tasks.append(&mut tasks);
-        }
-        // Add in vectors grouped by sequence value, ordered lowest to highest value.
-        weighted_on_stop_tasks.push(sequence_on_stop_weighted_tasks);
-    }
-
-    // Finally apply weight to unsequenced on_stop tasks.
-    trace!("created weighted_on_stop_tasks: {:?}", weighted_tasks);
-    let mut weighted_on_stop_unsequenced_tasks = Vec::new();
-    for task in unsequenced_on_stop_tasks {
-        // divide by greatest common divisor so bucket is as small as possible
-        let weight = task.weight / u;
-        trace!(
-            "{}: {} has weight of {} (reduced with gcd to {})",
-            task.tasks_index,
-            task.name,
-            task.weight,
-            weight
-        );
-        // Weighted list of tuples holding the id and name of the task.
-        let mut tasks = vec![(task.tasks_index, task.name.to_string()); weight];
-        weighted_on_stop_unsequenced_tasks.append(&mut tasks);
-    }
-    // Add final vector of unsequenced on_stop tasks last.
-    weighted_on_stop_tasks.push(weighted_on_stop_unsequenced_tasks);
 
     // Return sequenced buckets of weighted usize pointers to and names of Goose Tasks
-    (
-        weighted_on_start_tasks,
-        weighted_tasks,
-        weighted_on_stop_tasks,
-    )
+    (on_start_tasks, tasks, on_stop_tasks)
+}
+
+/// Build a weighted vector of vectors of unsequenced GooseTasks.
+fn weight_unsequenced_tasks(
+    unsequenced_tasks: &UnsequencedGooseTasks,
+    u: usize,
+) -> (Vec<Vec<usize>>, usize) {
+    // Build a vector of vectors to be used to schedule users.
+    let mut available_unsequenced_tasks = Vec::with_capacity(unsequenced_tasks.len());
+    let mut total_tasks = 0;
+    for task in unsequenced_tasks.iter() {
+        // divide by greatest common divisor so vector is as short as possible
+        let weight = task.weight / u;
+        trace!(
+            "{}: {} has weight of {} (reduced with gcd to {})",
+            task.tasks_index,
+            task.name,
+            task.weight,
+            weight
+        );
+        let weighted_tasks = vec![task.tasks_index; weight];
+        available_unsequenced_tasks.push(weighted_tasks);
+        total_tasks += weight;
+    }
+    (available_unsequenced_tasks, total_tasks)
+}
+
+/// Build a weighted vector of vectors of sequenced GooseTasks.
+fn weight_sequenced_tasks(
+    sequenced_tasks: &SequencedGooseTasks,
+    u: usize,
+) -> (BTreeMap<usize, Vec<Vec<usize>>>, usize) {
+    // Build a sequenced BTreeMap containing weighted vectors of GooseTasks.
+    let mut available_sequenced_tasks = BTreeMap::new();
+    let mut total_tasks = 0;
+    // Step through sequences, each containing a bucket of all GooseTasks with the same
+    // sequence value, allowing actual waiting to be done by weight_unsequenced_tasks().
+    for (sequence, unsequenced_tasks) in sequenced_tasks.iter() {
+        let (weighted_tasks, total_weighted_tasks) =
+            weight_unsequenced_tasks(&unsequenced_tasks, u);
+        total_tasks += total_weighted_tasks;
+        available_sequenced_tasks.insert(*sequence, weighted_tasks);
+    }
+
+    (available_sequenced_tasks, total_tasks)
+}
+
+fn schedule_sequenced_tasks(
+    available_sequenced_tasks: &BTreeMap<usize, Vec<Vec<usize>>>,
+    total_tasks: usize,
+    scheduler: &GooseScheduler,
+) -> Vec<usize> {
+    let mut weighted_tasks: Vec<usize> = Vec::new();
+
+    for (_sequence, tasks) in available_sequenced_tasks.iter() {
+        let scheduled_tasks = schedule_unsequenced_tasks(tasks, total_tasks, scheduler);
+        weighted_tasks.extend(scheduled_tasks);
+    }
+
+    weighted_tasks
+}
+
+// Return a list of tasks in the order to be run.
+fn schedule_unsequenced_tasks(
+    available_unsequenced_tasks: &Vec<Vec<usize>>,
+    total_tasks: usize,
+    scheduler: &GooseScheduler,
+) -> Vec<usize> {
+    // Now build the weighted list with the appropriate scheduler.
+    let mut weighted_tasks = Vec::new();
+    match scheduler {
+        GooseScheduler::RoundRobin => {
+            // Allocate task sets round robin.
+            let tasks_len = available_unsequenced_tasks.len();
+            let mut available_tasks = available_unsequenced_tasks.clone();
+            loop {
+                // Tasks are contained in a vector of vectors. The outer vectors each
+                // contain a different GooseTask, and the inner vectors contain each
+                // instance of that specific GooseTask.
+                for (task_index, tasks) in available_tasks.iter_mut().enumerate().take(tasks_len) {
+                    if let Some(task) = tasks.pop() {
+                        debug!("allocating task from Task {}", task_index);
+                        weighted_tasks.push(task);
+                    }
+                }
+                if weighted_tasks.len() >= total_tasks {
+                    break;
+                }
+            }
+        }
+        GooseScheduler::Serial | GooseScheduler::Random => {
+            // Allocate task sets serially in the weighted order defined. If the Random
+            // scheduler is being used, tasks will get shuffled later.
+            for (task_index, tasks) in available_unsequenced_tasks.iter().enumerate() {
+                debug!(
+                    "allocating all {} tasks from Task {}",
+                    tasks.len(),
+                    task_index
+                );
+
+                let mut tasks_clone = tasks.clone();
+                if scheduler == &GooseScheduler::Random {
+                    tasks_clone.shuffle(&mut thread_rng());
+                }
+                weighted_tasks.append(&mut tasks_clone);
+            }
+        }
+    }
+
+    weighted_tasks
 }
 
 fn is_valid_host(host: &str) -> Result<bool, GooseError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1155,7 +1155,7 @@ impl GooseAttack {
         }
 
         info!(
-            "allocating GooseTasks to GooseUsers with {:?} scheduler",
+            "allocating tasks and task sets with {:?} scheduler",
             self.scheduler
         );
 
@@ -4028,7 +4028,7 @@ fn allocate_tasks(
     task_set: &GooseTaskSet,
     scheduler: &GooseScheduler,
 ) -> (WeightedGooseTasks, WeightedGooseTasks, WeightedGooseTasks) {
-    info!(
+    debug!(
         "allocating GooseTasks on GooseUsers with {:?} scheduler",
         scheduler
     );
@@ -4196,7 +4196,7 @@ fn weight_sequenced_tasks(
     // Build a sequenced BTreeMap containing weighted vectors of GooseTasks.
     let mut available_sequenced_tasks = BTreeMap::new();
     // Step through sequences, each containing a bucket of all GooseTasks with the same
-    // sequence value, allowing actual waiting to be done by weight_unsequenced_tasks().
+    // sequence value, allowing actual weighting to be done by weight_unsequenced_tasks().
     for (sequence, unsequenced_tasks) in sequenced_tasks.iter() {
         let (weighted_tasks, _total_weighted_tasks) =
             weight_unsequenced_tasks(&unsequenced_tasks, u);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4177,10 +4177,7 @@ fn allocate_tasks(
 }
 
 /// Build a weighted vector of vectors of unsequenced GooseTasks.
-fn weight_unsequenced_tasks(
-    unsequenced_tasks: &UnsequencedGooseTasks,
-    u: usize,
-) -> (Vec<Vec<usize>>, usize) {
+fn weight_unsequenced_tasks(unsequenced_tasks: &[GooseTask], u: usize) -> (Vec<Vec<usize>>, usize) {
     // Build a vector of vectors to be used to schedule users.
     let mut available_unsequenced_tasks = Vec::with_capacity(unsequenced_tasks.len());
     let mut total_tasks = 0;
@@ -4238,7 +4235,7 @@ fn schedule_sequenced_tasks(
 
 // Return a list of tasks in the order to be run.
 fn schedule_unsequenced_tasks(
-    available_unsequenced_tasks: &Vec<Vec<usize>>,
+    available_unsequenced_tasks: &[Vec<usize>],
     total_tasks: usize,
     scheduler: &GooseScheduler,
 ) -> Vec<usize> {
@@ -4248,7 +4245,7 @@ fn schedule_unsequenced_tasks(
         GooseScheduler::RoundRobin => {
             // Allocate task sets round robin.
             let tasks_len = available_unsequenced_tasks.len();
-            let mut available_tasks = available_unsequenced_tasks.clone();
+            let mut available_tasks = available_unsequenced_tasks.to_owned();
             loop {
                 // Tasks are contained in a vector of vectors. The outer vectors each
                 // contain a different GooseTask, and the inner vectors contain each

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,5 +12,5 @@ pub use crate::goose::{
 };
 pub use crate::metrics::GooseMetrics;
 pub use crate::{
-    task, taskset, GooseAttack, GooseDefault, GooseDefaultType, GooseError, GooseTaskSetScheduler,
+    task, taskset, GooseAttack, GooseDefault, GooseDefaultType, GooseError, GooseScheduler,
 };

--- a/src/user.rs
+++ b/src/user.rs
@@ -67,10 +67,11 @@ pub async fn user_main(
                 } else {
                     0
                 };
+
                 // Counter to track how long we've slept, waking regularly to check for messages.
                 let mut slept: usize = 0;
 
-                // Check if the parent thread has sent us any messages.
+                // Wake every second to check if the parent thread has told us to exit.
                 let mut in_sleep_loop = true;
                 while in_sleep_loop {
                     let mut message = thread_receiver.try_recv();

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -130,25 +130,25 @@ fn common_build_configuration(
 }
 
 // Helper to confirm all variations generate appropriate results.
-fn validate_test(scheduler: &GooseTaskSetScheduler, mock_endpoints: &[MockRef]) {
+fn validate_test(scheduler: &GooseScheduler, mock_endpoints: &[MockRef]) {
     // START_ONE_PATH is loaded one and only one time on all variations.
     mock_endpoints[START_ONE_KEY].assert_hits(1);
 
     // Now validate scheduler-specific counters.
     match scheduler {
-        GooseTaskSetScheduler::RoundRobin => {
+        GooseScheduler::RoundRobin => {
             // We launch an equal number of each task set, so we call both endpoints
             // an equal number of times.
             mock_endpoints[TWO_KEY].assert_hits(mock_endpoints[ONE_KEY].hits());
             mock_endpoints[ONE_KEY].assert_hits(USERS / 2);
         }
-        GooseTaskSetScheduler::Serial => {
+        GooseScheduler::Serial => {
             // As we only launch as many users as the weight of the first task set, we only
             // call the first endpoint, never the second endpoint.
             mock_endpoints[ONE_KEY].assert_hits(USERS);
             mock_endpoints[TWO_KEY].assert_hits(0);
         }
-        GooseTaskSetScheduler::Random => {
+        GooseScheduler::Random => {
             // When scheduling task sets randomly, we don't know how many of each will get
             // launched, but we do now that added together they will equal the total number
             // of users.
@@ -180,7 +180,7 @@ fn get_tasks() -> (GooseTaskSet, GooseTaskSet, GooseTask, GooseTask) {
 }
 
 // Helper to run all standalone tests.
-fn run_standalone_test(scheduler: &GooseTaskSetScheduler) {
+fn run_standalone_test(scheduler: &GooseScheduler) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -210,7 +210,7 @@ fn run_standalone_test(scheduler: &GooseTaskSetScheduler) {
 }
 
 // Helper to run all gaggle tests.
-fn run_gaggle_test(scheduler: &GooseTaskSetScheduler) {
+fn run_gaggle_test(scheduler: &GooseScheduler) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -257,7 +257,7 @@ fn run_gaggle_test(scheduler: &GooseTaskSetScheduler) {
 #[test]
 // Load test with multiple tasks allocating GooseTaskSets in round robin order.
 fn test_round_robin() {
-    run_standalone_test(&GooseTaskSetScheduler::RoundRobin);
+    run_standalone_test(&GooseScheduler::RoundRobin);
 }
 
 #[test]
@@ -266,13 +266,13 @@ fn test_round_robin() {
 // Load test with multiple tasks allocating GooseTaskSets in round robin order, in
 // Gaggle mode.
 fn test_round_robin_gaggle() {
-    run_gaggle_test(&GooseTaskSetScheduler::RoundRobin);
+    run_gaggle_test(&GooseScheduler::RoundRobin);
 }
 
 #[test]
 // Load test with multiple tasks allocating GooseTaskSets in serial order.
 fn test_serial() {
-    run_standalone_test(&GooseTaskSetScheduler::Serial);
+    run_standalone_test(&GooseScheduler::Serial);
 }
 
 #[test]
@@ -281,13 +281,13 @@ fn test_serial() {
 // Load test with multiple tasks allocating GooseTaskSets in serial order, in
 // Gaggle mode.
 fn test_serial_gaggle() {
-    run_gaggle_test(&GooseTaskSetScheduler::Serial);
+    run_gaggle_test(&GooseScheduler::Serial);
 }
 
 #[test]
 // Load test with multiple tasks allocating GooseTaskSets in random order.
 fn test_random() {
-    run_standalone_test(&GooseTaskSetScheduler::Random);
+    run_standalone_test(&GooseScheduler::Random);
 }
 
 #[test]
@@ -296,5 +296,5 @@ fn test_random() {
 // Load test with multiple tasks allocating GooseTaskSets in random order, in
 // Gaggle mode.
 fn test_random_gaggle() {
-    run_gaggle_test(&GooseTaskSetScheduler::Random);
+    run_gaggle_test(&GooseScheduler::Random);
 }


### PR DESCRIPTION
Prior to this PR, Goose's Task scheduler is a bit complex: it maintains pointers to multiple buckets (tracking sequenced tasks versus unsequenced tasks), and initially allocates `GooseTask`s sequentially as they're defined, and subsequently shuffles them each time they're re-run.

With this PR, each `GooseUser` schedules their `GooseTask`s one time at startup, and then repeatedly runs the tasks over and over in the same order. It allocates `GooseTask`s based on the configured `GooseScheduler`, so either `RoundRobin`, `Sequential`, or `Random`, defaulting to `RoundRobin` if not otherwise configured. The primary goal of this change is to ensure that load tests are consistent from run to run; general simplification was just a bonus.

(When writing https://github.com/tag1consulting/loadtest-blog I initially had all tasks within a single taskset, and was annoyed that it was _first_ loading the blog 95 times, then loading the front page 4 times and so on: I had to [split it like this into three task sets](https://github.com/tag1consulting/loadtest-blog/blob/main/src/main.rs#L12) to properly round robin between the tasks. With this PR, I could have created a single task set and it still would have round robined from blog to front page to the blog listing page as desired.)

Changes in this PR:
 - allocate `GooseTask`s with the same `GooseScheduler` as is used to allocate `GooseTaskSet`s
 - simplify how `GooseUser`s run tasks, scheduling only once at start and then re-running the same progression each time; no-longer requires tracking multiple buckets just a single position (removing an atomic integer from the `GooseUser` object)
 - default to launching `GooseTask`s with the `GooseScheduler::RoundRobin` scheduler, instead of a variation on the `GooseScheduler::Serial` and `GooseScheduler::Random` scheduler (in which tasks were run in the order defined then shuffled each time they were run)
 - simplifying how tasks are scheduled provides a ~2% speedup in performance: https://docs.google.com/spreadsheets/d/1zRrNQDK2DBd7Dxi4hBvlOjiI-WYXnyEoMJp9baus8T0/edit#gid=0
 - add test coverage for scheduling `GooseTask`s, and for scheduling Sequenced `GooseTask`s.