### PR TITLE
support starting, stopping, and restarting load test through Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,17 @@
     o default host to bind WebSocket Controller to: `GooseDefault::WebSocketHost` (&str)
     o default port to bind WebSocket Controller to: `GooseDefault::WebSocketPort` (usize)
  - make it possible to start and stop a load test without completely restarting Goose
- - introduce `--no-autostart` to disable automatically starting the load test, leaves Goose in an idle state waiting for Controller commands
+ - introduce `--no-autostart` to disable automatically starting the load test, leaves Goose in an idle state waiting for Controller commands (optionally change the default with `GooseDefault::NoAutoStart`)
     o renamed `stop` Controller command to `shutdown`
     o added new `start` Controller command, telling idle Goose load test to start
+    o added new `stop` Controller command, telling running Goose load test to stop and return to idle state
+ - code cleanup and logic consollidation to support Controller fixed a bug where metrics wouldn't display and the debug file, request file, and html report weren't written when load test was stopped while still launching users
+ - regularly sync metrics, using a timeout to avoid hanging the main loop
+ - properly reset metrics when load test is stopped and restarted
+ - properly flush debug file, request file, and html report when stopping load test with Controller
+ - properly (re)create debug file, request file, and html report when starting load test with Controller
+ - if metrics are enabled, display when controller stops load test
+
 
 ## 0.11.1 May 16, 2021
  - update [`rand`](https://docs.rs/rand) dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
     o `help` (and `?`) display help
     o `exit` (and `quit`) exit the telnet Controller
     o `echo` pings the parent process and confirms the controller is working
-    o `stop` stops the running load test (and exits the controller)
+    o `shutdown` shuts down the running load test (and exits the controller)
     o `hatchrate` (and `hatch_rate`) FLOAT sets per-second rate users hatch
     o `config` displays the current load test configuration
     o `config-json` displays the current load test configuration in json format
@@ -19,7 +19,7 @@
     o default port to bind telnet Controller to: `GooseDefault::TelnetPort` (usize)
  - introduce WebSocket Controller allowing real-time control of load test, optionally disable with `--no-websocket`, supports the following commands:
     o `exit` (and `quit`) exit the WebSocket Controller
-    o `stop` stops the running load test (and exits the controller)
+    o `shutdown` shuts down the running load test (and exits the controller)
     o `hatchrate` (and `hatch_rate`) FLOAT sets per-second rate users hatch
     o `config` returns the current load test configuration in json format
     o `metrics` (and `stats`) returns metrics for the current load test in json format
@@ -29,6 +29,10 @@
     o default to not enabling WebSocket Controller: `GooseDefault::NoWebSocket` (bool)
     o default host to bind WebSocket Controller to: `GooseDefault::WebSocketHost` (&str)
     o default port to bind WebSocket Controller to: `GooseDefault::WebSocketPort` (usize)
+ - make it possible to start and stop a load test without completely restarting Goose
+ - introduce `--no-autostart` to disable automatically starting the load test, leaves Goose in an idle state waiting for Controller commands
+    o renamed `stop` Controller command to `shutdown`
+    o added new `start` Controller command, telling idle Goose load test to start
 
 ## 0.11.1 May 16, 2021
  - update [`rand`](https://docs.rs/rand) dependency to `0.8` branch, update [`gen_range`](https://docs.rs/rand/0.8.*/rand/trait.Rng.html#method.gen_range) method call

--- a/README.md
+++ b/README.md
@@ -528,7 +528,8 @@ goose 0.11.2 controller commands:
  help (?)           this help
  exit (quit)        exit controller
  echo               confirm controller is working
- start              start an idle loat test
+ start              start an idle load test
+ stop               stop a running load test and return to idle state
  shutdown           shutdown running load test (and exit controller)
  hatchrate FLOAT    set per-second rate users hatch
  config             display load test configuration
@@ -542,9 +543,9 @@ goose>
 
 The host and port that the WebSocket Controller listens on can be configured at start time with `--websocket-host` and `--websocket-port`. The WebSocket Controller can be completely disabled with the `--no-websocket` command line option. The defaults can be changed with `GooseDefault::WebSocketHost`,`GooseDefault::WebSocketPort`, and `GooseDefault::NoWebSocket`.
 
-The WebSocket Controller supports a subset of the above commands, including `exit`, `stop`, `hatchrate FLOAT`, `config` and `metrics`. Requests and Response are in JSON format.
+The WebSocket Controller supports a subset of the above commands, including `exit`, `start`, `stop`, `shutdown`, `hatchrate FLOAT`, `config` and `metrics`. Requests and Response are in JSON format.
 
-Requests must be in the following format:
+Requests must be made in the following format:
 ```json
 {
   "request": String, 
@@ -567,7 +568,7 @@ Responses will always be in the following format:
 }
 ```
 
-Note that the `error` field will only contain a String if `success` is `false`.
+The `error` field will only contain a String if `success` is `false`.
 
 For example:
 ```

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Advanced:
   --no-websocket             Doesn't enable WebSocket Controller
   --websocket-host HOST      Sets WebSocket Controller host (default: 0.0.0.0)
   --websocket-port PORT      Sets WebSocket Controller TCP port (default: 5117)
+  --no-autostart             Doesn't automatically start load test
   --throttle-requests VALUE  Sets maximum requests per second
   --sticky-follow            Follows base_url redirect with subsequent requests
 
@@ -482,6 +483,7 @@ The following defaults can be configured with a `bool`:
  - do not track task metrics: `GooseDefault::NoTaskMetrics`
  - do not start telnet Controller thread: `GooseDefault::NoTelnet`
  - do not start WebSocket Controller thread: `GooseDefault::NoWebSocket`
+ - do not autostart load test, wait instead for a Controller to start: `GooseDefault::NoAutoStart`
  - track status codes: `GooseDefault::StatusCodes`
  - follow redirect of base_url: `GooseDefault::StickyFollow`
  - enable Manager mode: `GooseDefault::Manager`
@@ -511,7 +513,9 @@ For example, without any run-time options the following load test would automati
 
 ## Controlling Running Goose Load Test
 
-By default, Goose will launch a telnet Controller thread that listens on `0.0.0.0:5116`, and a WebSocket Controller thread that listens on `0.0.0.0:5117`. The running Goose load test can be controlled through these Controllers.
+By default, Goose will launch a telnet Controller thread that listens on `0.0.0.0:5116`, and a WebSocket Controller thread that listens on `0.0.0.0:5117`. The running Goose load test can be controlled through these Controllers. Goose can optionally be started with the `--no-autostart` run time option to prevent the load test from automatically starting, requiring instead that it be started with a Controller command.
+
+NOTE: The controller currently is not Gaggle-aware, and only functions correctly when running Goose as a single process in standalone mode.
 
 ### Telnet Controller
 

--- a/README.md
+++ b/README.md
@@ -528,7 +528,8 @@ goose 0.11.2 controller commands:
  help (?)           this help
  exit (quit)        exit controller
  echo               confirm controller is working
- stop               stop running load test (and exit controller)
+ start              start an idle loat test
+ shutdown           shutdown running load test (and exit controller)
  hatchrate FLOAT    set per-second rate users hatch
  config             display load test configuration
  config-json        display load test configuration in json format

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -821,7 +821,8 @@ fn display_help() -> String {
  help (?)           this help
  exit (quit)        exit controller
  echo               confirm controller is working
- start              start an idle loat test
+ start              start an idle load test
+ stop               stop a running load test and return to idle state
  shutdown           shutdown running load test (and exit controller)
  hatchrate FLOAT    set per-second rate users hatch
  config             display load test configuration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4477,15 +4477,15 @@ pub struct GooseConfiguration {
     /// Doesn't enable WebSocket Controller
     #[options(no_short)]
     pub no_websocket: bool,
-    /// Doesn't automatically start load test
-    #[options(no_short)]
-    pub no_autostart: bool,
     /// Sets WebSocket Controller host (default: 0.0.0.0)
     #[options(no_short, meta = "HOST")]
     pub websocket_host: String,
     /// Sets WebSocket Controller TCP port (default: 5117)
     #[options(no_short, meta = "PORT")]
     pub websocket_port: u16,
+    /// Doesn't automatically start load test
+    #[options(no_short)]
+    pub no_autostart: bool,
     /// Sets maximum requests per second
     #[options(no_short, meta = "VALUE")]
     pub throttle_requests: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3744,6 +3744,15 @@ impl GooseAttack {
                             info!("Goose is currently idle.");
                             goose_attack_run_state.idle_status_displayed = true;
                         }
+                        // Gracefully exit loop if ctrl-c is caught.
+                        if goose_attack_run_state.canceled.load(Ordering::SeqCst) {
+                            // No metrics to display when sitting idle, so disable.
+                            self.metrics.display_metrics = false;
+                            self.set_attack_phase(
+                                &mut goose_attack_run_state,
+                                AttackPhase::Stopping,
+                            );
+                        }
                     } else {
                         // Prepare to start the load test, resetting timers and counters.
                         self.reset_run_state(&mut goose_attack_run_state).await;

--- a/src/util.rs
+++ b/src/util.rs
@@ -53,7 +53,7 @@ pub async fn sleep_minus_drift(
 ) -> tokio::time::Instant {
     match duration.checked_sub(drift.elapsed()) {
         Some(delay) if delay.as_nanos() > 0 => tokio::time::sleep(delay).await,
-        _ => warn!("sleep_minus_drift: drift was greater than or equal to duration, not sleeping"),
+        _ => info!("sleep_minus_drift: drift was greater than or equal to duration, not sleeping"),
     };
     tokio::time::Instant::now()
 }


### PR DESCRIPTION
 - make it possible to start and stop a load test without completely restarting Goose
 - introduce `--no-autostart` to disable automatically starting the load test, leaves Goose in an idle state waiting for Controller commands
    o renamed `stop` Controller command to `shutdown`
    o added new `start` Controller command, telling idle Goose load test to start
    o added new `stop` Controller command, telling starting or running Goose load test to stop and return to an idle state
- consolidation of logic to properly support Controller fixed a bug where metrics wouldn't display and the debug file, request file, and html report weren't written when load test was stopped while still launching users
- regularly sync metrics, using a timeout to avoid hanging the main loop
- properly reset metrics when load test is stopped and restarted
- properly flush debug file, request file, and html report when stopping load test with Controller
- properly (re)create debug file, request file, and html report when starting load test with Controller
- if metrics are enabled, display when controller stops load test