### PR TITLE
[WIP] add traits to improve compile-time validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
  - introduce telnet Controller allowing real-time control of load test, optionally disable with `--no-telnet`, supports the following commands:
     o `help` (and `?`) display help
     o `exit` (and `quit`) exit the telnet Controller
-    o `echo` pings the parent process and confirms the controller is working
     o `shutdown` shuts down the running load test (and exits the controller)
     o `hatchrate` (and `hatch_rate`) FLOAT sets per-second rate users hatch
     o `config` displays the current load test configuration
@@ -17,12 +16,9 @@
     o default to not enabling telnet Controller: `GooseDefault::NoTelnet` (bool)
     o default host to bind telnet Controller to: `GooseDefault::TelnetHost` (&str)
     o default port to bind telnet Controller to: `GooseDefault::TelnetPort` (usize)
- - introduce WebSocket Controller allowing real-time control of load test, optionally disable with `--no-websocket`, supports the following commands:
-    o `exit` (and `quit`) exit the WebSocket Controller
-    o `shutdown` shuts down the running load test (and exits the controller)
-    o `hatchrate` (and `hatch_rate`) FLOAT sets per-second rate users hatch
-    o `config` returns the current load test configuration in json format
-    o `metrics` (and `stats`) returns metrics for the current load test in json format
+ - introduce WebSocket Controller allowing real-time control of load test, optionally disable with `--no-websocket`, supports the same commands as the telnet Controller, except:
+    o `config` and `config-json` both return the load test configuration in json format
+    o `metrics` and `metrics-json` both return metrics for the current load test in json format
  - WebSocket Controller bind host defaults to `0.0.0.0`, can be configured with `--websocket-host`
  - WebSocket Controller bind port defaults to `5117`, can be configured with `--websocket-port`
  - WebSocket Controller defaults can be changed:
@@ -40,6 +36,8 @@
  - properly flush debug file, request file, and html report when stopping load test with Controller
  - properly (re)create debug file, request file, and html report when starting load test with Controller
  - if metrics are enabled, display when controller stops load test
+ - de-duplicate code with traits, gaining compile-time validation that both Controllers are properly handling all defined commands
+ - add [`async_trait`](https://docs.rs/async_trait) dependency as stable Rust doesn't otherwise support async traits
 
 
 ## 0.11.1 May 16, 2021

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["loadtesting", "performance", "web", "framework", "tool"]
 license = "Apache-2.0"
 
 [dependencies]
+async-trait = "0.1"
 chrono = "0.4"
 ctrlc = "3.1"
 flume = "0.10"

--- a/README.md
+++ b/README.md
@@ -531,7 +531,6 @@ goose> ?
 goose 0.11.2 controller commands:
  help (?)           this help
  exit (quit)        exit controller
- echo               confirm controller is working
  start              start an idle load test
  stop               stop a running load test and return to idle state
  shutdown           shutdown running load test (and exit controller)
@@ -547,7 +546,7 @@ goose>
 
 The host and port that the WebSocket Controller listens on can be configured at start time with `--websocket-host` and `--websocket-port`. The WebSocket Controller can be completely disabled with the `--no-websocket` command line option. The defaults can be changed with `GooseDefault::WebSocketHost`,`GooseDefault::WebSocketPort`, and `GooseDefault::NoWebSocket`.
 
-The WebSocket Controller supports a subset of the above commands, including `exit`, `start`, `stop`, `shutdown`, `hatchrate FLOAT`, `config` and `metrics`. Requests and Response are in JSON format.
+The WebSocket Controller supports the same commands listed above. Requests and Response are in JSON format.
 
 Requests must be made in the following format:
 ```json
@@ -568,20 +567,22 @@ Responses will always be in the following format:
 {
   "response": String,
   "success": Boolean,
-  "error": Option<String>,
 }
 ```
-
-The `error` field will only contain a String if `success` is `false`.
 
 For example:
 ```
 % websocat ws://127.0.0.1:5117
-foobar
-{"response":"unrecognized json request","success":false,"error":"unrecognized json request"}
+foo   
+{"response":"unable to parse json, see Goose README.MD","success":false}
+{"request": "foo"}
+{"response":"unrecognized command","success":false}
 {"request": "config"}
-{"response":"{\"help\":false,\"version\":false,\"list\":false,\"host\":\"http://apache/\",\"users\":1,\"hatch_rate\":\".5\",\"run_time\":\"\",\"log_level\":0,\"log_file\":\"\",\"verbose\":1,\"running_metrics\":null,\"no_reset_metrics\":false,\"no_metrics\":false,\"no_task_metrics\":false,\"no_error_summary\":false,\"report_file\":\"\",\"requests_file\":\"\",\"requests_format\":\"json\",\"debug_file\":\"\",\"debug_format\":\"json\",\"no_debug_body\":false,\"status_codes\":false,\"no_telnet\":false,\"telnet_host\":\"0.0.0.0\",\"telnet_port\":5116,\"no_websocket\":false,\"websocket_host\":\"0.0.0.0\",\"websocket_port\":5117,\"throttle_requests\":0,\"sticky_follow\":false,\"manager\":false,\"expect_workers\":null,\"no_hash_check\":false,\"manager_bind_host\":\"\",\"manager_bind_port\":0,\"worker\":false,\"manager_host\":\"\",\"manager_port\":0}","success":true,"error":null}
+{"response":"{\"help\":false,\"version\":false,\"list\":false,\"host\":\"http://apache/\",\"users\":5,\"hatch_rate\":\".5\",\"run_time\":\"\",\"log_level\":0,\"log_file\":\"\",\"verbose\":1,\"running_metrics\":null,\"no_reset_metrics\":false,\"no_metrics\":false,\"no_task_metrics\":false,\"no_error_summary\":false,\"report_file\":\"\",\"requests_file\":\"\",\"requests_format\":\"json\",\"debug_file\":\"\",\"debug_format\":\"json\",\"no_debug_body\":false,\"status_codes\":false,\"no_telnet\":false,\"telnet_host\":\"0.0.0.0\",\"telnet_port\":5116,\"no_websocket\":false,\"websocket_host\":\"0.0.0.0\",\"websocket_port\":5117,\"no_autostart\":true,\"throttle_requests\":0,\"sticky_follow\":false,\"manager\":false,\"expect_workers\":null,\"no_hash_check\":false,\"manager_bind_host\":\"\",\"manager_bind_port\":0,\"worker\":false,\"manager_host\":\"\",\"manager_port\":0}","success":true}
+{"request": "stop"}
+{"response":"load test not running, failed to stop","success":false}
 {"request": "exit"}
+{"response":"goodbye!","success":true}
 ```
 
 ## Throttling Requests

--- a/README.md
+++ b/README.md
@@ -574,9 +574,9 @@ For example:
 ```
 % websocat ws://127.0.0.1:5117
 foo   
-{"response":"unable to parse json, see Goose README.MD","success":false}
+{"response":"unable to parse json, see Goose README.md","success":false}
 {"request": "foo"}
-{"response":"unrecognized command","success":false}
+{"response":"unrecognized command, see Goose README.md","success":false}
 {"request": "config"}
 {"response":"{\"help\":false,\"version\":false,\"list\":false,\"host\":\"http://apache/\",\"users\":5,\"hatch_rate\":\".5\",\"run_time\":\"\",\"log_level\":0,\"log_file\":\"\",\"verbose\":1,\"running_metrics\":null,\"no_reset_metrics\":false,\"no_metrics\":false,\"no_task_metrics\":false,\"no_error_summary\":false,\"report_file\":\"\",\"requests_file\":\"\",\"requests_format\":\"json\",\"debug_file\":\"\",\"debug_format\":\"json\",\"no_debug_body\":false,\"status_codes\":false,\"no_telnet\":false,\"telnet_host\":\"0.0.0.0\",\"telnet_port\":5116,\"no_websocket\":false,\"websocket_host\":\"0.0.0.0\",\"websocket_port\":5117,\"no_autostart\":true,\"throttle_requests\":0,\"sticky_follow\":false,\"manager\":false,\"expect_workers\":null,\"no_hash_check\":false,\"manager_bind_host\":\"\",\"manager_bind_port\":0,\"worker\":false,\"manager_host\":\"\",\"manager_port\":0}","success":true}
 {"request": "stop"}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -6,6 +6,7 @@
 use crate::metrics::GooseMetrics;
 use crate::GooseConfiguration;
 
+use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
 use regex::{Regex, RegexSet};
 use serde::{Deserialize, Serialize};
@@ -17,7 +18,7 @@ use std::io;
 use std::str;
 
 /// Goose currently supports two different Controller protocols: telnet and WebSocket.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum GooseControllerProtocol {
     /// Allows control of Goose via telnet.
     Telnet,
@@ -31,22 +32,25 @@ pub enum GooseControllerProtocol {
 /// the commands are defined in the
 /// [`regex::RegexSet`](https://docs.rs/regex/*/regex/struct.RegexSet.html) in
 /// [`controller_main()`](./fn.controller_main.html) as it is used to determine which
-/// regex matched, if any.
-#[derive(Debug)]
+/// regex matched, if any. Any commands that require a second match to capture values
+/// must be defined at the beginning of this enum.
+#[derive(Clone, Debug, PartialEq)]
 pub enum GooseControllerCommand {
     /// Change how quickly new [`GooseUser`](../goose/struct.GooseUser.html)s are launched.
     HatchRate,
-    /// Display the current [`GooseConfiguration`](../struct.GooseConfiguration.html)s
+    /// Display the current [`GooseConfiguration`](../struct.GooseConfiguration.html)s.
     Config,
+    /// Display the current [`GooseConfiguration`](../struct.GooseConfiguration.html)s in json format.
+    ConfigJson,
     /// Display the current [`GooseMetric`](../metrics/struct.GooseMetrics.html)s.
     Metrics,
+    /// Display the current [`GooseMetric`](../metrics/struct.GooseMetrics.html)s in json format.
+    MetricsJson,
     /// Displays a list of all supported commands.
     Help,
     /// Disconnect from the controller.
     Exit,
     /// Verify that the controller can talk to the parent process.
-    Echo,
-    /// Start an idle load test.
     Start,
     /// Stop a running test, putting it into an idle state.
     Stop,
@@ -56,20 +60,11 @@ pub enum GooseControllerCommand {
 
 /// This structure is used to send commands and values to the parent process.
 #[derive(Debug)]
-pub struct GooseControllerCommandAndValue {
+pub struct GooseControllerRequestMessage {
     /// The command that is being sent to the parent.
     pub command: GooseControllerCommand,
-    /// The value that is being sent to the parent.
-    pub value: String,
-}
-
-/// An enumeration of all messages that the controller can send to the parent thread.
-#[derive(Debug)]
-pub enum GooseControllerRequestMessage {
-    /// A command alone.
-    Command(GooseControllerCommand),
-    /// A command and a value together.
-    CommandAndValue(GooseControllerCommandAndValue),
+    /// An optional value that is being sent to the parent.
+    pub value: Option<String>,
 }
 
 /// An enumeration of all messages the parent can reply back to the controller thread.
@@ -121,11 +116,615 @@ pub struct GooseControllerWebSocketResponse {
     error: Option<String>,
 }
 
-/// The control loop listens for connection on the configured TCP port. Each connection
-/// spawns a new thread so multiple clients can connect.
-/// @TODO: set configurable limit of how many control connections are allowed
-/// @TODO: authentication
-/// @TODO: ssl
+/// Return type to indicate whether or not to exit the Controller thread.
+type GooseControllerExit = bool;
+
+/// Simplify the GooseController trait definition for WebSockets.
+type GooseControllerWebSocketMessage =
+    std::result::Result<tungstenite::Message, tungstenite::Error>;
+
+/// Simplify the GooseControllerExecuteCommand trait definition for WebSockets.
+type GooseControllerWebSocketSender = futures::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+    tungstenite::Message,
+>;
+
+/// This state object is created in the main Controller thread and then passed to the specific
+/// per-client thread.
+pub struct GooseControllerState {
+    /// Track which controller-thread this is.
+    thread_id: u32,
+    /// A shared channel for communicating with the parent process.
+    channel_tx: flume::Sender<GooseControllerRequest>,
+    /// A compiled set of regular expressions used for matching commands.
+    commands: RegexSet,
+    /// A compiled vector of regular expressions used for capturing values from commands.
+    captures: Vec<Regex>,
+    /// Which protocol this Controller understands.
+    protocol: GooseControllerProtocol,
+}
+// Defines functions shared by all Controllers.
+impl GooseControllerState {
+    async fn accept_connections(self, mut socket: tokio::net::TcpStream) {
+        let peer_addr = socket
+            .peer_addr()
+            .map_or("UNKNOWN ADDRESS".to_string(), |p| p.to_string());
+        info!(
+            "{:?} client [{}] connected from {}",
+            self.protocol, self.thread_id, peer_addr
+        );
+
+        match self.protocol {
+            GooseControllerProtocol::Telnet => {
+                let mut buf: [u8; 1024] = [0; 1024];
+
+                // Display initial goose> prompt.
+                write_to_socket_raw(&mut socket, "goose> ").await;
+
+                loop {
+                    // Process data received from the client in a loop.
+                    let n = socket
+                        .read(&mut buf)
+                        .await
+                        .expect("failed to read data from socket");
+
+                    // Invalid request, exit.
+                    if n == 0 {
+                        return;
+                    }
+
+                    // Extract the command string in a protocol-specific way.
+                    if let Ok(command_string) = self.get_command_string(buf).await {
+                        // Extract the command and value in a generic way.
+                        if let Ok(request_message) = self.get_match(&command_string).await {
+                            // Act on the commmand received.
+                            if self.execute_command(request_message, &mut socket).await {
+                                // If execute_command returns true, it's time to exit.
+                                info!(
+                                    "telnet client [{}] disconnected from {}",
+                                    self.thread_id, peer_addr
+                                );
+                                break;
+                            }
+                        } else {
+                            write_to_socket(&mut socket, "unrecognized command").await;
+                        }
+                    } else {
+                        // Corrupted request from telnet client, exit.
+                        info!(
+                            "telnet client [{}] disconnected from {}",
+                            self.thread_id, peer_addr
+                        );
+                        break;
+                    }
+                }
+            }
+            GooseControllerProtocol::WebSocket => {
+                let stream = match tokio_tungstenite::accept_async(socket).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        info!("invalid websocket handshake: {}", e);
+                        return;
+                    }
+                };
+                let (mut ws_sender, mut ws_receiver) = stream.split();
+
+                loop {
+                    // Wait until the client sends a command.
+                    let data = ws_receiver
+                        .next()
+                        .await
+                        .expect("failed to read data from socket");
+
+                    // Extract the command string in a protocol-specific way.
+                    if let Ok(command_string) = self.get_command_string(data).await {
+                        // Extract the command and value in a generic way.
+                        if let Ok(request_message) = self.get_match(&command_string).await {
+                            if self.execute_command(request_message, &mut ws_sender).await {
+                                // If execute_command() returns true, it's time to exit.
+                                info!(
+                                    "telnet client [{}] disconnected from {}",
+                                    self.thread_id, peer_addr
+                                );
+                                break;
+                            }
+                        } else {
+                            write_to_websocket(
+                                &mut ws_sender,
+                                "unrecognized command".to_string(),
+                                Some("unrecognized command".to_string()),
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Both Controllers use a common function to identify commands.
+    async fn get_match(&self, command_string: &str) -> Result<GooseControllerRequestMessage, ()> {
+        let matches = self.commands.matches(&command_string);
+        if matches.matched(GooseControllerCommand::Help as usize) {
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::Help,
+                value: None,
+            })
+        } else if matches.matched(GooseControllerCommand::Exit as usize) {
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::Exit,
+                value: None,
+            })
+        } else if matches.matched(GooseControllerCommand::Start as usize) {
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::Start,
+                value: None,
+            })
+        } else if matches.matched(GooseControllerCommand::Stop as usize) {
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::Stop,
+                value: None,
+            })
+        } else if matches.matched(GooseControllerCommand::Shutdown as usize) {
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::Shutdown,
+                value: None,
+            })
+        } else if matches.matched(GooseControllerCommand::Config as usize) {
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::Config,
+                value: None,
+            })
+        } else if matches.matched(GooseControllerCommand::ConfigJson as usize) {
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::ConfigJson,
+                value: None,
+            })
+        } else if matches.matched(GooseControllerCommand::Metrics as usize) {
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::Metrics,
+                value: None,
+            })
+        } else if matches.matched(GooseControllerCommand::MetricsJson as usize) {
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::MetricsJson,
+                value: None,
+            })
+        } else if matches.matched(GooseControllerCommand::HatchRate as usize) {
+            // Perform a second regex to capture the hatch_rate value.
+            let caps = self.captures[GooseControllerCommand::HatchRate as usize]
+                .captures(command_string)
+                .unwrap();
+            let hatch_rate = caps.get(2).map_or("", |m| m.as_str());
+            Ok(GooseControllerRequestMessage {
+                command: GooseControllerCommand::HatchRate,
+                value: Some(hatch_rate.to_string()),
+            })
+        } else {
+            Err(())
+        }
+    }
+
+    // Use a rust match to enforce at compile time that all commands are supported.
+    async fn process_command(
+        &self,
+        request_message: GooseControllerRequestMessage,
+    ) -> Result<GooseControllerResponseMessage, String> {
+        match self.send_to_parent_and_get_reply(request_message).await {
+            Ok(r) => Ok(r),
+            Err(e) => Err(format!("controller command failed: {}", e)),
+        }
+    }
+
+    /// Send a message to parent thread, with or without an optional value, and wait for
+    /// a reply.
+    async fn send_to_parent_and_get_reply(
+        &self,
+        request: GooseControllerRequestMessage,
+    ) -> Result<GooseControllerResponseMessage, String> {
+        // Create a one-shot channel to allow the parent to reply to our request. As flume
+        // doesn't implement a one-shot channel, we use tokio for this temporary channel.
+        let (response_tx, response_rx): (
+            tokio::sync::oneshot::Sender<GooseControllerResponse>,
+            tokio::sync::oneshot::Receiver<GooseControllerResponse>,
+        ) = tokio::sync::oneshot::channel();
+
+        if self
+            .channel_tx
+            .try_send(GooseControllerRequest {
+                response_channel: Some(response_tx),
+                client_id: self.thread_id,
+                request,
+            })
+            .is_err()
+        {
+            return Err("parent process has closed the controller channel".to_string());
+        }
+
+        // Await response from parent.
+        match response_rx.await {
+            Ok(value) => Ok(value.response),
+            Err(e) => Err(format!("one-shot channel dropped without reply: {}", e)),
+        }
+    }
+}
+
+/// Controller-protocol-specific functions, necessary to manage the different way each
+/// Controller protocol communicates with a client.
+#[async_trait]
+trait GooseController<T> {
+    // Extract the command string from a Controller client request.
+    async fn get_command_string(&self, raw_value: T) -> Result<String, String>;
+}
+#[async_trait]
+impl GooseController<[u8; 1024]> for GooseControllerState {
+    // Extract the command string from a telnet Controller client request.
+    async fn get_command_string(&self, raw_value: [u8; 1024]) -> Result<String, String> {
+        let command_string = match str::from_utf8(&raw_value) {
+            Ok(m) => {
+                if let Some(c) = m.lines().next() {
+                    c
+                } else {
+                    ""
+                }
+            }
+            Err(e) => {
+                let error = format!("ignoring unexpected input from telnet controller: {}", e);
+                info!("{}", error);
+                return Err(error);
+            }
+        };
+
+        Ok(command_string.to_string())
+    }
+}
+#[async_trait]
+impl GooseController<GooseControllerWebSocketMessage> for GooseControllerState {
+    // Extract the command string from a WebSocket Controller client request.
+    async fn get_command_string(
+        &self,
+        raw_value: GooseControllerWebSocketMessage,
+    ) -> Result<String, String> {
+        if let Ok(request) = raw_value {
+            if request.is_text() {
+                if let Ok(request) = request.into_text() {
+                    debug!("websocket request: {:?}", request.trim());
+                    let command_string: GooseControllerWebSocketRequest =
+                        match serde_json::from_str(&request) {
+                            Ok(c) => c,
+                            Err(_) => {
+                                return Err("unrecognized json request, refer to Goose README.md"
+                                    .to_string())
+                            }
+                        };
+                    return Ok(command_string.request);
+                }
+            }
+        }
+
+        Err(
+            "failed to get command string from WebSocket request, refer to Goose README.md"
+                .to_string(),
+        )
+    }
+}
+#[async_trait]
+trait GooseControllerExecuteCommand<T> {
+    // Run the command received from a Controller request.
+    async fn execute_command(
+        &self,
+        request_message: GooseControllerRequestMessage,
+        socket: &mut T,
+    ) -> GooseControllerExit;
+    // Process the response received back from the parent process after running a command.
+    async fn process_response(
+        &self,
+        command: GooseControllerCommand,
+        response: Result<GooseControllerResponseMessage, String>,
+        socket: &mut T,
+    ) -> GooseControllerExit;
+    // Send reply to comment depending on value of boolean response.
+    async fn boolean_reply(
+        &self,
+        socket: &mut T,
+        response_message: GooseControllerResponseMessage,
+        success_message: &str,
+        failure_message: &str,
+    );
+}
+#[async_trait]
+impl GooseControllerExecuteCommand<tokio::net::TcpStream> for GooseControllerState {
+    // Run the command received from a telnet Controller request.
+    async fn execute_command(
+        &self,
+        request_message: GooseControllerRequestMessage,
+        socket: &mut tokio::net::TcpStream,
+    ) -> GooseControllerExit {
+        // First handle commands that don't require interaction with the parent process.
+        if [GooseControllerCommand::Help, GooseControllerCommand::Exit]
+            .contains(&request_message.command)
+        {
+            let exit_controller = self
+                .process_response(
+                    request_message.command,
+                    Ok(GooseControllerResponseMessage::Bool(true)),
+                    socket,
+                )
+                .await;
+            return exit_controller;
+        }
+
+        // Retain a copy of the command used when processing the parent response.
+        let command = request_message.command.clone();
+
+        // Now handle commands that require interaction with the parent process.
+        let response = self.process_command(request_message).await;
+        self.process_response(command, response, socket).await
+    }
+
+    // Process the response received back from the parent process after running a command.
+    async fn process_response(
+        &self,
+        command: GooseControllerCommand,
+        response: Result<GooseControllerResponseMessage, String>,
+        socket: &mut tokio::net::TcpStream,
+    ) -> GooseControllerExit {
+        let response_message = match response {
+            Ok(m) => m,
+            Err(e) => {
+                // Command failed for unexpected reason.
+                write_to_socket(socket, &e).await;
+                return true;
+            }
+        };
+
+        match command {
+            GooseControllerCommand::HatchRate => {
+                self.boolean_reply(
+                    socket,
+                    response_message,
+                    "hatch_rate reconfigured",
+                    "failed to reconfigure hatch_rate",
+                )
+                .await;
+            }
+            GooseControllerCommand::Config => {
+                if let GooseControllerResponseMessage::Config(config) = response_message {
+                    write_to_socket(socket, &format!("{:#?}", config)).await;
+                } else {
+                    write_to_socket(socket, "error loading configuration").await;
+                }
+            }
+            GooseControllerCommand::ConfigJson => {
+                if let GooseControllerResponseMessage::Config(config) = response_message {
+                    let config_json: String =
+                        serde_json::to_string(&config).expect("unexpected failure");
+                    write_to_socket(socket, &config_json).await;
+                } else {
+                    write_to_socket(socket, "error loading configuration").await;
+                }
+            }
+            GooseControllerCommand::Metrics => {
+                if let GooseControllerResponseMessage::Metrics(metrics) = response_message {
+                    write_to_socket(socket, &metrics.to_string()).await;
+                } else {
+                    write_to_socket(socket, "error loading metrics").await;
+                }
+            }
+            GooseControllerCommand::MetricsJson => {
+                if let GooseControllerResponseMessage::Metrics(metrics) = response_message {
+                    let metrics_json: String =
+                        serde_json::to_string(&metrics).expect("unexpected failure");
+                    write_to_socket(socket, &metrics_json).await;
+                } else {
+                    write_to_socket(socket, "error loading metrics").await;
+                }
+            }
+            GooseControllerCommand::Help => {
+                write_to_socket(socket, &display_help()).await;
+            }
+            GooseControllerCommand::Exit => {
+                write_to_socket(socket, "goodbye!").await;
+                return true;
+            }
+            // This shouldn't work if the load test isn't idle.
+            GooseControllerCommand::Start => {
+                self.boolean_reply(
+                    socket,
+                    response_message,
+                    "load test started",
+                    "failed to start load test (be sure it is idle)",
+                )
+                .await;
+            }
+            // This shouldn't work if the load test isn't running.
+            GooseControllerCommand::Stop => {
+                self.boolean_reply(
+                    socket,
+                    response_message,
+                    "load test stopped",
+                    "failed to stop load test (be sure it is running)",
+                )
+                .await;
+            }
+            GooseControllerCommand::Shutdown => {
+                if let GooseControllerResponseMessage::Bool(true) = response_message {
+                    // Don't display a goose> prompt after initiating shut down.
+                    write_to_socket_raw(socket, "load test shutting down....").await;
+                } else {
+                    write_to_socket(socket, "failed to shut down load test").await;
+                }
+            }
+        }
+        false
+    }
+
+    // Send reply to comment depending on value of boolean response.
+    async fn boolean_reply(
+        &self,
+        socket: &mut tokio::net::TcpStream,
+        response_message: GooseControllerResponseMessage,
+        success_message: &str,
+        failure_message: &str,
+    ) {
+        if let GooseControllerResponseMessage::Bool(true) = response_message {
+            write_to_socket(socket, success_message).await;
+        } else {
+            write_to_socket(socket, failure_message).await;
+        }
+    }
+}
+#[async_trait]
+impl GooseControllerExecuteCommand<GooseControllerWebSocketSender> for GooseControllerState {
+    // Run the command received from a WebSocket Controller request.
+    async fn execute_command(
+        &self,
+        request_message: GooseControllerRequestMessage,
+        socket: &mut GooseControllerWebSocketSender,
+    ) -> GooseControllerExit {
+        // First handle commands that don't require interaction with the parent process.
+        if [GooseControllerCommand::Help, GooseControllerCommand::Exit]
+            .contains(&request_message.command)
+        {
+            let exit_controller = self
+                .process_response(
+                    request_message.command,
+                    Ok(GooseControllerResponseMessage::Bool(true)),
+                    socket,
+                )
+                .await;
+            return exit_controller;
+        }
+
+        // Retain a copy of the command used when processing the parent response.
+        let command = request_message.command.clone();
+
+        // Now handle commands that require interaction with the parent process.
+        let response = self.process_command(request_message).await;
+        self.process_response(command, response, socket).await
+    }
+
+    // Process the response received back from the parent process after running a command.
+    async fn process_response(
+        &self,
+        command: GooseControllerCommand,
+        response: Result<GooseControllerResponseMessage, String>,
+        socket: &mut GooseControllerWebSocketSender,
+    ) -> GooseControllerExit {
+        let response_message = match response {
+            Ok(m) => m,
+            Err(e) => {
+                // Command failed for unexpected reason.
+                write_to_websocket(socket, e.clone(), Some(e)).await;
+                return true;
+            }
+        };
+
+        match command {
+            GooseControllerCommand::HatchRate => {
+                self.boolean_reply(
+                    socket,
+                    response_message,
+                    "hatch_rate reconfigured",
+                    "failed to reconfigure hatch_rate",
+                )
+                .await;
+            }
+            GooseControllerCommand::Config | GooseControllerCommand::ConfigJson => {
+                if let GooseControllerResponseMessage::Config(config) = response_message {
+                    let config_json: String =
+                        serde_json::to_string(&config).expect("unexpected failure");
+                    write_to_websocket(socket, format!("{:#?}", config_json), None).await;
+                }
+            }
+            GooseControllerCommand::Metrics | GooseControllerCommand::MetricsJson => {
+                if let GooseControllerResponseMessage::Metrics(metrics) = response_message {
+                    let metrics_json: String =
+                        serde_json::to_string(&metrics).expect("unexpected failure");
+                    write_to_websocket(socket, metrics_json, None).await;
+                }
+            }
+            GooseControllerCommand::Help => {
+                write_to_websocket(socket, display_help(), None).await;
+            }
+            GooseControllerCommand::Exit => {
+                write_to_websocket(socket, "goodbye!".to_string(), None).await;
+                socket
+                    .send(Message::Close(Some(tungstenite::protocol::CloseFrame {
+                        code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+                        reason: std::borrow::Cow::Borrowed("exit"),
+                    })))
+                    .await
+                    .expect("failed to write data to stream");
+                return true;
+            }
+            // This shouldn't work if the load test isn't idle.
+            GooseControllerCommand::Start => {
+                self.boolean_reply(
+                    socket,
+                    response_message,
+                    "load test started",
+                    "failed to start load test (be sure it is idle)",
+                )
+                .await;
+            }
+            // This shouldn't work if the load test isn't running.
+            GooseControllerCommand::Stop => {
+                self.boolean_reply(
+                    socket,
+                    response_message,
+                    "load test stopped",
+                    "failed to stop load test (be sure it is running)",
+                )
+                .await;
+            }
+            GooseControllerCommand::Shutdown => {
+                self.boolean_reply(
+                    socket,
+                    response_message,
+                    "load test shut down",
+                    "failed to shut down load test",
+                )
+                .await;
+                socket
+                    .send(Message::Close(Some(tungstenite::protocol::CloseFrame {
+                        code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+                        reason: std::borrow::Cow::Borrowed("shutdown"),
+                    })))
+                    .await
+                    .expect("failed to write data to stream");
+            }
+        }
+        false
+    }
+
+    // Send reply to comment depending on value of boolean response.
+    async fn boolean_reply(
+        &self,
+        socket: &mut GooseControllerWebSocketSender,
+        response_message: GooseControllerResponseMessage,
+        success_message: &str,
+        failure_message: &str,
+    ) {
+        if let GooseControllerResponseMessage::Bool(true) = response_message {
+            write_to_websocket(socket, success_message.to_string(), None).await;
+        } else {
+            write_to_websocket(
+                socket,
+                failure_message.to_string(),
+                Some(failure_message.to_string()),
+            )
+            .await;
+        }
+    }
+}
+
+/// The control loop listens for connections on the configured TCP port. Each connection
+/// spawns a new thread so multiple clients can connect. Handles incoming connections for
+/// both telnet and WebSocket clients.
+///  -  @TODO: optionally limit how many controller connections are allowed
+///  -  @TODO: optionally require client authentication
+///  -  @TODO: optionally ssl-encrypt client communication
 pub async fn controller_main(
     // Expose load test configuration to controller thread.
     configuration: GooseConfiguration,
@@ -159,8 +758,6 @@ pub async fn controller_main(
     // limitiation of RegexSet as documented at:
     // https://docs.rs/regex/1.5.4/regex/struct.RegexSet.html#limitations
     let hatchrate_regex = r"(?i)^(hatchrate|hatch_rate) ([0-9]*(\.[0-9]*)?){1}$";
-    let config_regex = r"(?i)^(config|config-json)$";
-    let metrics_regex = r"(?i)^(metrics|stats|metrics-json|stats-json)$";
     // @TODO: enable when the parent process processes it properly.
     //let users_regex = r"(?i)^users (\d+)$";
 
@@ -172,18 +769,17 @@ pub async fn controller_main(
         // Modify how quickly users hatch (or exit if users are reduced).
         hatchrate_regex,
         // Display the current load test configuration.
-        config_regex,
+        r"(?i)^config$",
+        // Display the current load test configuration in json.
+        r"(?i)^config-json$",
         // Display running metrics for the currently active load test.
-        metrics_regex,
-        // Modify number of users simulated.
-        // @TODO: enable when the parent process processes it properly.
-        //users_regex,
+        r"(?i)^(metrics|stats)$",
+        // Display running metrics for the currently active load test in json.
+        r"(?i)^(metrics-json|stats-json)$",
         // Provide a list of possible commands.
         r"(?i)^(help|\?)$",
         // Exit/quit the controller connection, does not affect load test.
         r"(?i)^(exit|quit)$",
-        // Confirm the server is still connected and alive.
-        r"(?i)^echo$",
         // Start an idle load test.
         r"(?i)^start$",
         // Stop an idle load test.
@@ -195,13 +791,7 @@ pub async fn controller_main(
 
     // The following regular expressions are used when matching against certain commands
     // to then capture a matched value.
-    let captures = vec![
-        Regex::new(hatchrate_regex).unwrap(),
-        Regex::new(config_regex).unwrap(),
-        Regex::new(metrics_regex).unwrap(),
-    ];
-    // @TODO: enable when the parent process processes it properly.
-    //Regex::new(users_regex).unwrap();
+    let captures = vec![Regex::new(hatchrate_regex).unwrap()];
 
     // Counter increments each time a controller client connects with this protocol.
     let mut thread_id: u32 = 0;
@@ -209,507 +799,21 @@ pub async fn controller_main(
     // Wait for a connection.
     while let Ok((stream, _)) = listener.accept().await {
         thread_id += 1;
-        // Spawn a new thread to communicate with client, igoring the returned JoinHandle.
-        let _ = match &protocol {
-            GooseControllerProtocol::Telnet => tokio::spawn(accept_telnet_connection(
-                thread_id,
-                channel_tx.clone(),
-                stream,
-                commands.clone(),
-                captures.clone(),
-            )),
-            GooseControllerProtocol::WebSocket => tokio::spawn(accept_websocket_connection(
-                thread_id,
-                channel_tx.clone(),
-                stream,
-                commands.clone(),
-                captures.clone(),
-            )),
+
+        let controller_state = GooseControllerState {
+            thread_id,
+            channel_tx: channel_tx.clone(),
+            commands: commands.clone(),
+            captures: captures.clone(),
+            protocol: protocol.clone(),
         };
+
+        // Spawn a new thread to communicate with a client. The returned JoinHandle is
+        // ignored as the thread simply runs until the client exits or Goose shuts down.
+        let _ = tokio::spawn(controller_state.accept_connections(stream));
     }
 
     Ok(())
-}
-
-// Respond to an incoming telnet connection.
-// @TODO: add support for ssl and optional authentication.
-// @TODO: limit the number of active connections to prevent DoS.
-async fn accept_telnet_connection(
-    thread_id: u32,
-    channel_tx: flume::Sender<GooseControllerRequest>,
-    mut socket: tokio::net::TcpStream,
-    commands: RegexSet,
-    captures: Vec<Regex>,
-) {
-    let peer_addr = socket
-        .peer_addr()
-        .map_or("UNKNOWN ADDRESS".to_string(), |p| p.to_string());
-    info!("telnet client [{}] connected from {}", thread_id, peer_addr);
-
-    // Display initial goose> prompt.
-    write_to_socket_raw(&mut socket, "goose> ").await;
-
-    // @TODO: reset connection if larger command is entered (to unfreeze connection).
-    let mut buf = [0; 1024];
-
-    // Process data received from the client in a loop.
-    loop {
-        let n = socket
-            .read(&mut buf)
-            .await
-            .expect("failed to read data from socket");
-
-        if n == 0 {
-            return;
-        }
-
-        let command = match str::from_utf8(&buf) {
-            Ok(m) => {
-                if let Some(c) = m.lines().next() {
-                    c
-                } else {
-                    ""
-                }
-            }
-            Err(e) => {
-                warn!("ignoring unexpected input from telnet controller: {}", e);
-                continue;
-            }
-        };
-
-        let matches = commands.matches(command);
-        // Help
-        if matches.matched(GooseControllerCommand::Help as usize) {
-            write_to_socket(&mut socket, &display_help()).await;
-        // Exit
-        } else if matches.matched(GooseControllerCommand::Exit as usize) {
-            write_to_socket(&mut socket, "goodbye!").await;
-            info!(
-                "telnet client [{}] disconnected from {}",
-                thread_id, peer_addr
-            );
-            return;
-        // Echo
-        } else if matches.matched(GooseControllerCommand::Echo as usize) {
-            match send_to_parent_and_get_reply(
-                thread_id,
-                &channel_tx,
-                GooseControllerCommand::Echo,
-                None,
-            )
-            .await
-            {
-                Ok(_) => write_to_socket(&mut socket, "echo").await,
-                Err(e) => write_to_socket(&mut socket, &format!("echo failed: [{}]", e)).await,
-            }
-        // Start
-        } else if matches.matched(GooseControllerCommand::Start as usize) {
-            write_to_socket_raw(&mut socket, "starting load test ...").await;
-            match send_to_parent_and_get_reply(
-                thread_id,
-                &channel_tx,
-                GooseControllerCommand::Start,
-                None,
-            )
-            .await
-            {
-                Ok(_) => write_to_socket(&mut socket, "").await,
-                Err(e) => {
-                    write_to_socket(&mut socket, &format!("failed to start load test [{}]", e))
-                        .await
-                }
-            }
-        // Stop
-        } else if matches.matched(GooseControllerCommand::Stop as usize) {
-            write_to_socket_raw(&mut socket, "stopping load test ...").await;
-            match send_to_parent_and_get_reply(
-                thread_id,
-                &channel_tx,
-                GooseControllerCommand::Stop,
-                None,
-            )
-            .await
-            {
-                Ok(_) => write_to_socket(&mut socket, "").await,
-                Err(e) => {
-                    write_to_socket(&mut socket, &format!("failed to stop load test [{}]", e)).await
-                }
-            }
-        // Shutdown
-        } else if matches.matched(GooseControllerCommand::Shutdown as usize) {
-            write_to_socket_raw(&mut socket, "shutting down load test ...\n").await;
-            if let Err(e) = send_to_parent_and_get_reply(
-                thread_id,
-                &channel_tx,
-                GooseControllerCommand::Shutdown,
-                None,
-            )
-            .await
-            {
-                write_to_socket(
-                    &mut socket,
-                    &format!("failed to shut down load test [{}]", e),
-                )
-                .await;
-            }
-        // Hatch rate
-        } else if matches.matched(GooseControllerCommand::HatchRate as usize) {
-            // Perform a second map to capture the hatch_rate value.
-            let caps = captures[GooseControllerCommand::HatchRate as usize]
-                .captures(command)
-                .unwrap();
-            let hatch_rate = caps.get(2).map_or("", |m| m.as_str());
-            send_to_parent(
-                thread_id,
-                &channel_tx,
-                None,
-                GooseControllerCommand::HatchRate,
-                Some(hatch_rate.to_string()),
-            )
-            .await;
-            write_to_socket(
-                &mut socket,
-                &format!("reconfigured hatch_rate: {}", hatch_rate),
-            )
-            .await;
-        // Config
-        } else if matches.matched(GooseControllerCommand::Config as usize) {
-            // Perform a second map to capture the actual command matched.
-            let caps = captures[GooseControllerCommand::Config as usize]
-                .captures(command)
-                .unwrap();
-            let config_format = caps.get(1).map_or("", |m| m.as_str());
-            // Get an up-to-date copy of the configuration, as it may have changed since
-            // the version that was initially passed in.
-            if let Ok(value) = send_to_parent_and_get_reply(
-                thread_id,
-                &channel_tx,
-                GooseControllerCommand::Config,
-                None,
-            )
-            .await
-            {
-                match value {
-                    GooseControllerResponseMessage::Config(config) => {
-                        match config_format {
-                            // Display human-readable configuration.
-                            "config" => {
-                                write_to_socket(&mut socket, &format!("{:#?}", config)).await;
-                            }
-                            // Display json-formatted configuration.
-                            "config-json" => {
-                                // Convert the configuration object to a JSON string.
-                                let config_json: String =
-                                    serde_json::to_string(&config).expect("unexpected failure");
-                                write_to_socket(&mut socket, &config_json).await;
-                            }
-                            _ => (),
-                        }
-                    }
-                    _ => warn!(
-                        "parent process sent an unexpected reply, unable to update configuration"
-                    ),
-                }
-            }
-        // Metrics
-        } else if matches.matched(GooseControllerCommand::Metrics as usize) {
-            // Perform a second map to capture the actual command matched.
-            let caps = captures[GooseControllerCommand::Metrics as usize]
-                .captures(command)
-                .unwrap();
-            let metrics_format = caps.get(1).map_or("", |m| m.as_str());
-            // Get a copy of the current running metrics.
-            if let Ok(value) = send_to_parent_and_get_reply(
-                thread_id,
-                &channel_tx,
-                GooseControllerCommand::Metrics,
-                None,
-            )
-            .await
-            {
-                match value {
-                    GooseControllerResponseMessage::Metrics(metrics) => {
-                        match metrics_format {
-                            // Display human-readable metrics.
-                            "stats" | "metrics" => {
-                                write_to_socket(&mut socket, &format!("{}", metrics)).await;
-                            }
-                            // Display raw json-formatted metrics.
-                            "stats-json" | "metrics-json" => {
-                                // Convert the configuration object to a JSON string.
-                                let metrics_json: String =
-                                    serde_json::to_string(&metrics).expect("unexpected failure");
-                                write_to_socket(&mut socket, &metrics_json).await;
-                            }
-                            _ => (),
-                        }
-                    }
-                    _ => {
-                        warn!("parent process sent an unexpected reply, unable to display metrics")
-                    }
-                }
-            }
-        } else {
-            write_to_socket(&mut socket, "unrecognized command").await;
-        }
-    }
-}
-
-// Respond to an incoming websocket connection.
-// @TODO: add support for ssl and optional authentication.
-// @TODO: limit the number of active connections to prevent DoS.
-async fn accept_websocket_connection(
-    thread_id: u32,
-    channel_tx: flume::Sender<GooseControllerRequest>,
-    stream: tokio::net::TcpStream,
-    commands: RegexSet,
-    captures: Vec<Regex>,
-) {
-    let peer_addr = stream
-        .peer_addr()
-        .map_or("UNKNOWN ADDRESS".to_string(), |p| p.to_string());
-    info!(
-        "websocket client [{}] connected from {}",
-        thread_id, peer_addr
-    );
-
-    let ws_stream = match tokio_tungstenite::accept_async(stream).await {
-        Ok(s) => s,
-        Err(e) => {
-            info!("invalid websocket handshake: {}", e);
-            return;
-        }
-    };
-
-    let (mut ws_sender, mut ws_receiver) = ws_stream.split();
-
-    // Process data received from the client in a loop.
-    loop {
-        // Wait until the client sends a command.
-        let data = ws_receiver
-            .next()
-            .await
-            .expect("failed to read data from socket");
-
-        if let Ok(request) = data {
-            if request.is_text() {
-                if let Ok(request) = request.into_text() {
-                    debug!("websocket request: {:?}", request.trim());
-
-                    let command: GooseControllerWebSocketRequest =
-                        match serde_json::from_str(&request) {
-                            Ok(c) => c,
-                            Err(_) => {
-                                write_to_websocket(
-                                    &mut ws_sender,
-                                    "unrecognized json request".to_string(),
-                                    Some(
-                                        "unrecognized json request, refer to Goose README.md"
-                                            .to_string(),
-                                    ),
-                                )
-                                .await;
-                                continue;
-                            }
-                        };
-                    debug!("websocket request command: {:?}", command);
-
-                    let matches = commands.matches(&command.request);
-                    // Exit
-                    if matches.matched(GooseControllerCommand::Exit as usize) {
-                        ws_sender
-                            .send(Message::Close(Some(tungstenite::protocol::CloseFrame {
-                                code: tungstenite::protocol::frame::coding::CloseCode::Normal,
-                                reason: std::borrow::Cow::Borrowed("exit"),
-                            })))
-                            .await
-                            .expect("failed to write data to stream");
-                        info!(
-                            "websocket client [{}] disconnected from {}",
-                            thread_id, peer_addr
-                        );
-                        return;
-                    // Echo
-                    } else if matches.matched(GooseControllerCommand::Echo as usize) {
-                        match send_to_parent_and_get_reply(
-                            thread_id,
-                            &channel_tx,
-                            GooseControllerCommand::Echo,
-                            None,
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                write_to_websocket(&mut ws_sender, "echo".to_string(), None).await;
-                            }
-                            Err(e) => {
-                                write_to_websocket(
-                                    &mut ws_sender,
-                                    "echo failed".to_string(),
-                                    Some(e),
-                                )
-                                .await;
-                            }
-                        }
-                    // Start
-                    } else if matches.matched(GooseControllerCommand::Start as usize) {
-                        match send_to_parent_and_get_reply(
-                            thread_id,
-                            &channel_tx,
-                            GooseControllerCommand::Start,
-                            None,
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                write_to_websocket(
-                                    &mut ws_sender,
-                                    "load test started".to_string(),
-                                    None,
-                                )
-                                .await;
-                            }
-                            Err(e) => {
-                                write_to_websocket(
-                                    &mut ws_sender,
-                                    "failed to start load test".to_string(),
-                                    Some(e),
-                                )
-                                .await;
-                            }
-                        }
-                    // Stop
-                    } else if matches.matched(GooseControllerCommand::Stop as usize) {
-                        match send_to_parent_and_get_reply(
-                            thread_id,
-                            &channel_tx,
-                            GooseControllerCommand::Stop,
-                            None,
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                write_to_websocket(
-                                    &mut ws_sender,
-                                    "load test stopped".to_string(),
-                                    None,
-                                )
-                                .await;
-                            }
-                            Err(e) => {
-                                write_to_websocket(
-                                    &mut ws_sender,
-                                    "failed to stop load test".to_string(),
-                                    Some(e),
-                                )
-                                .await;
-                            }
-                        }
-                    // Shutdown
-                    } else if matches.matched(GooseControllerCommand::Shutdown as usize) {
-                        match send_to_parent_and_get_reply(
-                            thread_id,
-                            &channel_tx,
-                            GooseControllerCommand::Shutdown,
-                            None,
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                ws_sender
-                                    .send(Message::Close(Some(tungstenite::protocol::CloseFrame {
-                                        code: tungstenite::protocol::frame::coding::CloseCode::Away,
-                                        reason: std::borrow::Cow::Borrowed("stopping"),
-                                    })))
-                                    .await
-                                    .expect("failed to write data to stream");
-                            }
-                            Err(e) => {
-                                write_to_websocket(
-                                    &mut ws_sender,
-                                    "failed to shutdown load test".to_string(),
-                                    Some(e),
-                                )
-                                .await;
-                            }
-                        }
-                    // Hatch rate
-                    } else if matches.matched(GooseControllerCommand::HatchRate as usize) {
-                        // Perform a second map to capture the hatch_rate value.
-                        let caps = captures[GooseControllerCommand::HatchRate as usize]
-                            .captures(&command.request)
-                            .unwrap();
-                        let hatch_rate = caps.get(2).map_or("", |m| m.as_str());
-                        info!("matched hatch_rate: {}", hatch_rate);
-                        send_to_parent(
-                            thread_id,
-                            &channel_tx,
-                            None,
-                            GooseControllerCommand::HatchRate,
-                            Some(hatch_rate.to_string()),
-                        )
-                        .await;
-                        write_to_websocket(
-                            &mut ws_sender,
-                            "configured hatch_rate".to_string(),
-                            None,
-                        )
-                        .await;
-                    // Config
-                    } else if matches.matched(GooseControllerCommand::Config as usize) {
-                        // Get an up-to-date copy of the configuration, as it may have changed since
-                        // the version that was initially passed in.
-                        if let Ok(GooseControllerResponseMessage::Config(config)) =
-                            send_to_parent_and_get_reply(
-                                thread_id,
-                                &channel_tx,
-                                GooseControllerCommand::Config,
-                                None,
-                            )
-                            .await
-                        {
-                            // Convert the configuration object to a JSON string.
-                            let config_json: String =
-                                serde_json::to_string(&config).expect("unexpected failure");
-                            write_to_websocket(&mut ws_sender, config_json, None).await;
-                        }
-                    // Metrics
-                    } else if matches.matched(GooseControllerCommand::Metrics as usize) {
-                        // Get a copy of the current running metrics.
-                        if let Ok(GooseControllerResponseMessage::Metrics(metrics)) =
-                            send_to_parent_and_get_reply(
-                                //if let GooseControllerResponseMessage::Metrics(metrics) = value {
-                                thread_id,
-                                &channel_tx,
-                                GooseControllerCommand::Metrics,
-                                None,
-                            )
-                            .await
-                        {
-                            // Convert the configuration object to a JSON string.
-                            let metrics_json: String =
-                                serde_json::to_string(&metrics).expect("unexpected failure");
-                            write_to_websocket(&mut ws_sender, metrics_json, None).await;
-                        }
-                    // Unknown command
-                    } else {
-                        write_to_websocket(
-                            &mut ws_sender,
-                            "unrecognized command".to_string(),
-                            Some("unsupported command".to_string()),
-                        )
-                        .await;
-                    }
-                }
-            } else if request.is_close() {
-                info!(
-                    "telnet client [{}] disconnected from {}",
-                    thread_id, peer_addr
-                );
-                break;
-            }
-        }
-    }
 }
 
 /// Send a message to the client TcpStream, no prompt or line feed.
@@ -760,58 +864,6 @@ async fn write_to_websocket(
     }
 }
 
-/// Send a message to parent thread, with or without an optional value.
-async fn send_to_parent(
-    client_id: u32,
-    channel: &flume::Sender<GooseControllerRequest>,
-    response_channel: Option<tokio::sync::oneshot::Sender<GooseControllerResponse>>,
-    command: GooseControllerCommand,
-    optional_value: Option<String>,
-) {
-    if let Some(value) = optional_value {
-        // @TODO: handle a possible error when sending.
-        let _ = channel.try_send(GooseControllerRequest {
-            response_channel,
-            client_id,
-            request: GooseControllerRequestMessage::CommandAndValue(
-                GooseControllerCommandAndValue { command, value },
-            ),
-        });
-    } else {
-        // @TODO: handle a possible error when sending.
-        let _ = channel.try_send(GooseControllerRequest {
-            response_channel,
-            client_id,
-            request: GooseControllerRequestMessage::Command(command),
-        });
-    }
-}
-
-/// Send a message to parent thread, with or without an optional value, and wait for
-/// a reply.
-async fn send_to_parent_and_get_reply(
-    client_id: u32,
-    channel_tx: &flume::Sender<GooseControllerRequest>,
-    command: GooseControllerCommand,
-    value: Option<String>,
-) -> Result<GooseControllerResponseMessage, String> {
-    // Create a one-shot channel to allow the parent to reply to our request. As flume
-    // doesn't implement a one-shot channel, we use tokio for this temporary channel.
-    let (response_tx, response_rx): (
-        tokio::sync::oneshot::Sender<GooseControllerResponse>,
-        tokio::sync::oneshot::Receiver<GooseControllerResponse>,
-    ) = tokio::sync::oneshot::channel();
-
-    // Send request to parent.
-    send_to_parent(client_id, channel_tx, Some(response_tx), command, value).await;
-
-    // Await response from parent.
-    match response_rx.await {
-        Ok(value) => Ok(value.response),
-        Err(e) => Err(format!("one-shot channel dropped without reply: {}", e)),
-    }
-}
-
 // A controller help screen.
 // @TODO: document `users` when enabled:
 // users INT          set number of simulated users
@@ -820,7 +872,6 @@ fn display_help() -> String {
         r"{} {} controller commands:
  help (?)           this help
  exit (quit)        exit controller
- echo               confirm controller is working
  start              start an idle load test
  stop               stop a running load test and return to idle state
  shutdown           shutdown running load test (and exit controller)

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -4,7 +4,7 @@
 //! real-time control of the running load test.
 
 use crate::metrics::GooseMetrics;
-use crate::GooseConfiguration;
+use crate::{AttackPhase, GooseAttack, GooseAttackRunState, GooseConfiguration, GooseError};
 
 use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
@@ -816,4 +816,156 @@ fn display_help() -> String {
         env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION")
     )
+}
+
+/// The parent process side of the Controller functionality.
+impl GooseAttack {
+    /// Use the provided oneshot channel to reply to a controller client request.
+    pub(crate) fn reply_to_controller(
+        &mut self,
+        request: GooseControllerRequest,
+        response: GooseControllerResponseMessage,
+    ) {
+        if let Some(oneshot_tx) = request.response_channel {
+            if oneshot_tx
+                .send(GooseControllerResponse {
+                    client_id: request.client_id,
+                    response,
+                })
+                .is_err()
+            {
+                warn!("failed to send response to controller via one-shot channel")
+            }
+        }
+    }
+
+    /// Handle Controller requests.
+    pub(crate) async fn handle_controller_requests(
+        &mut self,
+        goose_attack_run_state: &mut GooseAttackRunState,
+    ) -> Result<(), GooseError> {
+        // If the controller is enabled, check if we've received any
+        // messages.
+        if let Some(c) = goose_attack_run_state.controller_channel_rx.as_ref() {
+            match c.try_recv() {
+                Ok(message) => {
+                    info!(
+                        "request from controller client {}: {:?}",
+                        message.client_id, message.request
+                    );
+                    match &message.request.command {
+                        // Send back a copy of the running configuration.
+                        GooseControllerCommand::Config | GooseControllerCommand::ConfigJson => {
+                            self.reply_to_controller(
+                                message,
+                                GooseControllerResponseMessage::Config(Box::new(
+                                    self.configuration.clone(),
+                                )),
+                            );
+                        }
+                        // Send back a copy of the running metrics.
+                        GooseControllerCommand::Metrics | GooseControllerCommand::MetricsJson => {
+                            self.reply_to_controller(
+                                message,
+                                GooseControllerResponseMessage::Metrics(Box::new(
+                                    self.metrics.clone(),
+                                )),
+                            );
+                        }
+                        // Start the load test, and acknowledge command.
+                        GooseControllerCommand::Start => {
+                            // We can only start an idle load test.
+                            if self.attack_phase == AttackPhase::Idle {
+                                self.set_attack_phase(
+                                    goose_attack_run_state,
+                                    AttackPhase::Starting,
+                                );
+                                self.reply_to_controller(
+                                    message,
+                                    GooseControllerResponseMessage::Bool(true),
+                                );
+                                // Reset the run state when starting a new load test.
+                                self.reset_run_state(goose_attack_run_state).await?;
+                            } else {
+                                self.reply_to_controller(
+                                    message,
+                                    GooseControllerResponseMessage::Bool(false),
+                                );
+                            }
+                        }
+                        // Stop the load test, and acknowledge command.
+                        GooseControllerCommand::Stop => {
+                            // We can only stop a starting or running load test.
+                            if [AttackPhase::Starting, AttackPhase::Running]
+                                .contains(&self.attack_phase)
+                            {
+                                self.set_attack_phase(
+                                    goose_attack_run_state,
+                                    AttackPhase::Stopping,
+                                );
+                                // Don't shutdown when load test is stopped by controller, remain idle instead.
+                                goose_attack_run_state.shutdown_after_stop = false;
+                                // Don't automatically restart the load test.
+                                self.configuration.no_autostart = true;
+                                self.reply_to_controller(
+                                    message,
+                                    GooseControllerResponseMessage::Bool(true),
+                                );
+                            } else {
+                                self.reply_to_controller(
+                                    message,
+                                    GooseControllerResponseMessage::Bool(false),
+                                );
+                            }
+                        }
+                        // Stop the load test, and acknowledge request.
+                        GooseControllerCommand::Shutdown => {
+                            // If load test is Idle, there are no metrics to display.
+                            if self.attack_phase == AttackPhase::Idle {
+                                self.metrics.display_metrics = false;
+                            }
+                            // Shutdown after stopping.
+                            goose_attack_run_state.shutdown_after_stop = true;
+                            // Properly stop any running GooseAttack first.
+                            self.set_attack_phase(goose_attack_run_state, AttackPhase::Stopping);
+                            // Confirm shut down to Controller.
+                            self.reply_to_controller(
+                                message,
+                                GooseControllerResponseMessage::Bool(true),
+                            );
+                        }
+                        GooseControllerCommand::HatchRate => {
+                            // The controller uses a regular expression to validate that
+                            // this is a valid float, so simply use it with further
+                            // validation.
+                            if let Some(hatch_rate) = &message.request.value {
+                                info!(
+                                    "changing hatch_rate from {:?} to {}",
+                                    self.configuration.hatch_rate, hatch_rate
+                                );
+                                self.configuration.hatch_rate = Some(hatch_rate.clone());
+                                self.reply_to_controller(
+                                    message,
+                                    GooseControllerResponseMessage::Bool(true),
+                                );
+                            } else {
+                                warn!(
+                                    "Controller didn't provide hatch_rate: {:#?}",
+                                    &message.request
+                                );
+                            }
+                        }
+                        _ => {
+                            warn!("Unexpected command: {:?}", &message.request);
+                        }
+                    }
+                }
+                Err(e) => {
+                    // Errors can be ignored, they happen any time there are no messages.
+                    debug!("error receiving message: {}", e);
+                }
+            }
+        };
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3883,12 +3883,18 @@ impl GooseAttack {
                             }
                             // Stop the load test, and acknowledge request.
                             GooseControllerCommand::Shutdown => {
+                                // If load test is Idle, there are no metrics to display.
+                                if self.attack_phase == AttackPhase::Idle {
+                                    self.metrics.display_metrics = false;
+                                }
+                                // Shutdown after stopping.
+                                goose_attack_run_state.shutdown_after_stop = true;
+                                // Properly stop any running GooseAttack first.
                                 self.set_attack_phase(
                                     &mut goose_attack_run_state,
                                     AttackPhase::Stopping,
                                 );
-                                // Shutdown after stopping.
-                                goose_attack_run_state.shutdown_after_stop = true;
+                                // Confirm shut down to Controller.
                                 self.reply_to_controller(
                                     message,
                                     GooseControllerResponseMessage::Bool(true),


### PR DESCRIPTION
 - use traits to de-duplicate code where possible, and to gain compile-time validation that both Controllers are properly handling all defined commands
 - add `async_trait` dependency as Stable Rust doesn't otherwise support async traits
 - add `GooseController` trait:
     o add `get_command_string()` providing controller-specific logic for extracting a command from the protocol-specific request
 - add `GooseControllerExecuteCommand` trait:
     o add `execute_command()` to run the command received from a Controller request
     o add `write_to_socket()` to implement the per-protocol logic for sending a message back to the controller client
 - introduce `GooseControllerState` created in the main Controller thread and then passed to the per-client thread as new requests come in, also provides the following functions:
    o `accept_connections` starts an appropriate control loop for supported protocols
    o `get_match` determines what command the controller client sent
    o `process_command` creates a temporary one-shot channel, sends a request to the parent, and waits for a reply
    o `process_local_command` handles requests that don't involve the parent process
    o `process_response` prepares a client response based on the parent process response
 - removed `GooseCommand::Echo` which was just an initial proof of concept
 - removed `GooseControllerRequestMessage` enum instead using the old `GooseControllerCommandAndValue` struct renamed as `GooseControllerRequestMessage`, making the value optional
 - simplified `write_to_controller` to process a `Result<String, String>` directly, removed `error` from `GooseControllerWebSocketResponse` to avoid special-handling for the WebSocket Controller (the error text instead goes in the `response` field)