### PR TITLE
introduce a WebSocket Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     o default to not enabling telnet Controller: `GooseDefault::NoController` (bool)
     o default host to bind telnet Controller to: `GooseDefault::ControllerHost` (&str)
     o default port to bind telnet Controller to: `GooseDefault::ControllerPort` (usize)
+ - introduce websocket Controller
 
 ## 0.11.1 May 16, 2021
  - update [`rand`](https://docs.rs/rand) dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.11.2-dev
- - introduce telnet Controller allowing real-time control of load test, optionally disable with `--no-controller`, supports the following commands:
+ - introduce telnet Controller allowing real-time control of load test, optionally disable with `--no-telnet`, supports the following commands:
     o `help` (and `?`) display help
     o `exit` (and `quit`) exit the telnet Controller
     o `echo` pings the parent process and confirms the controller is working
@@ -11,13 +11,24 @@
     o `config-json` displays the current load test configuration in json format
     o `metrics` (and `stats`) displays metrics for the current load test
     o `metrics-json` (and `stats-json`) displays metrics for the current load test in json format
- - telnet Controller bind host defaults to `0.0.0.0`, can be configured with `--controller-host`
- - telnet Controller bind port defaults to `5116`, can be configured with `--controller-port`
+ - telnet Controller bind host defaults to `0.0.0.0`, can be configured with `--telnet-host`
+ - telnet Controller bind port defaults to `5116`, can be configured with `--telnet-port`
  - telnet Controller defaults can be changed:
-    o default to not enabling telnet Controller: `GooseDefault::NoController` (bool)
-    o default host to bind telnet Controller to: `GooseDefault::ControllerHost` (&str)
-    o default port to bind telnet Controller to: `GooseDefault::ControllerPort` (usize)
- - introduce websocket Controller
+    o default to not enabling telnet Controller: `GooseDefault::NoTelnet` (bool)
+    o default host to bind telnet Controller to: `GooseDefault::TelnetHost` (&str)
+    o default port to bind telnet Controller to: `GooseDefault::TelnetPort` (usize)
+ - introduce WebSocket Controller allowing real-time control of load test, optionally disable with `--no-websocket`, supports the following commands:
+    o `exit` (and `quit`) exit the WebSocket Controller
+    o `stop` stops the running load test (and exits the controller)
+    o `hatchrate` (and `hatch_rate`) FLOAT sets per-second rate users hatch
+    o `config` returns the current load test configuration in json format
+    o `metrics` (and `stats`) returns metrics for the current load test in json format
+ - WebSocket Controller bind host defaults to `0.0.0.0`, can be configured with `--websocket-host`
+ - WebSocket Controller bind port defaults to `5117`, can be configured with `--websocket-port`
+ - WebSocket Controller defaults can be changed:
+    o default to not enabling WebSocket Controller: `GooseDefault::NoWebSocket` (bool)
+    o default host to bind WebSocket Controller to: `GooseDefault::WebSocketHost` (&str)
+    o default port to bind WebSocket Controller to: `GooseDefault::WebSocketPort` (usize)
 
 ## 0.11.1 May 16, 2021
  - update [`rand`](https://docs.rs/rand) dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ tokio = { version = "1", features = [
     "time",
     "sync",
 ] }
+tokio-tungstenite = "0.14"
+tungstenite = "0.13"
 url = "2"
 
 # optional dependencies

--- a/README.md
+++ b/README.md
@@ -232,9 +232,12 @@ Metrics:
   --status-codes             Tracks additional status code metrics
 
 Advanced:
-  --no-controller            Doesn't enable Controller TCP port
-  --controller-host HOST     Sets host Controller listens on (default: 0.0.0.0)
-  --controller-port PORT     Sets port Controller listens on (default: 5116)
+  --no-telnet                Doesn't enable telnet Controller
+  --telnet-host HOST         Sets telnet Controller host (default: 0.0.0.0)
+  --telnet-port PORT         Sets telnet Controller TCP port (default: 5116)
+  --no-websocket             Doesn't enable WebSocket Controller
+  --websocket-host HOST      Sets WebSocket Controller host (default: 0.0.0.0)
+  --websocket-port PORT      Sets WebSocket Controller TCP port (default: 5117)
   --throttle-requests VALUE  Sets maximum requests per second
   --sticky-follow            Follows base_url redirect with subsequent requests
 
@@ -454,7 +457,8 @@ The following defaults can be configured with a `&str`:
  - requests log file format: `GooseDefault::RequestsFormat`
  - debug log file name: `GooseDefault::DebugFile`
  - debug log file format: `GooseDefault::DebugFormat`
- - host to bind telnet Controller to: `GooseDefault::ControllerHost`
+ - host to bind telnet Controller to: `GooseDefault::TelnetHost`
+ - host to bind WebSocket Controller to: `GooseDefault::WebSocketHost`
  - host to bind Manager to: `GooseDefault::ManagerBindHost`
  - host for Worker to connect to: `GooseDefault::ManagerHost`
 
@@ -467,7 +471,8 @@ The following defaults can be configured with a `usize` integer:
  - verbosity: `GooseDefault::Verbose`
  - maximum requests per second: `GooseDefault::ThrottleRequests`
  - number of Workers to expect: `GooseDefault::ExpectWorkers`
- - port to bind telnet Controller to: `GooseDefault::ControllerPort`
+ - port to bind telnet Controller to: `GooseDefault::TelnetPort`
+ - port to bind WebSocket Controller to: `GooseDefault::WebSocketPort`
  - port to bind Manager to: `GooseDefault::ManagerBindPort`
  - port for Worker to connect to: `GooseDefault::ManagerPort`
 
@@ -475,7 +480,8 @@ The following defaults can be configured with a `bool`:
  - do not reset metrics after all users start: `GooseDefault::NoResetMetrics`
  - do not track metrics: `GooseDefault::NoMetrics`
  - do not track task metrics: `GooseDefault::NoTaskMetrics`
- - do not start telnet Controller thread: `GooseDefault::NoController`
+ - do not start telnet Controller thread: `GooseDefault::NoTelnet`
+ - do not start WebSocket Controller thread: `GooseDefault::NoWebSocket`
  - track status codes: `GooseDefault::StatusCodes`
  - follow redirect of base_url: `GooseDefault::StickyFollow`
  - enable Manager mode: `GooseDefault::Manager`
@@ -505,7 +511,11 @@ For example, without any run-time options the following load test would automati
 
 ## Controlling Running Goose Load Test
 
-By default, Goose will launch a telnet Controller thread that listens on `0.0.0.0:5116` and allows real-time control of a running load test. The host and port can be configured at start time with the `--controller-host` and `--controller-port` command line options. The defaults can be changed with `GooseDefault::ControllerHost` and `GooseDefault::ControllerPost`. To completely disable the telnet Controller thread, launch Goose with the `--no-controller` command line option.
+By default, Goose will launch a telnet Controller thread that listens on `0.0.0.0:5116`, and a WebSocket Controller thread that listens on `0.0.0.0:5117`. The running Goose load test can be controlled through these Controllers.
+
+### Telnet Controller
+
+The host and port that the telnet Controller listens on can be configured at start time with `--telnet-host` and `--telnet-port`. The telnet Controller can be completely disabled with the `--no-telnet` command line option. The defaults can be changed with, changed with `GooseDefault::TelnetHost`,`GooseDefault::TelnetPort`, and `GooseDefault::NoTelnet`.
 
 To learn about all available commands, telnet into the Controller thread and enter `help` (or `?`), for example:
 ```
@@ -526,6 +536,12 @@ goose 0.11.2 controller commands:
  metrics-json       display metrics for current load test in json format
 goose> 
 ```
+
+### WebSocket Controller
+
+The host and port that the WebSocket Controller listens on can be configured at start time with `--websocket-host` and `--websocket-port`. The WebSocket Controller can be completely disabled with the `--no-websocket` command line option. The defaults can be changed with, changed with `GooseDefault::WebSocketHost`,`GooseDefault::WebSocketPort`, and `GooseDefault::NoWebSocket`.
+
+The WebSocket Controller supports a subset of the above commands, including `exit`, `stop`, `hatchrate FLOAT`, `config` and `metrics`. All commands that return results do so in json format.
 
 ## Throttling Requests
 

--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ By default, Goose will launch a telnet Controller thread that listens on `0.0.0.
 
 ### Telnet Controller
 
-The host and port that the telnet Controller listens on can be configured at start time with `--telnet-host` and `--telnet-port`. The telnet Controller can be completely disabled with the `--no-telnet` command line option. The defaults can be changed with, changed with `GooseDefault::TelnetHost`,`GooseDefault::TelnetPort`, and `GooseDefault::NoTelnet`.
+The host and port that the telnet Controller listens on can be configured at start time with `--telnet-host` and `--telnet-port`. The telnet Controller can be completely disabled with the `--no-telnet` command line option. The defaults can be changed with `GooseDefault::TelnetHost`,`GooseDefault::TelnetPort`, and `GooseDefault::NoTelnet`.
 
 To learn about all available commands, telnet into the Controller thread and enter `help` (or `?`), for example:
 ```
@@ -539,7 +539,7 @@ goose>
 
 ### WebSocket Controller
 
-The host and port that the WebSocket Controller listens on can be configured at start time with `--websocket-host` and `--websocket-port`. The WebSocket Controller can be completely disabled with the `--no-websocket` command line option. The defaults can be changed with, changed with `GooseDefault::WebSocketHost`,`GooseDefault::WebSocketPort`, and `GooseDefault::NoWebSocket`.
+The host and port that the WebSocket Controller listens on can be configured at start time with `--websocket-host` and `--websocket-port`. The WebSocket Controller can be completely disabled with the `--no-websocket` command line option. The defaults can be changed with `GooseDefault::WebSocketHost`,`GooseDefault::WebSocketPort`, and `GooseDefault::NoWebSocket`.
 
 The WebSocket Controller supports a subset of the above commands, including `exit`, `stop`, `hatchrate FLOAT`, `config` and `metrics`. All commands that return results do so in json format.
 

--- a/README.md
+++ b/README.md
@@ -541,7 +541,42 @@ goose>
 
 The host and port that the WebSocket Controller listens on can be configured at start time with `--websocket-host` and `--websocket-port`. The WebSocket Controller can be completely disabled with the `--no-websocket` command line option. The defaults can be changed with `GooseDefault::WebSocketHost`,`GooseDefault::WebSocketPort`, and `GooseDefault::NoWebSocket`.
 
-The WebSocket Controller supports a subset of the above commands, including `exit`, `stop`, `hatchrate FLOAT`, `config` and `metrics`. All commands that return results do so in json format.
+The WebSocket Controller supports a subset of the above commands, including `exit`, `stop`, `hatchrate FLOAT`, `config` and `metrics`. Requests and Response are in JSON format.
+
+Requests must be in the following format:
+```json
+{
+  "request": String, 
+}
+```
+
+For example, a client should send the follow json to request the current load test metrics:
+```json
+{
+  "request": "metrics", 
+}
+```
+
+Responses will always be in the following format:
+```json
+{
+  "response": String,
+  "success": Boolean,
+  "error": Option<String>,
+}
+```
+
+Note that the `error` field will only contain a String if `success` is `false`.
+
+For example:
+```
+% websocat ws://127.0.0.1:5117
+foobar
+{"response":"unrecognized json request","success":false,"error":"unrecognized json request"}
+{"request": "config"}
+{"response":"{\"help\":false,\"version\":false,\"list\":false,\"host\":\"http://apache/\",\"users\":1,\"hatch_rate\":\".5\",\"run_time\":\"\",\"log_level\":0,\"log_file\":\"\",\"verbose\":1,\"running_metrics\":null,\"no_reset_metrics\":false,\"no_metrics\":false,\"no_task_metrics\":false,\"no_error_summary\":false,\"report_file\":\"\",\"requests_file\":\"\",\"requests_format\":\"json\",\"debug_file\":\"\",\"debug_format\":\"json\",\"no_debug_body\":false,\"status_codes\":false,\"no_telnet\":false,\"telnet_host\":\"0.0.0.0\",\"telnet_port\":5116,\"no_websocket\":false,\"websocket_host\":\"0.0.0.0\",\"websocket_port\":5117,\"throttle_requests\":0,\"sticky_follow\":false,\"manager\":false,\"expect_workers\":null,\"no_hash_check\":false,\"manager_bind_host\":\"\",\"manager_bind_port\":0,\"worker\":false,\"manager_host\":\"\",\"manager_port\":0}","success":true,"error":null}
+{"request": "exit"}
+```
 
 ## Throttling Requests
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,23 +1,38 @@
 use crate::metrics::GooseMetrics;
 use crate::GooseConfiguration;
 
+use futures::{SinkExt, StreamExt};
 use regex::{Regex, RegexSet};
+use serde_json::json;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tungstenite::Message;
 
 use std::io;
 use std::str;
 
+/// Goose currently supports two different Controller protocols: Telnet, and WebSocket.
 #[derive(Debug)]
-pub enum GooseControllerCommand {
-    Config,
-    Echo,
-    HatchRate,
-    Metrics,
-    Stop,
-    Users,
+pub enum GooseControllerProtocol {
+    /// Allows control of Goose via telnet.
+    Telnet,
+    /// Allows control of Goose via a websocket.
+    WebSocket,
 }
 
+/// All commands recognized by the Goose Controllers.
+#[derive(Debug)]
+pub enum GooseControllerCommand {
+    HatchRate,
+    Config,
+    Metrics,
+    Help,
+    Exit,
+    Echo,
+    Stop,
+}
+
+/// This structure is used to send commands and values to the parent process.
 #[derive(Debug)]
 pub struct GooseControllerCommandAndValue {
     pub command: GooseControllerCommand,
@@ -66,260 +81,480 @@ pub async fn controller_main(
     // Expose load test configuration to controller thread.
     configuration: GooseConfiguration,
     // For sending requests to the parent process.
-    communication_channel_tx: flume::Sender<GooseControllerRequest>,
+    channel_tx: flume::Sender<GooseControllerRequest>,
+    // Which type of controller to launch.
+    protocol: GooseControllerProtocol,
 ) -> io::Result<()> {
-    // Listen on configured TCP port.
-    let address = format!(
-        "{}:{}",
-        configuration.controller_host, configuration.controller_port
+    let address;
+    match &protocol {
+        GooseControllerProtocol::Telnet => {
+            address = format!(
+                "{}:{}",
+                configuration.telnet_host, configuration.telnet_port
+            );
+        }
+        GooseControllerProtocol::WebSocket => {
+            address = format!(
+                "{}:{}",
+                configuration.websocket_host, configuration.websocket_port
+            );
+        }
+    }
+
+    // All controllers use a TcpListener port.
+    debug!(
+        "preparing to bind {:?} controller to: {}",
+        protocol, address
     );
-    debug!("preparing to bind controller to: {}", &address);
     let listener = TcpListener::bind(&address).await?;
-    info!("controller listening on: {}", address);
+    info!("{:?} controller listening on: {}", protocol, address);
 
-    // Simple incrementing counter each time a controller thread launches.
-    let mut threads: u32 = 0;
+    // These first regular expressions are compiled twice. Once as part of a set used to match
+    // against a command. The second time to capture specific matched values. This is a
+    // limitiation of RegexSet as documented at:
+    // https://docs.rs/regex/1.5.4/regex/struct.RegexSet.html#limitations
+    let hatchrate_regex = r"(?i)^(hatchrate|hatch_rate) ([0-9]*(\.[0-9]*)?){1}$";
+    let config_regex = r"(?i)^(config|config-json)$";
+    let metrics_regex = r"(?i)^(metrics|stats|metrics-json|stats-json)$";
+    // @TODO: enable when the parent process processes it properly.
+    //let users_regex = r"(?i)^users (\d+)$";
 
+    // The following RegexSet is matched against all commands received through the controller.
+    let commands = RegexSet::new(&[
+        // Modify how quickly users hatch (or exit if users are reduced).
+        hatchrate_regex,
+        // Display the current load test configuration.
+        config_regex,
+        // Display running metrics for the currently active load test.
+        metrics_regex,
+        // Modify number of users simulated.
+        // @TODO: enable when the parent process processes it properly.
+        //users_regex,
+        // Provide a list of possible commands.
+        r"(?i)^(help|\?)$",
+        // Exit/quit the controller connection, does not affect load test.
+        r"(?i)^(exit|quit)$",
+        // Confirm the server is still connected and alive.
+        r"(?i)^echo$",
+        // Stop the load test (which will cause the controller connection to quit).
+        r"(?i)^stop$",
+    ])
+    .unwrap();
+
+    // The following regular expressions are used when matching against certain commands
+    // to then capture a matched value.
+    let captures = vec![
+        Regex::new(hatchrate_regex).unwrap(),
+        Regex::new(config_regex).unwrap(),
+        Regex::new(metrics_regex).unwrap(),
+    ];
+    // @TODO: enable when the parent process processes it properly.
+    //compiled_expressions.push(Regex::new(users_regex).unwrap());
+
+    // Simple counter that increments each time a controller client of this type connects.
+    let mut thread_id: u32 = 0;
+
+    // Wait for a connection.
+    while let Ok((stream, _)) = listener.accept().await {
+        thread_id += 1;
+        match &protocol {
+            GooseControllerProtocol::Telnet => {
+                let _ = tokio::spawn(accept_telnet_connection(
+                    thread_id,
+                    channel_tx.clone(),
+                    stream,
+                    commands.clone(),
+                    captures.clone(),
+                ));
+            }
+            GooseControllerProtocol::WebSocket => {
+                let _ = tokio::spawn(accept_websocket_connection(
+                    thread_id,
+                    channel_tx.clone(),
+                    stream,
+                    commands.clone(),
+                    captures.clone(),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// Respond to an incoming telnet connection.
+// @TODO: add support for ssl and optional authentication.
+// @TODO: limit the number of active connections to prevent DoS.
+async fn accept_telnet_connection(
+    thread_id: u32,
+    channel_tx: flume::Sender<GooseControllerRequest>,
+    mut socket: tokio::net::TcpStream,
+    commands: RegexSet,
+    captures: Vec<Regex>,
+) {
+    let peer_addr = socket
+        .peer_addr()
+        .map_or("UNKNOWN ADDRESS".to_string(), |p| p.to_string());
+    info!("telnet client [{}] connected from {}", thread_id, peer_addr);
+
+    // Display initial goose> prompt.
+    write_to_socket_raw(&mut socket, "goose> ").await;
+
+    // @TODO: reset connection if larger command is entered (to unfreeze connection).
+    let mut buf = [0; 1024];
+
+    // Process data received from the client in a loop.
     loop {
-        // Asynchronously wait for an inbound socket.
-        let (mut socket, _) = listener.accept().await?;
+        let n = socket
+            .read(&mut buf)
+            .await
+            .expect("failed to read data from socket");
 
-        // Clone the communication channel to hand to the next thread.
-        let channel_tx = communication_channel_tx.clone();
+        if n == 0 {
+            return;
+        }
 
-        // Increment counter each time a new thread launches, and pass id into thread.
-        threads += 1;
-        let controller_thread_id = threads;
-
-        // Handle the client in a thread, allowing multiple clients to be processed
-        // concurrently.
-        tokio::spawn(async move {
-            match socket.peer_addr() {
-                Ok(p) => info!("client [{}] connected from {}", controller_thread_id, p),
-                Err(e) => info!(
-                    "client [{}] conected from UNKNOWN ADDRESS [{}]",
-                    controller_thread_id, e
-                ),
-            };
-
-            // Display initial goose> prompt.
-            write_to_socket_raw(&mut socket, "goose> ").await;
-
-            // @TODO: controller output gets message up if a larger command is entered, reset
-            // the connection.
-            let mut buf = [0; 1024];
-
-            // The following regular expressions get compiled a second time if matched by the
-            // RegexSet in order to capture the matched value.
-            let hatchrate_regex = r"(?i)^(hatchrate|hatch_rate) ([0-9]*(\.[0-9]*)?){1}$";
-            let config_regex = r"(?i)^(config|config-json)$";
-            let metrics_regex = r"(?i)^(metrics|stats|metrics-json|stats-json)$";
-            // @TODO: enable when the parent process processes it properly.
-            //let users_regex = r"(?i)^users (\d+)$";
-
-            // Compile regular expression set once to use for for matching all commands
-            // received through the controller port.
-            // @TODO: Figure out a clean way to map the location in the RegexSet here when
-            // performing the matches.matched() tests below. The current implementation is
-            // fragile to programmer mistakes if a command is inserted or moved.
-            let commands = RegexSet::new(&[
-                // Provide a list of possible commands.
-                r"(?i)^(help|\?)$",
-                // Exit/quit the controller connection, does not affect load test.
-                r"(?i)^(exit|quit)$",
-                // Confirm the server is still connected and alive.
-                r"(?i)^echo$",
-                // Stop the load test (which will cause the controller connection to quit).
-                r"(?i)^stop$",
-                // Modify how quickly users hatch (or exit if users are reduced).
-                hatchrate_regex,
-                // Display the current load test configuration.
-                config_regex,
-                // Display running metrics for the currently active load test.
-                metrics_regex,
-                // Modify number of users simulated.
-                // @TODO: enable when the parent process processes it properly.
-                //users_regex,
-            ])
-            .unwrap();
-
-            // Also compile the following regular expressions once to use for when
-            // the RegexSet matches these commands, to then capture the matched value.
-            let re_hatchrate = Regex::new(hatchrate_regex).unwrap();
-            let re_config = Regex::new(config_regex).unwrap();
-            let re_metrics = Regex::new(metrics_regex).unwrap();
-            // @TODO: enable when the parent process processes it properly.
-            //let re_users = Regex::new(users_regex).unwrap();
-
-            // Process data received from the client in a loop.
-            loop {
-                let n = socket
-                    .read(&mut buf)
-                    .await
-                    .expect("failed to read data from socket");
-
-                if n == 0 {
-                    return;
-                }
-
-                let message = match str::from_utf8(&buf) {
-                    Ok(m) => {
-                        let mut messages = m.lines();
-                        // @TODO: don't crash when we fail to exctract a line
-                        messages.next().expect("failed to extract a line")
-                    }
-                    Err(_) => continue,
-                };
-
-                let matches = commands.matches(message);
-                // Help
-                if matches.matched(0) {
-                    write_to_socket(&mut socket, &display_help()).await;
-                // Exit
-                } else if matches.matched(1) {
-                    write_to_socket(&mut socket, "goodbye!").await;
-                    match socket.peer_addr() {
-                        Ok(p) => info!("client [{}] disconnected from {}", controller_thread_id, p),
-                        Err(e) => info!(
-                            "client [{}] disconnected from UNKNOWN ADDRESS [{}]",
-                            controller_thread_id, e
-                        ),
-                    };
-                    return;
-                // Echo
-                } else if matches.matched(2) {
-                    match send_to_parent_and_get_reply(
-                        controller_thread_id,
-                        &channel_tx,
-                        GooseControllerCommand::Echo,
-                        None,
-                    )
-                    .await
-                    {
-                        Ok(_) => write_to_socket(&mut socket, "echo").await,
-                        Err(e) => {
-                            write_to_socket(&mut socket, &format!("echo failed: [{}]", e)).await
-                        }
-                    }
-                // Stop
-                } else if matches.matched(3) {
-                    write_to_socket_raw(&mut socket, "stopping load test ...\n").await;
-                    if let Err(e) = send_to_parent_and_get_reply(
-                        controller_thread_id,
-                        &channel_tx,
-                        GooseControllerCommand::Stop,
-                        None,
-                    )
-                    .await
-                    {
-                        write_to_socket(&mut socket, &format!("failed to stop load test [{}]", e))
-                            .await;
-                    }
-                // Hatch rate
-                } else if matches.matched(4) {
-                    // This requires a second lookup to capture the integer, as documented at:
-                    // https://docs.rs/regex/1.5.4/regex/struct.RegexSet.html#limitations
-                    let caps = re_hatchrate.captures(message).unwrap();
-                    let hatch_rate = caps.get(2).map_or("", |m| m.as_str());
-                    send_to_parent(
-                        controller_thread_id,
-                        &channel_tx,
-                        None,
-                        GooseControllerCommand::HatchRate,
-                        Some(hatch_rate.to_string()),
-                    )
-                    .await;
-                    write_to_socket(
-                        &mut socket,
-                        &format!("reconfigured hatch_rate: {}", hatch_rate),
-                    )
-                    .await;
-                // Config
-                } else if matches.matched(5) {
-                    let caps = re_config.captures(message).unwrap();
-                    let config_format = caps.get(1).map_or("", |m| m.as_str());
-                    // Get an up-to-date copy of the configuration, as it may have changed since
-                    // the version that was initially passed in.
-                    if let Ok(value) = send_to_parent_and_get_reply(
-                        controller_thread_id,
-                        &channel_tx,
-                        GooseControllerCommand::Config,
-                        None,
-                    )
-                    .await
-                    {
-                        match value {
-                            GooseControllerResponseMessage::Config(config) => {
-                                match config_format {
-                                    "config" => {
-                                        write_to_socket(&mut socket, &format!("{:#?}", config)).await;
-                                    },
-                                    "config-json" => {
-                                        // Convert the configuration object to a JSON string.
-                                        let config_json: String = serde_json::to_string(&config)
-                                            .expect("unexpected failure");
-                                        write_to_socket(&mut socket, &config_json).await;
-                                    }
-                                    _ => (),
-                                }
-                            },
-                            _ => warn!("parent process sent an unexpected reply, unable to update configuration"),
-                        }
-                    }
-                // Metrics
-                } else if matches.matched(6) {
-                    let caps = re_metrics.captures(message).unwrap();
-                    let metrics_format = caps.get(1).map_or("", |m| m.as_str());
-                    // Get a copy of the current running metrics.
-                    if let Ok(value) = send_to_parent_and_get_reply(
-                        controller_thread_id,
-                        &channel_tx,
-                        GooseControllerCommand::Metrics,
-                        None,
-                    )
-                    .await
-                    {
-                        match value {
-                            GooseControllerResponseMessage::Metrics(metrics) => {
-                                match metrics_format {
-                                    "stats" | "metrics" => {
-                                        write_to_socket(&mut socket, &format!("{}", metrics)).await;
-                                    },
-                                    "stats-json" | "metrics-json" => {
-                                        // Convert the configuration object to a JSON string.
-                                        let metrics_json: String = serde_json::to_string(&metrics)
-                                            .expect("unexpected failure");
-                                        write_to_socket(&mut socket, &metrics_json).await;
-                                    },
-                                    _ => (),
-                                }
-                            },
-                            _ => warn!("parent process sent an unexpected reply, unable to display metrics"),
-                        }
-                    }
-                // Users
-                /*
-                 * @TODO: enable when the parent process processes it properly.
-                } else if matches.matched(7) {
-                    // This requires a second lookup to capture the integer, as documented at:
-                    // https://docs.rs/regex/1.5.4/regex/struct.RegexSet.html#limitations
-                    let caps = re_users.captures(message).unwrap();
-                    let users = caps.get(1).map_or("", |m| m.as_str());
-                    send_to_parent(
-                        controller_thread_id,
-                        &channel_tx,
-                        None,
-                        GooseControllerCommand::Users,
-                        Some(users.to_string()),
-                    )
-                    .await;
-                    write_to_socket(&mut socket, &format!("reconfigured users: {}", users)).await;
-                */
+        let command = match str::from_utf8(&buf) {
+            Ok(m) => {
+                if let Some(c) = m.lines().next() {
+                    c
                 } else {
-                    write_to_socket(&mut socket, "unrecognized command").await;
+                    ""
                 }
             }
-        });
+            Err(e) => {
+                warn!("ignoring unexpected input from telnet controller: {}", e);
+                continue;
+            }
+        };
+
+        let matches = commands.matches(command);
+        // Help
+        if matches.matched(GooseControllerCommand::Help as usize) {
+            write_to_socket(&mut socket, &display_help()).await;
+        // Exit
+        } else if matches.matched(GooseControllerCommand::Exit as usize) {
+            write_to_socket(&mut socket, "goodbye!").await;
+            info!(
+                "telnet client [{}] disconnected from {}",
+                thread_id, peer_addr
+            );
+            return;
+        // Echo
+        } else if matches.matched(GooseControllerCommand::Echo as usize) {
+            match send_to_parent_and_get_reply(
+                thread_id,
+                &channel_tx,
+                GooseControllerCommand::Echo,
+                None,
+            )
+            .await
+            {
+                Ok(_) => write_to_socket(&mut socket, "echo").await,
+                Err(e) => write_to_socket(&mut socket, &format!("echo failed: [{}]", e)).await,
+            }
+        // Stop
+        } else if matches.matched(GooseControllerCommand::Stop as usize) {
+            write_to_socket_raw(&mut socket, "stopping load test ...\n").await;
+            if let Err(e) = send_to_parent_and_get_reply(
+                thread_id,
+                &channel_tx,
+                GooseControllerCommand::Stop,
+                None,
+            )
+            .await
+            {
+                write_to_socket(&mut socket, &format!("failed to stop load test [{}]", e)).await;
+            }
+        // Hatch rate
+        } else if matches.matched(GooseControllerCommand::HatchRate as usize) {
+            // Perform a second map to capture the hatch_rate value.
+            let caps = captures[GooseControllerCommand::HatchRate as usize]
+                .captures(command)
+                .unwrap();
+            let hatch_rate = caps.get(2).map_or("", |m| m.as_str());
+            send_to_parent(
+                thread_id,
+                &channel_tx,
+                None,
+                GooseControllerCommand::HatchRate,
+                Some(hatch_rate.to_string()),
+            )
+            .await;
+            write_to_socket(
+                &mut socket,
+                &format!("reconfigured hatch_rate: {}", hatch_rate),
+            )
+            .await;
+        // Config
+        } else if matches.matched(GooseControllerCommand::Config as usize) {
+            // Perform a second map to capture the actual command matched.
+            let caps = captures[GooseControllerCommand::Config as usize]
+                .captures(command)
+                .unwrap();
+            let config_format = caps.get(1).map_or("", |m| m.as_str());
+            // Get an up-to-date copy of the configuration, as it may have changed since
+            // the version that was initially passed in.
+            if let Ok(value) = send_to_parent_and_get_reply(
+                thread_id,
+                &channel_tx,
+                GooseControllerCommand::Config,
+                None,
+            )
+            .await
+            {
+                match value {
+                    GooseControllerResponseMessage::Config(config) => {
+                        match config_format {
+                            "config" => {
+                                write_to_socket(&mut socket, &format!("{:#?}", config)).await;
+                            }
+                            "config-json" => {
+                                // Convert the configuration object to a JSON string.
+                                let config_json: String =
+                                    serde_json::to_string(&config).expect("unexpected failure");
+                                write_to_socket(&mut socket, &config_json).await;
+                            }
+                            _ => (),
+                        }
+                    }
+                    _ => warn!(
+                        "parent process sent an unexpected reply, unable to update configuration"
+                    ),
+                }
+            }
+        // Metrics
+        } else if matches.matched(GooseControllerCommand::Metrics as usize) {
+            // Perform a second map to capture the actual command matched.
+            let caps = captures[GooseControllerCommand::Metrics as usize]
+                .captures(command)
+                .unwrap();
+            let metrics_format = caps.get(1).map_or("", |m| m.as_str());
+            // Get a copy of the current running metrics.
+            if let Ok(value) = send_to_parent_and_get_reply(
+                thread_id,
+                &channel_tx,
+                GooseControllerCommand::Metrics,
+                None,
+            )
+            .await
+            {
+                match value {
+                    GooseControllerResponseMessage::Metrics(metrics) => {
+                        match metrics_format {
+                            "stats" | "metrics" => {
+                                write_to_socket(&mut socket, &format!("{}", metrics)).await;
+                            }
+                            "stats-json" | "metrics-json" => {
+                                // Convert the configuration object to a JSON string.
+                                let metrics_json: String =
+                                    serde_json::to_string(&metrics).expect("unexpected failure");
+                                write_to_socket(&mut socket, &metrics_json).await;
+                            }
+                            _ => (),
+                        }
+                    }
+                    _ => {
+                        warn!("parent process sent an unexpected reply, unable to display metrics")
+                    }
+                }
+            }
+        } else {
+            write_to_socket(&mut socket, "unrecognized command").await;
+        }
+    }
+}
+
+// Respond to an incoming websocket connection.
+// @TODO: add support for ssl and optional authentication.
+// @TODO: limit the number of active connections to prevent DoS.
+async fn accept_websocket_connection(
+    thread_id: u32,
+    channel_tx: flume::Sender<GooseControllerRequest>,
+    stream: tokio::net::TcpStream,
+    commands: RegexSet,
+    captures: Vec<Regex>,
+) {
+    let peer_addr = stream
+        .peer_addr()
+        .map_or("UNKNOWN ADDRESS".to_string(), |p| p.to_string());
+    info!(
+        "websocket client [{}] connected from {}",
+        thread_id, peer_addr
+    );
+
+    let ws_stream = tokio_tungstenite::accept_async(stream)
+        .await
+        .expect("Error during the websocket handshake occurred");
+
+    let (mut ws_sender, mut ws_receiver) = ws_stream.split();
+
+    // Process data received from the client in a loop.
+    loop {
+        // Wait until the client sends a command.
+        let data = ws_receiver
+            .next()
+            .await
+            .expect("failed to read data from socket");
+
+        if let Ok(command) = data {
+            if command.is_text() {
+                if let Ok(command) = command.into_text() {
+                    info!("{:?}", command.trim());
+                    let matches = commands.matches(&command.trim());
+                    // Exit
+                    if matches.matched(GooseControllerCommand::Exit as usize) {
+                        ws_sender
+                            .send(Message::Close(Some(tungstenite::protocol::CloseFrame {
+                                code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+                                reason: std::borrow::Cow::Borrowed("exit"),
+                            })))
+                            .await
+                            .expect("failed to write data to stream");
+                        info!(
+                            "websocket client [{}] disconnected from {}",
+                            thread_id, peer_addr
+                        );
+                        return;
+                    // Echo
+                    } else if matches.matched(GooseControllerCommand::Echo as usize) {
+                        match send_to_parent_and_get_reply(
+                            thread_id,
+                            &channel_tx,
+                            GooseControllerCommand::Echo,
+                            None,
+                        )
+                        .await
+                        {
+                            Ok(_) => {
+                                ws_sender
+                                    .send(Message::Text(json!({"success": true}).to_string()))
+                                    .await
+                                    .expect("failed to write data to stream");
+                            }
+                            Err(e) => {
+                                ws_sender
+                                    .send(Message::Text(
+                                        json!({
+                                            "error": format!("failed to echo load test [{}]", e)
+                                        })
+                                        .to_string(),
+                                    ))
+                                    .await
+                                    .expect("failed to write data to stream");
+                            }
+                        }
+                    // Stop
+                    } else if matches.matched(GooseControllerCommand::Stop as usize) {
+                        match send_to_parent_and_get_reply(
+                            thread_id,
+                            &channel_tx,
+                            GooseControllerCommand::Stop,
+                            None,
+                        )
+                        .await
+                        {
+                            Ok(_) => {
+                                ws_sender
+                                    .send(Message::Close(Some(tungstenite::protocol::CloseFrame {
+                                        code: tungstenite::protocol::frame::coding::CloseCode::Away,
+                                        reason: std::borrow::Cow::Borrowed("stopping"),
+                                    })))
+                                    .await
+                                    .expect("failed to write data to stream");
+                            }
+                            Err(e) => {
+                                ws_sender
+                                    .send(Message::Text(
+                                        json!({
+                                            "error": format!("failed to stop load test [{}]", e)
+                                        })
+                                        .to_string(),
+                                    ))
+                                    .await
+                                    .expect("failed to write data to stream");
+                            }
+                        }
+                    // Hatch rate
+                    } else if matches.matched(GooseControllerCommand::HatchRate as usize) {
+                        // Perform a second map to capture the hatch_rate value.
+                        let caps = captures[GooseControllerCommand::HatchRate as usize]
+                            .captures(&command.trim())
+                            .unwrap();
+                        let hatch_rate = caps.get(2).map_or("", |m| m.as_str());
+                        info!("matched hatch_rate: {}", hatch_rate);
+                        send_to_parent(
+                            thread_id,
+                            &channel_tx,
+                            None,
+                            GooseControllerCommand::HatchRate,
+                            Some(hatch_rate.to_string()),
+                        )
+                        .await;
+                        ws_sender
+                            .send(Message::Text(json!({"success": true}).to_string()))
+                            .await
+                            .expect("failed to write data to stream");
+                    // Config
+                    } else if matches.matched(GooseControllerCommand::Config as usize) {
+                        // Get an up-to-date copy of the configuration, as it may have changed since
+                        // the version that was initially passed in.
+                        if let Ok(GooseControllerResponseMessage::Config(config)) =
+                            send_to_parent_and_get_reply(
+                                thread_id,
+                                &channel_tx,
+                                GooseControllerCommand::Config,
+                                None,
+                            )
+                            .await
+                        {
+                            // Convert the configuration object to a JSON string.
+                            let config_json: String =
+                                serde_json::to_string(&config).expect("unexpected failure");
+                            ws_sender
+                                .send(Message::Text(config_json))
+                                .await
+                                .expect("failed to write data to stream");
+                        }
+                    // Metrics
+                    } else if matches.matched(GooseControllerCommand::Metrics as usize) {
+                        // Get a copy of the current running metrics.
+                        if let Ok(GooseControllerResponseMessage::Metrics(metrics)) =
+                            send_to_parent_and_get_reply(
+                                //if let GooseControllerResponseMessage::Metrics(metrics) = value {
+                                thread_id,
+                                &channel_tx,
+                                GooseControllerCommand::Metrics,
+                                None,
+                            )
+                            .await
+                        {
+                            // Convert the configuration object to a JSON string.
+                            let metrics_json: String =
+                                serde_json::to_string(&metrics).expect("unexpected failure");
+                            ws_sender
+                                .send(Message::Text(metrics_json))
+                                .await
+                                .expect("failed to write data to stream");
+                        }
+                    // Unknown command
+                    } else {
+                        ws_sender
+                            .send(Message::Text(
+                                json!({"error": "unrecognized command"}).to_string(),
+                            ))
+                            .await
+                            .expect("failed to write data to stream");
+                    }
+                }
+            } else if command.is_close() {
+                info!(
+                    "telnet client [{}] disconnected from {}",
+                    thread_id, peer_addr
+                );
+                break;
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -710,7 +710,7 @@ pub struct GooseDefaults {
     no_debug_body: Option<bool>,
     /// An optional default for not enabling telnet Controller thread.
     no_telnet: Option<bool>,
-    /// An optional default for not enabling websocket Controller thread.
+    /// An optional default for not enabling WebSocket Controller thread.
     no_websocket: Option<bool>,
     /// An optional default to track additional status code metrics.
     status_codes: Option<bool>,
@@ -2692,6 +2692,7 @@ impl GooseAttack {
             flume::Receiver<GooseControllerRequest>,
         ) = flume::unbounded();
 
+        // Configured telnet Controller if not disabled.
         if !self.configuration.no_telnet {
             // Configure telnet_host, using default if run-time option is not set.
             if self.configuration.telnet_host.is_empty() {
@@ -2721,6 +2722,7 @@ impl GooseAttack {
             )));
         }
 
+        // Configured WebSocket Controller if not disabled.
         if !self.configuration.no_websocket {
             // Configure websocket_host, using default if run-time option is not set.
             if self.configuration.websocket_host.is_empty() {
@@ -2751,7 +2753,7 @@ impl GooseAttack {
             )));
         }
 
-        // Return the parent end of the channel, if created.
+        // Return the parent end of the Controller channel.
         Some(controller_request_rx)
     }
 
@@ -4295,22 +4297,22 @@ pub struct GooseConfiguration {
     #[options(no_short, help = "Tracks additional status code metrics\n\nAdvanced:")]
     pub status_codes: bool,
 
-    /// Doesn't enable telnet Controller TCP port
+    /// Doesn't enable telnet Controller
     #[options(no_short)]
     pub no_telnet: bool,
-    /// Sets host telnet Controller listens on (default: 0.0.0.0)
+    /// Sets telnet Controller host (default: 0.0.0.0)
     #[options(no_short, meta = "HOST")]
     pub telnet_host: String,
-    /// Sets port telnet Controller listens on (default: 5116)
+    /// Sets telnet Controller TCP port (default: 5116)
     #[options(no_short, meta = "PORT")]
     pub telnet_port: u16,
-    /// Doesn't enable WebSocket Controller TCP port
+    /// Doesn't enable WebSocket Controller
     #[options(no_short)]
     pub no_websocket: bool,
-    /// Sets host WebSocket Controller listens on (default: 0.0.0.0)
+    /// Sets WebSocket Controller host (default: 0.0.0.0)
     #[options(no_short, meta = "HOST")]
     pub websocket_host: String,
-    /// Sets port WebSocket Controller listens on (default: 5117)
+    /// Sets WebSocket Controller TCP port (default: 5117)
     #[options(no_short, meta = "PORT")]
     pub websocket_port: u16,
     /// Sets maximum requests per second

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,6 @@
 //! use goose::{
 //!     task, taskset, GooseAttack, GooseDefault, GooseDefaultType, GooseError, GooseScheduler,
 //! };
-
 //! ```
 //!
 //! Below your `main` function (which currently is the default `Hello, world!`), add

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,8 +465,8 @@ use tokio::runtime::Runtime;
 use url::Url;
 
 use crate::controller::{
-    GooseControllerCommand, GooseControllerRequest, GooseControllerRequestMessage,
-    GooseControllerResponse, GooseControllerResponseMessage,
+    GooseControllerCommand, GooseControllerProtocol, GooseControllerRequest,
+    GooseControllerRequestMessage, GooseControllerResponse, GooseControllerResponseMessage,
 };
 use crate::goose::{
     GaggleUser, GooseDebug, GooseRawRequest, GooseRequest, GooseTask, GooseTaskSet, GooseUser,
@@ -479,8 +479,11 @@ use crate::worker::{register_shutdown_pipe_handler, GaggleMetrics};
 /// Constant defining Goose's default port when running a Gaggle.
 const DEFAULT_PORT: &str = "5115";
 
-/// Constant defining Goose's default Controller port.
-const DEFAULT_CONTROLLER_PORT: &str = "5116";
+/// Constant defining Goose's default telnet Controller port.
+const DEFAULT_TELNET_PORT: &str = "5116";
+
+/// Constant defining Goose's default WebSocket Controller port.
+const DEFAULT_WEBSOCKET_PORT: &str = "5117";
 
 // WORKER_ID is only used when running a gaggle (a distributed load test).
 lazy_static! {
@@ -706,7 +709,9 @@ pub struct GooseDefaults {
     /// An optional default for not logging response body in debug log.
     no_debug_body: Option<bool>,
     /// An optional default for not enabling telnet Controller thread.
-    no_controller: Option<bool>,
+    no_telnet: Option<bool>,
+    /// An optional default for not enabling websocket Controller thread.
+    no_websocket: Option<bool>,
     /// An optional default to track additional status code metrics.
     status_codes: Option<bool>,
     /// An optional default maximum requests per second.
@@ -719,10 +724,14 @@ pub struct GooseDefaults {
     expect_workers: Option<u16>,
     /// An optional default for Manager to ignore load test checksum.
     no_hash_check: Option<bool>,
-    /// An optional default for host Controller listens on.
-    controller_host: Option<String>,
-    /// An optional default for port Controller listens on.
-    controller_port: Option<u16>,
+    /// An optional default for host telnet Controller listens on.
+    telnet_host: Option<String>,
+    /// An optional default for port telnet Controller listens on.
+    telnet_port: Option<u16>,
+    /// An optional default for host WebSocket Controller listens on.
+    websocket_host: Option<String>,
+    /// An optional default for port WebSocket Controller listens on.
+    websocket_port: Option<u16>,
     /// An optional default for host Manager listens on.
     manager_bind_host: Option<String>,
     /// An optional default for port Manager listens on.
@@ -775,7 +784,9 @@ pub enum GooseDefault {
     /// An optional default for not logging the response body in the debug log.
     NoDebugBody,
     /// An optional default for not enabling telnet Controller thread.
-    NoController,
+    NoTelnet,
+    /// An optional default for not enabling WebSocket Controller thread.
+    NoWebSocket,
     /// An optional default to track additional status code metrics.
     StatusCodes,
     /// An optional default maximum requests per second.
@@ -788,10 +799,14 @@ pub enum GooseDefault {
     ExpectWorkers,
     /// An optional default for Manager to ignore load test checksum.
     NoHashCheck,
-    /// An optional default for host Controller listens on.
-    ControllerHost,
-    /// An optional default for port Controller listens on.
-    ControllerPort,
+    /// An optional default for host telnet Controller listens on.
+    TelnetHost,
+    /// An optional default for port telnet Controller listens on.
+    TelnetPort,
+    /// An optional default for host Websocket Controller listens on.
+    WebSocketHost,
+    /// An optional default for port WebSocket Controller listens on.
+    WebSocketPort,
     /// An optional default for host Manager listens on.
     ManagerBindHost,
     /// An optional default for port Manager listens on.
@@ -2660,32 +2675,14 @@ impl GooseAttack {
         (Some(all_threads_throttle), Some(parent_to_throttle_tx))
     }
 
-    // Helper to spawn a controller thread. The controller thread uses one channel to send
-    // requests to the parent thread. The parent uses the other channel to send responses
-    // back to the controller thread.
-    async fn setup_controller(&mut self) -> Option<flume::Receiver<GooseControllerRequest>> {
-        // If the controller is disabled, return immediately.
-        if self.configuration.no_controller {
+    // Helper to optionally spawn a telnet and/or WebSocket Controller thread. The Controller
+    // threads share a control channel, allowing it to send requests to the parent process. When
+    // a response is required, the Controller will also send a one-shot channel allowing a direct
+    // reply.
+    async fn setup_controllers(&mut self) -> Option<flume::Receiver<GooseControllerRequest>> {
+        // If the telnet controller is disabled, return immediately.
+        if self.configuration.no_telnet && self.configuration.no_websocket {
             return None;
-        }
-
-        // Configure controller_host, using default if run-time option is not set.
-        if self.configuration.controller_host.is_empty() {
-            self.configuration.controller_host =
-                if let Some(host) = self.defaults.controller_host.clone() {
-                    host
-                } else {
-                    "0.0.0.0".to_string()
-                }
-        }
-
-        // Then configure controller_port, using default if run-time option is not set.
-        if self.configuration.controller_port == 0 {
-            self.configuration.controller_port = if let Some(port) = self.defaults.controller_port {
-                port
-            } else {
-                DEFAULT_CONTROLLER_PORT.to_string().parse().unwrap()
-            };
         }
 
         // Create an unbounded channel for controller threads to send requests to the parent
@@ -2695,12 +2692,64 @@ impl GooseAttack {
             flume::Receiver<GooseControllerRequest>,
         ) = flume::unbounded();
 
-        // Spawn the initial controller thread to allow real-time control of the load test.
-        // There is no need to rejoin this thread when the load test ends.
-        let _ = Some(tokio::spawn(controller::controller_main(
-            self.configuration.clone(),
-            all_threads_controller_request_tx,
-        )));
+        if !self.configuration.no_telnet {
+            // Configure telnet_host, using default if run-time option is not set.
+            if self.configuration.telnet_host.is_empty() {
+                self.configuration.telnet_host =
+                    if let Some(host) = self.defaults.telnet_host.clone() {
+                        host
+                    } else {
+                        "0.0.0.0".to_string()
+                    }
+            }
+
+            // Then configure telnet_port, using default if run-time option is not set.
+            if self.configuration.telnet_port == 0 {
+                self.configuration.telnet_port = if let Some(port) = self.defaults.telnet_port {
+                    port
+                } else {
+                    DEFAULT_TELNET_PORT.to_string().parse().unwrap()
+                };
+            }
+
+            // Spawn the initial controller thread to allow real-time control of the load test.
+            // There is no need to rejoin this thread when the load test ends.
+            let _ = Some(tokio::spawn(controller::controller_main(
+                self.configuration.clone(),
+                all_threads_controller_request_tx.clone(),
+                GooseControllerProtocol::Telnet,
+            )));
+        }
+
+        if !self.configuration.no_websocket {
+            // Configure websocket_host, using default if run-time option is not set.
+            if self.configuration.websocket_host.is_empty() {
+                self.configuration.websocket_host =
+                    if let Some(host) = self.defaults.websocket_host.clone() {
+                        host
+                    } else {
+                        "0.0.0.0".to_string()
+                    }
+            }
+
+            // Then configure websocket_port, using default if run-time option is not set.
+            if self.configuration.websocket_port == 0 {
+                self.configuration.websocket_port = if let Some(port) = self.defaults.websocket_port
+                {
+                    port
+                } else {
+                    DEFAULT_WEBSOCKET_PORT.to_string().parse().unwrap()
+                };
+            }
+
+            // Spawn the initial controller thread to allow real-time control of the load test.
+            // There is no need to rejoin this thread when the load test ends.
+            let _ = Some(tokio::spawn(controller::controller_main(
+                self.configuration.clone(),
+                all_threads_controller_request_tx,
+                GooseControllerProtocol::WebSocket,
+            )));
+        }
 
         // Return the parent end of the channel, if created.
         Some(controller_request_rx)
@@ -2805,8 +2854,8 @@ impl GooseAttack {
         // If enabled, spawn a throttle thread.
         let (throttle_threads_tx, parent_to_throttle_tx) = self.setup_throttle().await;
 
-        // Spawn a controller thread.
-        let controller_channel_rx = self.setup_controller().await;
+        // Optionally spawn a telnet and/or Websocket Controller thread.
+        let controller_channel_rx = self.setup_controllers().await;
 
         // Grab now() once from the standard library, used by multiple timers in
         // the run state.
@@ -3715,6 +3764,7 @@ impl GooseAttack {
                             },
                             GooseControllerRequestMessage::CommandAndValue(command_and_value) => {
                                 match command_and_value.command {
+                                    /*
                                     GooseControllerCommand::Users => {
                                         info!(
                                             "changing users from {:?} to {}",
@@ -3723,6 +3773,7 @@ impl GooseAttack {
                                         self.configuration.users =
                                             Some(command_and_value.value.parse().unwrap());
                                     }
+                                    */
                                     GooseControllerCommand::HatchRate => {
                                         // The controller uses a regular expression to validate that
                                         // this is a valid float, so simply use it with further
@@ -3930,7 +3981,8 @@ impl GooseAttack {
 ///  - GooseDefault::RequestsFormat
 ///  - GooseDefault::DebugFile
 ///  - GooseDefault::DebugFormat
-///  - GooseDefault::ControllerHost
+///  - GooseDefault::TelnetHost
+///  - GooseDefault::WebSocketHost
 ///  - GooseDefault::ManagerBindHost
 ///  - GooseDefault::ManagerHost
 ///
@@ -3944,7 +3996,8 @@ impl GooseAttack {
 ///  - GooseDefault::Verbose
 ///  - GooseDefault::ThrottleRequests
 ///  - GooseDefault::ExpectWorkers
-///  - GooseDefault::ControllerPort
+///  - GooseDefault::TelnetPort
+///  - GooseDefault::WebSocketPort
 ///  - GooseDefault::ManagerBindPort
 ///  - GooseDefault::ManagerPort
 ///
@@ -3955,7 +4008,8 @@ impl GooseAttack {
 ///  - GooseDefault::NoTaskMetrics
 ///  - GooseDefault::NoErrorSummary
 ///  - GooseDefault::NoDebugBody
-///  - GooseDefault::NoController
+///  - GooseDefault::NoTelnet
+///  - GooseDefault::NoWebSocket
 ///  - GooseDefault::StatusCodes
 ///  - GooseDefault::StickyFollow
 ///  - GooseDefault::Manager
@@ -3990,7 +4044,8 @@ impl GooseDefaultType<&str> for GooseAttack {
             GooseDefault::RequestsFormat => self.defaults.requests_format = Some(value.to_string()),
             GooseDefault::DebugFile => self.defaults.debug_file = Some(value.to_string()),
             GooseDefault::DebugFormat => self.defaults.debug_format = Some(value.to_string()),
-            GooseDefault::ControllerHost => self.defaults.controller_host = Some(value.to_string()),
+            GooseDefault::TelnetHost => self.defaults.telnet_host = Some(value.to_string()),
+            GooseDefault::WebSocketHost => self.defaults.websocket_host = Some(value.to_string()),
             GooseDefault::ManagerBindHost => {
                 self.defaults.manager_bind_host = Some(value.to_string())
             }
@@ -4002,7 +4057,8 @@ impl GooseDefaultType<&str> for GooseAttack {
             | GooseDefault::Verbose
             | GooseDefault::ThrottleRequests
             | GooseDefault::ExpectWorkers
-            | GooseDefault::ControllerPort
+            | GooseDefault::TelnetPort
+            | GooseDefault::WebSocketPort
             | GooseDefault::ManagerBindPort
             | GooseDefault::ManagerPort => {
                 return Err(GooseError::InvalidOption {
@@ -4020,7 +4076,8 @@ impl GooseDefaultType<&str> for GooseAttack {
             | GooseDefault::NoTaskMetrics
             | GooseDefault::NoErrorSummary
             | GooseDefault::NoDebugBody
-            | GooseDefault::NoController
+            | GooseDefault::NoTelnet
+            | GooseDefault::NoWebSocket
             | GooseDefault::StatusCodes
             | GooseDefault::StickyFollow
             | GooseDefault::Manager
@@ -4049,7 +4106,8 @@ impl GooseDefaultType<usize> for GooseAttack {
             GooseDefault::Verbose => self.defaults.verbose = Some(value as u8),
             GooseDefault::ThrottleRequests => self.defaults.throttle_requests = Some(value),
             GooseDefault::ExpectWorkers => self.defaults.expect_workers = Some(value as u16),
-            GooseDefault::ControllerPort => self.defaults.controller_port = Some(value as u16),
+            GooseDefault::TelnetPort => self.defaults.telnet_port = Some(value as u16),
+            GooseDefault::WebSocketPort => self.defaults.websocket_port = Some(value as u16),
             GooseDefault::ManagerBindPort => self.defaults.manager_bind_port = Some(value as u16),
             GooseDefault::ManagerPort => self.defaults.manager_port = Some(value as u16),
             // Otherwise display a helpful and explicit error.
@@ -4061,7 +4119,8 @@ impl GooseDefaultType<usize> for GooseAttack {
             | GooseDefault::RequestsFormat
             | GooseDefault::DebugFile
             | GooseDefault::DebugFormat
-            | GooseDefault::ControllerHost
+            | GooseDefault::TelnetHost
+            | GooseDefault::WebSocketHost
             | GooseDefault::ManagerBindHost
             | GooseDefault::ManagerHost => {
                 return Err(GooseError::InvalidOption {
@@ -4078,7 +4137,8 @@ impl GooseDefaultType<usize> for GooseAttack {
             | GooseDefault::NoTaskMetrics
             | GooseDefault::NoErrorSummary
             | GooseDefault::NoDebugBody
-            | GooseDefault::NoController
+            | GooseDefault::NoTelnet
+            | GooseDefault::NoWebSocket
             | GooseDefault::StatusCodes
             | GooseDefault::StickyFollow
             | GooseDefault::Manager
@@ -4105,7 +4165,8 @@ impl GooseDefaultType<bool> for GooseAttack {
             GooseDefault::NoTaskMetrics => self.defaults.no_task_metrics = Some(value),
             GooseDefault::NoErrorSummary => self.defaults.no_error_summary = Some(value),
             GooseDefault::NoDebugBody => self.defaults.no_debug_body = Some(value),
-            GooseDefault::NoController => self.defaults.no_controller = Some(value),
+            GooseDefault::NoTelnet => self.defaults.no_telnet = Some(value),
+            GooseDefault::NoWebSocket => self.defaults.no_websocket = Some(value),
             GooseDefault::StatusCodes => self.defaults.status_codes = Some(value),
             GooseDefault::StickyFollow => self.defaults.sticky_follow = Some(value),
             GooseDefault::Manager => self.defaults.manager = Some(value),
@@ -4120,7 +4181,8 @@ impl GooseDefaultType<bool> for GooseAttack {
             | GooseDefault::RunningMetrics
             | GooseDefault::DebugFile
             | GooseDefault::DebugFormat
-            | GooseDefault::ControllerHost
+            | GooseDefault::TelnetHost
+            | GooseDefault::WebSocketHost
             | GooseDefault::ManagerBindHost
             | GooseDefault::ManagerHost => {
                 return Err(GooseError::InvalidOption {
@@ -4139,7 +4201,8 @@ impl GooseDefaultType<bool> for GooseAttack {
             | GooseDefault::Verbose
             | GooseDefault::ThrottleRequests
             | GooseDefault::ExpectWorkers
-            | GooseDefault::ControllerPort
+            | GooseDefault::TelnetPort
+            | GooseDefault::WebSocketPort
             | GooseDefault::ManagerBindPort
             | GooseDefault::ManagerPort => {
                 return Err(GooseError::InvalidOption {
@@ -4232,15 +4295,24 @@ pub struct GooseConfiguration {
     #[options(no_short, help = "Tracks additional status code metrics\n\nAdvanced:")]
     pub status_codes: bool,
 
-    /// Doesn't enable Controller TCP port
+    /// Doesn't enable telnet Controller TCP port
     #[options(no_short)]
-    pub no_controller: bool,
-    /// Sets host Controller listens on (default: 0.0.0.0)
+    pub no_telnet: bool,
+    /// Sets host telnet Controller listens on (default: 0.0.0.0)
     #[options(no_short, meta = "HOST")]
-    pub controller_host: String,
-    /// Sets port Controller listens on (default: 5116)
+    pub telnet_host: String,
+    /// Sets port telnet Controller listens on (default: 5116)
     #[options(no_short, meta = "PORT")]
-    pub controller_port: u16,
+    pub telnet_port: u16,
+    /// Doesn't enable WebSocket Controller TCP port
+    #[options(no_short)]
+    pub no_websocket: bool,
+    /// Sets host WebSocket Controller listens on (default: 0.0.0.0)
+    #[options(no_short, meta = "HOST")]
+    pub websocket_host: String,
+    /// Sets port WebSocket Controller listens on (default: 5117)
+    #[options(no_short, meta = "PORT")]
+    pub websocket_port: u16,
     /// Sets maximum requests per second
     #[options(no_short, meta = "VALUE")]
     pub throttle_requests: usize,
@@ -4614,7 +4686,9 @@ mod test {
             .unwrap()
             .set_default(GooseDefault::NoErrorSummary, true)
             .unwrap()
-            .set_default(GooseDefault::NoController, true)
+            .set_default(GooseDefault::NoTelnet, true)
+            .unwrap()
+            .set_default(GooseDefault::NoWebSocket, true)
             .unwrap()
             .set_default(GooseDefault::ReportFile, report_file.as_str())
             .unwrap()
@@ -4664,7 +4738,8 @@ mod test {
         assert!(goose_attack.defaults.no_metrics == Some(true));
         assert!(goose_attack.defaults.no_task_metrics == Some(true));
         assert!(goose_attack.defaults.no_error_summary == Some(true));
-        assert!(goose_attack.defaults.no_controller == Some(true));
+        assert!(goose_attack.defaults.no_telnet == Some(true));
+        assert!(goose_attack.defaults.no_websocket == Some(true));
         assert!(goose_attack.defaults.report_file == Some(report_file));
         assert!(goose_attack.defaults.requests_file == Some(requests_file));
         assert!(goose_attack.defaults.requests_format == Some(requests_format));


### PR DESCRIPTION
 - introduce WebSocket Controller allowing real-time control of load test, optionally disable with `--no-websocket`, supports the following commands:
    o `exit` (and `quit`) exit the WebSocket Controller
    o `stop` stops the running load test (and exits the controller)
    o `hatchrate` (and `hatch_rate`) FLOAT sets per-second rate users hatch
    o `config` returns the current load test configuration in json format
    o `metrics` (and `stats`) returns metrics for the current load test in json format
 - WebSocket Controller bind host defaults to `0.0.0.0`, can be configured with `--websocket-host`
 - WebSocket Controller bind port defaults to `5117`, can be configured with `--websocket-port`
 - WebSocket Controller defaults can be changed:
    o default to not enabling WebSocket Controller: `GooseDefault::NoWebSocket` (bool)
    o default host to bind WebSocket Controller to: `GooseDefault::WebSocketHost` (&str)
    o default port to bind WebSocket Controller to: `GooseDefault::WebSocketPort` (usize)
- renamed run time options `--no-controller`, `--controller-host`, `--controller-port` to `--no-telnet`, `--telnet-host`, `--telnet-port` to differentiate between controllers
- renamed `GooseDefault::NoController`,`GooseDefault::ConterllerHost`, and `GooseDefault::ControllerPort` to `GooseDefault::NoTelnet`,`GooseDefault::TelnetHost`, and `GooseDefault::TelnetPort` to differentiate between controllers
- requests to the WebSocket Controller must be in the following format:
  ```
  {
    `request`: String,
  }
  ```
- response from the WebSocket Controller are always in the following format:
  ```
  {
    response: String,
    success: bool,
    error: Option<String>,
  }
  ```
For example:

```
% websocat ws://127.0.0.1:5117
{"request": "hatchrate 5"}
{"response":"set hatch_rate","success":true,"error":null}
{"request": "config"}
{"response":"{\"help\":false,\"version\":false,\"list\":false,\"host\":\"http://apache/\",\"users\":1,\"hatch_rate\":\"5\",\"run_time\":\"\",\"log_level\":0,\"log_file\":\"\",\"verbose\":1,\"running_metrics\":null,\"no_reset_metrics\":false,\"no_metrics\":false,\"no_task_metrics\":false,\"no_error_summary\":false,\"report_file\":\"\",\"requests_file\":\"\",\"requests_format\":\"json\",\"debug_file\":\"\",\"debug_format\":\"json\",\"no_debug_body\":false,\"status_codes\":false,\"no_telnet\":false,\"telnet_host\":\"0.0.0.0\",\"telnet_port\":5116,\"no_websocket\":false,\"websocket_host\":\"0.0.0.0\",\"websocket_port\":5117,\"throttle_requests\":0,\"sticky_follow\":false,\"manager\":false,\"expect_workers\":null,\"no_hash_check\":false,\"manager_bind_host\":\"\",\"manager_bind_port\":0,\"worker\":false,\"manager_host\":\"\",\"manager_port\":0}","success":true,"error":null}
{"request": "foobar"}
{"response":"unrecognized command","success":false,"error":"unrecognized command"}
foobar
{"response":"unrecognized json request","success":false,"error":"unrecognized json request"}
{"request": "exit"}
```