### PR TITLE
release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
 ## 0.11.1 May 16, 2021
- - update `rand` dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call
- - update dependencies: `itertools` to `0.10`, `simplelog` to `0.10`, `url` to `2`
- - update `nng` dependency for optional `gaggle` feature
- - simplify `examples/umami` regex when parsing form
+ - update [`rand`](https://docs.rs/rand) dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call
+ - update dependencies: [`itertools`](https://docs.rs/itertools) to `0.10`, [`simplelog`](https://docs.rs/simplelog) to `0.10`, [`url`](https://docs.rs/url) to `2`
+ - update [`nng`](https://docs.rs/nng) dependency for optional `gaggle` feature
+ - simplify [`examples/umami`](https://github.com/tag1consulting/goose/tree/main/examples/umami) regex when parsing form
  - allow configuration of algorithm for allocating `GooseTask`s the same as `GooseTaskSet`s; `GooseTaskSetScheduler` becomes more generically `GooseScheduler`
- - specify (and detect) minimum `rustc` requirement of `1.49.0`, due to `flume` dependency which in turn depends on `spinning_top` which uses `hint::spin_loop` which stabilized in `rustc` version `1.49.0
+ - specify (and detect) minimum `rustc` requirement of `1.49.0`, due to [`flume`](https://docs.rs/flume) dependency which in turn depends on [`spinning_top`](https://docs.rs/spinning_top) which uses [`hint::spin_loop`](https://doc.rust-lang.org/std/hint/fn.spin_loop.html) which stabilized in `rustc` version `1.49.0
+ - standardize links in documentation; general documentation cleanups
 
 ## 0.11.0 April 9, 2021
  - capture errors and count frequency for each, including summary in metrics report; optionally disable with `--no-error-summary`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.11.1-dev
+## 0.11.1 May 16, 2021
  - update `rand` dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call
  - update dependencies: `itertools` to `0.10`, `simplelog` to `0.10`, `url` to `2`
  - update `nng` dependency for optional `gaggle` feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "goose"
-version = "0.11.1-dev"
+version = "0.11.1"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
-description = "A load testing tool inspired by Locust."
+description = "A load testing framework inspired by Locust."
 homepage = "https://tag1.com/goose"
 documentation = "https://docs.rs/goose/"
 repository = "https://github.com/tag1consulting/goose"

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ At this point it's possible to compile all dependencies, though the resulting bi
 ```
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.11.0
+  Downloaded goose v0.11.1
       ...
-   Compiling goose v0.11.0
+   Compiling goose v0.11.1
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1888,7 +1888,7 @@ impl GooseUser {
     /// [`reqwest::Client`](https://docs.rs/reqwest/*/reqwest/struct.Client.html). The first
     /// configures Goose to report itself as the
     /// [`user_agent`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.user_agent)
-    /// requesting web pages (ie `goose/0.11.0`). The second option configures
+    /// requesting web pages (ie `goose/0.11.1`). The second option configures
     /// [`reqwest`](https://docs.rs/reqwest/) to
     /// [store cookies](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.cookie_store),
     /// which is generally necessary if you aim to simulate logged in users.


### PR DESCRIPTION
## 0.11.1 May 16, 2021
 - update [`rand`](https://docs.rs/rand) dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call
 - update dependencies: [`itertools`](https://docs.rs/itertools) to `0.10`, [`simplelog`](https://docs.rs/simplelog) to `0.10`, [`url`](https://docs.rs/url) to `2`
 - update [`nng`](https://docs.rs/nng) dependency for optional `gaggle` feature
 - simplify [`examples/umami`](https://github.com/tag1consulting/goose/tree/main/examples/umami) regex when parsing form
 - allow configuration of algorithm for allocating `GooseTask`s the same as `GooseTaskSet`s; `GooseTaskSetScheduler` becomes more generically `GooseScheduler`
 - specify (and detect) minimum `rustc` requirement of `1.49.0`, due to [`flume`](https://docs.rs/flume) dependency which in turn depends on [`spinning_top`](https://docs.rs/spinning_top) which uses [`hint::spin_loop`](https://doc.rust-lang.org/std/hint/fn.spin_loop.html) which stabilized in `rustc` version `1.49.0
 - standardize links in documentation; general documentation cleanups