### PR TITLE
update optional `nng` dependence for `gaggle` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.1-dev
  - update `rand` dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call
  - update dependencies: `itertools` to `0.10`, `simplelog` to `0.10`, `url` to `2`
+ - update `nng` dependency for optional `gaggle` feature
 
 ## 0.11.0 April 9, 2021
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1", features = ["fs", "io-util", "macros", "rt-multi-thread
 url = "2"
 
 # optional dependencies
-nng = { version = "1.0.0-rc", optional = true }
+nng = { version = "1.0", optional = true }
 
 [features]
 default = ["reqwest/default-tls"]


### PR DESCRIPTION
 - use `1.0` instead of `1.0.0-rc1`
 - fixes `gaggle` compilation on Mac ARM64