### PR TITLE
update rand dependency to 0.8 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.11.1-dev
+ - update `rand` dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call
 
 ## 0.11.0 April 9, 2021
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = "1.4"
 log = "0.4"
 num_cpus = "1.0"
 num-format = "0.4"
-rand = "0.7"
+rand = "0.8"
 regex = "1"
 reqwest = { version = "0.11",  default-features = false, features = ["cookies", "json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -134,7 +134,7 @@ async fn drupal_loadtest_front_page(user: &GooseUser) -> GooseTaskResult {
 
 /// View a node from 1 to 10,000, created by preptest.sh.
 async fn drupal_loadtest_node_page(user: &GooseUser) -> GooseTaskResult {
-    let nid = rand::thread_rng().gen_range(1, 10_000);
+    let nid = rand::thread_rng().gen_range(1..10_000);
     let _goose = user.get(format!("/node/{}", &nid).as_str()).await?;
 
     Ok(())
@@ -142,7 +142,7 @@ async fn drupal_loadtest_node_page(user: &GooseUser) -> GooseTaskResult {
 
 /// View a profile from 2 to 5,001, created by preptest.sh.
 async fn drupal_loadtest_profile_page(user: &GooseUser) -> GooseTaskResult {
-    let uid = rand::thread_rng().gen_range(2, 5_001);
+    let uid = rand::thread_rng().gen_range(2..5_001);
     let _goose = user.get(format!("/user/{}", &uid).as_str()).await?;
 
     Ok(())
@@ -174,7 +174,7 @@ async fn drupal_loadtest_login(user: &GooseUser) -> GooseTaskResult {
                     };
 
                     // Log the user in.
-                    let uid: usize = rand::thread_rng().gen_range(3, 5_002);
+                    let uid: usize = rand::thread_rng().gen_range(3..5_002);
                     let username = format!("user{}", uid);
                     let params = [
                         ("name", username.as_str()),
@@ -217,7 +217,7 @@ async fn drupal_loadtest_login(user: &GooseUser) -> GooseTaskResult {
 
 /// Post a comment.
 async fn drupal_loadtest_post_comment(user: &GooseUser) -> GooseTaskResult {
-    let nid: i32 = rand::thread_rng().gen_range(1, 10_000);
+    let nid: i32 = rand::thread_rng().gen_range(1..10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -101,7 +101,7 @@ pub async fn user_main(
 
         // Prepare to sleep for a random value from min_wait to max_wait.
         let wait_time = if thread_user.max_wait > 0 {
-            rand::thread_rng().gen_range(thread_user.min_wait, thread_user.max_wait)
+            rand::thread_rng().gen_range(thread_user.min_wait..thread_user.max_wait)
         } else {
             0
         };


### PR DESCRIPTION
- Update `rand` to the latest `0.8` branch
- Requires update to how the [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method is invoked