### PR TITLE
document and enforce minimum `rustc` requirement of `1.49.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - update `nng` dependency for optional `gaggle` feature
  - simplify `examples/umami` regex when parsing form
  - allow configuration of algorithm for allocating `GooseTask`s the same as `GooseTaskSet`s; `GooseTaskSetScheduler` becomes more generically `GooseScheduler`
+ - specify (and detect) minimum `rustc` requirement of `1.49.0`, due to `flume` dependency which in turn depends on `spinning_top` which uses `hint::spin_loop` which stabilized in `rustc` version `1.49.0
 
 ## 0.11.0 April 9, 2021
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ default = ["reqwest/default-tls"]
 gaggle = ["nng"]
 rustls = ["reqwest/rustls-tls"]
 
+[build-dependencies]
+rustc_version = "0.3"
+
 [dev-dependencies]
 httpmock = "0.5"
 serial_test = "0.5"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Goose is a Rust load testing tool inspired by [Locust](https://locust.io/). User
   - [Gaggle: a distributed load test](https://www.tag1consulting.com/blog/show-me-how-flock-flies-working-gaggle-goose)
   - [Optimizing Goose performance](https://www.tag1consulting.com/blog/golden-goose-egg-compile-time-adventure)
 
+### Requirements
+
+- Minimum required `rustc` version is `1.49.0`: `goose` depends on [`flume`](https://docs.rs/flume) for communication between threads, which in turn depends on [`spinning_top`](https://docs.rs/spinning_top) which uses `hint::spin_loop` which stabilized in `rustc` version `1.49.0`. More detail in https://github.com/rust-lang/rust/issues/55002.
+
 ## Getting Started
 
 The [in-line documentation](https://docs.rs/goose/*/goose/#creating-a-simple-goose-load-test) offers much more detail about Goose specifics. For a general background to help you get started with Rust and Goose, read on.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use rustc_version::{version, Version};
+use std::io::{self, Write};
+use std::process::exit;
+
+fn main() {
+    // Goose can only be compiled with rustc version 1.49.0 or greater.
+    if version().expect("failed to determine rustc version")
+        < Version::parse("1.49.0").expect("failed to parse minimum required version")
+    {
+        writeln!(&mut io::stderr(), "goose dependency `flume` depends on `spinning_top` crate which requires rustc >= 1.49.0.").expect("failed to write to stderr");
+        writeln!(
+            &mut io::stderr(),
+            "detected rustc version: {}",
+            version().expect("failed to determine rustc version")
+        )
+        .expect("failed to write to stderr");
+        writeln!(&mut io::stderr(), "note: see issue #55002 <https://github.com/rust-lang/rust/issues/55002> for more information").expect("failed to write to stderr");
+        // Exit to avoid a more confusing error message and simplify debugging if
+        // trying to build Goose with an unsupported version of rustc.
+        exit(1);
+    }
+}


### PR DESCRIPTION
 - document and enforce minimum `rustc` version of `1.49.0`
 - fixes #265
 - goose depends on [`flume`](https://docs.rs/flume) for communication between threads, which in turn depends on [`spinning_top`](https://docs.rs/spinning_top) which uses `hint::spin_loop` which stabilized in `rustc` version `1.49.0`. More detail in https://github.com/rust-lang/rust/issues/55002.

In the event that goose is compiled with an earlier version of `rustc` it will fail and provide a helpful error:

```
   Compiling goose v0.11.1-dev (~/goose)
error: failed to run custom build command for `goose v0.11.1-dev (~/goose)`

Caused by:
  process didn't exit successfully: `~/goose/target/release/build/goose-0b1c363936c37b47/build-script-build` (exit code: 1)
  --- stderr
  goose dependency `flume` depends on `spinning_top` crate which requires rustc >= 1.49.0.
  detected rustc version: 1.48.0
  note: see issue #55002 <https://github.com/rust-lang/rust/issues/55002> for more information
```

Prior to this change, compilation of goose instead failed with a more confusing error:
```
   Compiling spinning_top v0.2.3
error[E0658]: use of unstable library feature 'renamed_spin_loop'
  --> /home/jandrews/.cargo/registry/src/github.com-1ecc6299db9ec823/spinning_top-0.2.3/src/spinlock.rs:57:17
   |
57 |                 hint::spin_loop();
   |                 ^^^^^^^^^^^^^^^
   |
   = note: see issue #55002 <https://github.com/rust-lang/rust/issues/55002> for more information

error: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.
error: could not compile `spinning_top`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```