### PR TITLE
don't require host when --no-autostart enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
  - if metrics are enabled, display when controller stops load test
  - de-duplicate code with traits, gaining compile-time validation that both Controllers are properly handling all defined commands
  - add [`async_trait`](https://docs.rs/async_trait) dependency as stable Rust doesn't otherwise support async traits
+ - allow starting Goose without specifying a host if `--no-autostart` is enabled, requiring instead that the host be configured via a Controller before starting a load test
 
 
 ## 0.11.1 May 16, 2021

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ For example, without any run-time options the following load test would automati
 
 ## Controlling Running Goose Load Test
 
-By default, Goose will launch a telnet Controller thread that listens on `0.0.0.0:5116`, and a WebSocket Controller thread that listens on `0.0.0.0:5117`. The running Goose load test can be controlled through these Controllers. Goose can optionally be started with the `--no-autostart` run time option to prevent the load test from automatically starting, requiring instead that it be started with a Controller command.
+By default, Goose will launch a telnet Controller thread that listens on `0.0.0.0:5116`, and a WebSocket Controller thread that listens on `0.0.0.0:5117`. The running Goose load test can be controlled through these Controllers. Goose can optionally be started with the `--no-autostart` run time option to prevent the load test from automatically starting, requiring instead that it be started with a Controller command. When Goose is started this way, a host is not required and can instead be configured via the Controller.
 
 NOTE: The controller currently is not Gaggle-aware, and only functions correctly when running Goose as a single process in standalone mode.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2612,12 +2612,16 @@ impl GooseAttack {
     // Create and schedule GooseUsers. This requires that the host that will be load tested
     // has been configured.
     fn prepare_load_test(&mut self) -> Result<(), GooseError> {
-        // Be sure a valid host has been defined before building configuration.
-        Url::parse(&self.configuration.host).map_err(|parse_error| GooseError::InvalidHost {
-            host: self.configuration.host.to_string(),
-            detail: "There was a failure parsing the host.".to_string(),
-            parse_error,
-        })?;
+        // If not on a Worker, be sure a valid host has been defined before building configuration.
+        if self.attack_mode != AttackMode::Worker {
+            Url::parse(&self.configuration.host).map_err(|parse_error| {
+                GooseError::InvalidHost {
+                    host: self.configuration.host.to_string(),
+                    detail: "There was a failure parsing the host.".to_string(),
+                    parse_error,
+                }
+            })?;
+        }
 
         // Apply weights to tasks in each task set.
         for task_set in &mut self.task_sets {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2299,23 +2299,27 @@ impl GooseAttack {
 
     // Configure whether or not to enable the telnet Controller. Always disable when in Gaggle mode.
     fn set_no_telnet(&mut self) {
-        // Currently Gaggles are not Controller-aware.
+        // Currently Gaggles are not Controller-aware, force disable.
         if [AttackMode::Manager, AttackMode::Worker].contains(&self.attack_mode) {
             self.configuration.no_telnet = true;
-        // Otherwise, respect default if configured.
-        } else if let Some(default_no_telnet) = self.defaults.no_telnet {
-            self.configuration.no_telnet = default_no_telnet;
+        // Otherwise, if --no-telnet flag not set, respect default if configured.
+        } else if !self.configuration.no_telnet {
+            if let Some(default_no_telnet) = self.defaults.no_telnet {
+                self.configuration.no_telnet = default_no_telnet;
+            }
         }
     }
 
     // Configure whether or not to enable the WebSocket Controller. Always disable when in Gaggle mode.
     fn set_no_websocket(&mut self) {
-        // Currently Gaggles are not Controller-aware.
+        // Currently Gaggles are not Controller-aware, force disable.
         if [AttackMode::Manager, AttackMode::Worker].contains(&self.attack_mode) {
             self.configuration.no_websocket = true;
-        // Otherwise, respect default if configured.
-        } else if let Some(default_no_telnet) = self.defaults.no_telnet {
-            self.configuration.no_websocket = default_no_telnet;
+        // Otherwise, if --no-websocket flag not set, respect default if configured.
+        } else if !self.configuration.no_websocket {
+            if let Some(default_no_telnet) = self.defaults.no_telnet {
+                self.configuration.no_websocket = default_no_telnet;
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2327,16 +2327,7 @@ impl GooseAttack {
         let mut value = false;
 
         // Currently Gaggles are not Controller-aware.
-        if [AttackMode::Manager, AttackMode::Worker].contains(&self.attack_mode) {
-            return Err(GooseError::InvalidOption {
-                option: key.to_string(),
-                value: value.to_string(),
-                detail: format!(
-                    "{} can not be set together with the --manager or --worker flags.",
-                    key
-                ),
-            });
-        } else if self.configuration.no_autostart {
+        if self.configuration.no_autostart {
             key = "--no-autostart";
             value = true;
         // Otherwise set default if configured.
@@ -2347,16 +2338,27 @@ impl GooseAttack {
             self.configuration.no_autostart = default_no_autostart;
         }
 
-        // Can't disable autostart if there's no Controller enabled.
-        if self.configuration.no_autostart
-            && self.configuration.no_telnet
-            && self.configuration.no_websocket
-        {
-            return Err(GooseError::InvalidOption {
-                option: key.to_string(),
-                value: value.to_string(),
-                detail: format!("{} can not be set together with both the --no-telnet and --no-websocket flags.", key),
-            });
+        if self.configuration.no_autostart {
+            // Can't disable autostart in Gaggle mode.
+            if [AttackMode::Manager, AttackMode::Worker].contains(&self.attack_mode) {
+                return Err(GooseError::InvalidOption {
+                    option: key.to_string(),
+                    value: value.to_string(),
+                    detail: format!(
+                        "{} can not be set together with the --manager or --worker flags.",
+                        key
+                    ),
+                });
+            }
+
+            // Can't disable autostart if there's no Controller enabled.
+            if self.configuration.no_telnet && self.configuration.no_websocket {
+                return Err(GooseError::InvalidOption {
+                    option: key.to_string(),
+                    value: value.to_string(),
+                    detail: format!("{} can not be set together with both the --no-telnet and --no-websocket flags.", key),
+                });
+            }
         }
 
         Ok(())


### PR DESCRIPTION
 - make it possible to start Goose without setting a host if `--no-autostart` is enabled
 - do not allow `no_autostart` with both `no_telnet` and `no_websocket` as a Controller is required if not automatically starting the load test
 - properly set `no_autostart`, `no_telnet` and `no_websocket` from defaults