### PR TITLE
add new commands: host, users, runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
     o `help` (and `?`) display help
     o `exit` (and `quit`) exit the telnet Controller
     o `shutdown` shuts down the running load test (and exits the controller)
+    o `host` (and `hosts`) HOST sets host to load test against, ie http://localhost/
+    o `users` (and `user`) INT sets number of simulated users
     o `hatchrate` (and `hatch_rate`) FLOAT sets per-second rate users hatch
+    o `runtime` (and `run_time`) TIME sets how long the load test should run
     o `config` displays the current load test configuration
     o `config-json` displays the current load test configuration in json format
     o `metrics` (and `stats`) displays metrics for the current load test

--- a/README.md
+++ b/README.md
@@ -534,7 +534,10 @@ goose 0.11.2 controller commands:
  start              start an idle load test
  stop               stop a running load test and return to idle state
  shutdown           shutdown running load test (and exit controller)
+ host HOST          set host to load test, ie http://localhost/
+ users INT          set number of simulated users
  hatchrate FLOAT    set per-second rate users hatch
+ runtime TIME       set how long to run test, ie 1h30m5s
  config             display load test configuration
  config-json        display load test configuration in json format
  metrics            display metrics for current load test

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1110,10 +1110,8 @@ impl GooseAttack {
                                     "changing run_time from {:?} to {}",
                                     self.configuration.run_time, run_time
                                 );
-                                // @TODO: Update lib.rs to refer to the configuration value for run_time
-                                // whenever a load test starts. Also, be sure it doesn't shutdown Goose
-                                // if started with --no-autostart.
                                 self.configuration.run_time = run_time.clone();
+                                self.set_run_time()?;
                                 self.reply_to_controller(
                                     message,
                                     GooseControllerResponseMessage::Bool(true),

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -29,14 +29,25 @@ pub enum GooseControllerProtocol {
 
 /// All commands recognized by the Goose Controllers.
 ///
-/// Developer note: The order commands are defined here must match the order in which
-/// the commands are defined in the
+/// The steps required to add a new command:
+///  1) Define the command here in the GooseControllerCommand enum.
+///  2) Add the regular expression for matching the new command in the `command`
 /// [`regex::RegexSet`](https://docs.rs/regex/*/regex/struct.RegexSet.html) in
-/// [`controller_main()`](./fn.controller_main.html) as it is used to determine which
-/// regex matched, if any. Any commands that require a second match to capture values
-/// must be defined at the beginning of this enum.
-///
-/// @TODO: Document the steps necessary to add a new Controller command.
+/// [`controller_main()`](./fn.controller_main.html).
+///  2a) If a value needs to be captured, define the regular expression in a variable
+///      outside the set, and add the variable to the top section of the set with the
+///      other regex variables.
+///  2b) In the same function, also add the variable to the `captures` Vector, in the
+///      same order that it was added to the `command` `RegexSet`. Order is important
+///      as this is how the regex is later identified.
+///  3) Check for a match to the new regex in `get_match`, any additional validation
+///      beyond the regex must be performed here (for example, the regular expression
+///      for capturing hosts simply confirms that the host starts with http or https,
+///      then in `get_match` it calls `util::is_valid_host()` to be sure it is truly
+///      a valid host before passing it to the parent process).
+///  4) Add any parent process logic for the command to `handle_controller_requests`
+///  5) Handle the response in `process_response`, returning a `Result<String, String>`
+///     succinctly describing success or failure.
 #[derive(Clone, Debug, PartialEq)]
 pub enum GooseControllerCommand {
     /// Configure the host to load test, for example http://localhost/.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2878,7 +2878,7 @@ impl GooseAttack {
             running_metrics_timer: std_now,
             display_running_metrics: false,
             all_users_spawned: false,
-            shutdown_after_stop: true,
+            shutdown_after_stop: !self.configuration.no_autostart,
             canceled: Arc::new(AtomicBool::new(false)),
             socket,
         };
@@ -3673,7 +3673,7 @@ impl GooseAttack {
         goose_attack_run_state.user_channels = Vec::new();
         goose_attack_run_state.running_metrics_timer = std_now;
         goose_attack_run_state.display_running_metrics = false;
-        goose_attack_run_state.shutdown_after_stop = true;
+        goose_attack_run_state.shutdown_after_stop = !self.configuration.no_autostart;
         goose_attack_run_state.all_users_spawned = false;
 
         // If enabled, spawn a logger thread.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,6 @@ use std::{fmt, io, time};
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::runtime::Runtime;
-use url::Url;
 
 use crate::controller::{GooseControllerProtocol, GooseControllerRequest};
 use crate::goose::{
@@ -2451,13 +2450,13 @@ impl GooseAttack {
             for task_set in &self.task_sets {
                 match &task_set.host {
                     Some(h) => {
-                        if is_valid_host(h).is_ok() {
+                        if util::is_valid_host(h).is_ok() {
                             info!("host for {} configured: {}", task_set.name, h);
                         }
                     }
                     None => match &self.defaults.host {
                         Some(h) => {
-                            if is_valid_host(h).is_ok() {
+                            if util::is_valid_host(h).is_ok() {
                                 info!("host for {} configured: {}", task_set.name, h);
                             }
                         }
@@ -2473,7 +2472,7 @@ impl GooseAttack {
                     },
                 }
             }
-        } else if is_valid_host(&self.configuration.host).is_ok() {
+        } else if util::is_valid_host(&self.configuration.host).is_ok() {
             info!("global host configured: {}", self.configuration.host);
         }
 
@@ -4630,42 +4629,9 @@ fn schedule_unsequenced_tasks(
     weighted_tasks
 }
 
-// Helper function to determine if a host can be parsed.
-fn is_valid_host(host: &str) -> Result<bool, GooseError> {
-    Url::parse(host).map_err(|parse_error| GooseError::InvalidHost {
-        host: host.to_string(),
-        detail: "Invalid host.".to_string(),
-        parse_error,
-    })?;
-    Ok(true)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn valid_host() {
-        assert_eq!(is_valid_host("http://example.com").is_ok(), true);
-        assert_eq!(is_valid_host("example.com").is_ok(), false);
-        assert_eq!(is_valid_host("http://example.com/").is_ok(), true);
-        assert_eq!(is_valid_host("example.com/").is_ok(), false);
-        assert_eq!(
-            is_valid_host("https://www.example.com/and/with/path").is_ok(),
-            true
-        );
-        assert_eq!(
-            is_valid_host("www.example.com/and/with/path").is_ok(),
-            false
-        );
-        assert_eq!(is_valid_host("foo://example.com").is_ok(), true);
-        assert_eq!(is_valid_host("file:///path/to/file").is_ok(), true);
-        assert_eq!(is_valid_host("/path/to/file").is_ok(), false);
-        assert_eq!(is_valid_host("http://").is_ok(), false);
-        assert_eq!(is_valid_host("http://foo").is_ok(), true);
-        assert_eq!(is_valid_host("http:///example.com").is_ok(), true);
-        assert_eq!(is_valid_host("http:// example.com").is_ok(), false);
-    }
 
     #[test]
     fn set_defaults() {


### PR DESCRIPTION
Introduce the following Controller commands:
 - `host HOST`: set host to load test, ie http://localhost/ (can only be set when load test is idle); matches any of `host`, `hosts`, `hostname`, `host-name` and `host_name`
 - `users INT`: set number of simulated users (can only be set when load test is idle); matches `user` and `users` both
 - `runtime TIME`: set how long to run test, ie 1h30m5s (can be set even when load test is running); matches  any of `runtime`, `run_time`, `run-time` and `run`
 - move `is_valid_host()` into mod `util` and also call it from the Controller
 - added developer documentation on the steps necessary to add a new command