### PR TITLE
make internal shared funcs and structs pub(crate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.11.3-dev
+ - remove internal-only functions and structures from documentation, exposing only what's useful to consumers of the Goose library
 
 ## 0.11.2 June 10, 2021
  - introduce telnet Controller allowing real-time control of load test, optionally disable with `--no-telnet`, supports the following commands:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.11.3-dev
- - remove internal-only functions and structures from documentation, exposing only what's useful to consumers of the Goose library
+## 0.12.0-dev
+ - remove internal-only functions and structures from documentation, exposing only what's useful to consumers of the Goose library (API change)
+ - expose utility functions used by Goose for use by load tests
 
 ## 0.11.2 June 10, 2021
  - introduce telnet Controller allowing real-time control of load test, optionally disable with `--no-telnet`, supports the following commands:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,7 +498,11 @@ type DebugLoggerHandle = Option<tokio::task::JoinHandle<()>>;
 /// Optional unbounded sender from all GooseUsers to logger thread, if enabled.
 type DebugLoggerChannel = Option<flume::Sender<Option<GooseDebug>>>;
 
-/// Worker ID to aid in tracing logs when running a Gaggle.
+/// Returns the unique identifier of the running Worker when running in Gaggle mode.
+///
+/// The first Worker to connect to the Manager is assigned an ID of 1. For each
+/// subsequent Worker to connect to the Manager the ID is incremented by 1. This
+/// identifier is primarily an aid in tracing logs.
 pub fn get_worker_id() -> usize {
     WORKER_ID.load(Ordering::Relaxed)
 }
@@ -657,6 +661,11 @@ pub enum AttackPhase {
 #[derive(Clone, Debug, PartialEq)]
 /// Used to define the order [`GooseTaskSet`](./goose/struct.GooseTaskSet.html)s and
 /// [`GooseTask`](./goose/struct.GooseTask.html)s are allocated.
+///
+/// In order to configure the scheduler, and to see examples of the different scheduler
+/// variants, review the
+/// [`GooseAttack::set_scheduler`](./struct.GooseAttack.html#method.set_scheduler)
+/// documentation.
 pub enum GooseScheduler {
     /// Allocate one of each available type at a time (default).
     RoundRobin,
@@ -945,7 +954,9 @@ impl GooseAttack {
     }
 
     /// Initialize a [`GooseAttack`](./struct.GooseAttack.html) with an already loaded
-    /// configuration. This should only be called by Worker instances.
+    /// configuration.
+    ///
+    /// This is generally used by Worker instances and tests.
     ///
     /// # Example
     /// ```rust
@@ -4074,8 +4085,9 @@ impl GooseAttack {
     }
 }
 
-/// All run-time options can optionally be configured with custom defaults. For
-/// example, you can optionally configure a default host for the load test. This is
+/// All run-time options can optionally be configured with custom defaults.
+///
+/// For example, you can optionally configure a default host for the load test. This is
 /// used if no per-[`GooseTaskSet`](./goose/struct.GooseTaskSet.html) host is defined,
 /// no `--host` CLI option is configured, and if the
 /// [`GooseTask`](./goose/struct.GooseTask.html) itself doesn't hard-code the host in
@@ -4099,47 +4111,47 @@ impl GooseAttack {
 ///
 /// The following run-time options can be configured with a custom default using a
 /// borrowed string slice (`&str`):
-///  - GooseDefault::Host
-///  - GooseDefault::LogFile
-///  - GooseDefault::RequestsFile
-///  - GooseDefault::RequestsFormat
-///  - GooseDefault::DebugFile
-///  - GooseDefault::DebugFormat
-///  - GooseDefault::TelnetHost
-///  - GooseDefault::WebSocketHost
-///  - GooseDefault::ManagerBindHost
-///  - GooseDefault::ManagerHost
+///  - [GooseDefault::Host](../goose/enum.GooseDefault.html#variant.Host)
+///  - [GooseDefault::LogFile](../goose/enum.GooseDefault.html#variant.LogFile)
+///  - [GooseDefault::RequestsFile](../goose/enum.GooseDefault.html#variant.RequestsFile)
+///  - [GooseDefault::RequestsFormat](../goose/enum.GooseDefault.html#variant.RequestsFormat)
+///  - [GooseDefault::DebugFile](../goose/enum.GooseDefault.html#variant.DebugFile)
+///  - [GooseDefault::DebugFormat](../goose/enum.GooseDefault.html#variant.DebugFormat)
+///  - [GooseDefault::TelnetHost](../goose/enum.GooseDefault.html#variant.TelnetHost)
+///  - [GooseDefault::WebSocketHost](../goose/enum.GooseDefault.html#variant.WebSocketHost)
+///  - [GooseDefault::ManagerBindHost](../goose/enum.GooseDefault.html#variant.ManagerBindHost)
+///  - [GooseDefault::ManagerHost](../goose/enum.GooseDefault.html#variant.ManagerHost)
 ///
 /// The following run-time options can be configured with a custom default using a
 /// `usize` integer:
-///  - GooseDefault::Users
-///  - GooseDefault::HatchRate
-///  - GooseDefault::RunTime
-///  - GooseDefault::RunningMetrics
-///  - GooseDefault::LogLevel
-///  - GooseDefault::Verbose
-///  - GooseDefault::ThrottleRequests
-///  - GooseDefault::ExpectWorkers
-///  - GooseDefault::TelnetPort
-///  - GooseDefault::WebSocketPort
-///  - GooseDefault::ManagerBindPort
-///  - GooseDefault::ManagerPort
+///  - [GooseDefault::Users](../goose/enum.GooseDefault.html#variant.Users)
+///  - [GooseDefault::HatchRate](../goose/enum.GooseDefault.html#variant.HatchRate)
+///  - [GooseDefault::RunTime](../goose/enum.GooseDefault.html#variant.RunTime)
+///  - [GooseDefault::RunningMetrics](../goose/enum.GooseDefault.html#variant.RunningMetrics)
+///  - [GooseDefault::LogLevel](../goose/enum.GooseDefault.html#variant.LogLevel)
+///  - [GooseDefault::Verbose](../goose/enum.GooseDefault.html#variant.Verbose)
+///  - [GooseDefault::ThrottleRequests](../goose/enum.GooseDefault.html#variant.ThrottleRequests)
+///  - [GooseDefault::ExpectWorkers](../goose/enum.GooseDefault.html#variant.ExpectWorkers)
+///  - [GooseDefault::TelnetPort](../goose/enum.GooseDefault.html#variant.TelnetPort)
+///  - [GooseDefault::WebSocketPort](../goose/enum.GooseDefault.html#variant.WebSocketPort)
+///  - [GooseDefault::ManagerBindPort](../goose/enum.GooseDefault.html#variant.ManagerBindPort)
+///  - [GooseDefault::ManagerPort](../goose/enum.GooseDefault.html#variant.ManagerPort)
 ///
 /// The following run-time flags can be configured with a custom default using a
 /// `bool` (and otherwise default to `false`).
-///  - GooseDefault::NoResetMetrics
-///  - GooseDefault::NoMetrics
-///  - GooseDefault::NoTaskMetrics
-///  - GooseDefault::NoErrorSummary
-///  - GooseDefault::NoDebugBody
-///  - GooseDefault::NoTelnet
-///  - GooseDefault::NoWebSocket
-///  - GooseDefault::NoAutoStart
-///  - GooseDefault::StatusCodes
-///  - GooseDefault::StickyFollow
-///  - GooseDefault::Manager
-///  - GooseDefault::NoHashCheck
-///  - GooseDefault::Worker
+///  - [GooseDefault::NoResetMetrics](../goose/enum.GooseDefault.html#variant.NoResetMetrics)
+///  - [GooseDefault::NoMetrics](../goose/enum.GooseDefault.html#variant.NoMetrics)
+///  - [GooseDefault::NoTaskMetrics](../goose/enum.GooseDefault.html#variant.NoTaskMetrics)
+///  - [GooseDefault::NoErrorSummary](../goose/enum.GooseDefault.html#variant.NoErrorSummary)
+///  - [GooseDefault::NoDebugBody](../goose/enum.GooseDefault.html#variant.NoDebugBody)
+///  - [GooseDefault::NoTelnet](../goose/enum.GooseDefault.html#variant.NoTelnet)
+///  - [GooseDefault::NoWebSocket](../goose/enum.GooseDefault.html#variant.NoWebSocket)
+///  - [GooseDefault::NoAutoStart](../goose/enum.GooseDefault.html#variant.NoAutoStart)
+///  - [GooseDefault::StatusCodes](../goose/enum.GooseDefault.html#variant.StatusCodes)
+///  - [GooseDefault::StickyFollow](../goose/enum.GooseDefault.html#variant.StickyFollow)
+///  - [GooseDefault::Manager](../goose/enum.GooseDefault.html#variant.Manager)
+///  - [GooseDefault::NoHashCheck](../goose/enum.GooseDefault.html#variant.NoHashCheck)
+///  - [GooseDefault::Worker](../goose/enum.GooseDefault.html#variant.Worker)
 ///
 /// # Another Example
 /// ```rust
@@ -4147,8 +4159,11 @@ impl GooseAttack {
 ///
 /// fn main() -> Result<(), GooseError> {
 ///     GooseAttack::initialize()?
+///         // Do not reset the metrics after the load test finishes starting.
 ///         .set_default(GooseDefault::NoResetMetrics, true)?
+///         // Display info level logs while the test runs.
 ///         .set_default(GooseDefault::Verbose, 1)?
+///         // Log all requests made during the test to `./goose-metrics.log`.
 ///         .set_default(GooseDefault::RequestsFile, "goose-metrics.log")?;
 ///
 ///     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,7 +433,7 @@ pub mod prelude;
 mod report;
 mod throttle;
 mod user;
-mod util;
+pub mod util;
 #[cfg(feature = "gaggle")]
 mod worker;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,7 @@ pub fn get_worker_id() -> usize {
 #[cfg(not(feature = "gaggle"))]
 #[derive(Debug, Clone)]
 /// Socket used for coordinating a Gaggle distributed load test.
-pub struct Socket {}
+pub(crate) struct Socket {}
 
 /// An enumeration of all errors a [`GooseAttack`](./struct.GooseAttack.html) can return.
 #[derive(Debug)]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -102,7 +102,7 @@ use crate::GooseConfiguration;
 /// Logger thread, opens a log file (if configured) and waits for messages from
 /// [`GooseUser`](../goose/struct.GooseUser.html) threads. This function is not intended
 /// to be invoked manually.
-pub async fn logger_main(
+pub(crate) async fn logger_main(
     configuration: GooseConfiguration,
     log_receiver: flume::Receiver<Option<GooseDebug>>,
 ) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1098,7 +1098,7 @@ impl GooseErrorMetric {
 }
 
 /// Helper to calculate requests and fails per seconds.
-pub fn per_second_calculations(duration: usize, total: usize, fail: usize) -> (f32, f32) {
+pub(crate) fn per_second_calculations(duration: usize, total: usize, fail: usize) -> (f32, f32) {
     let requests_per_second;
     let fails_per_second;
     if duration == 0 {
@@ -1120,7 +1120,7 @@ fn determine_precision(value: f32) -> usize {
 }
 
 /// Format large number in locale appropriate style.
-pub fn format_number(number: usize) -> String {
+pub(crate) fn format_number(number: usize) -> String {
     (number).to_formatted_string(&Locale::en)
 }
 
@@ -1128,7 +1128,7 @@ pub fn format_number(number: usize) -> String {
 ///
 /// Used in `lib.rs` to merge together per-thread times, and in `metrics.rs` to
 /// aggregate all times.
-pub fn merge_times(
+pub(crate) fn merge_times(
     mut global_response_times: BTreeMap<usize, usize>,
     local_response_times: BTreeMap<usize, usize>,
 ) -> BTreeMap<usize, usize> {
@@ -1146,7 +1146,7 @@ pub fn merge_times(
 }
 
 /// A helper function to update the global minimum time based on local time.
-pub fn update_min_time(mut global_min: usize, min: usize) -> usize {
+pub(crate) fn update_min_time(mut global_min: usize, min: usize) -> usize {
     if global_min == 0 || (min > 0 && min < global_min) {
         global_min = min;
     }
@@ -1154,7 +1154,7 @@ pub fn update_min_time(mut global_min: usize, min: usize) -> usize {
 }
 
 /// A helper function to update the global maximum time based on local time.
-pub fn update_max_time(mut global_max: usize, max: usize) -> usize {
+pub(crate) fn update_max_time(mut global_max: usize, max: usize) -> usize {
     if global_max < max {
         global_max = max;
     }
@@ -1162,7 +1162,7 @@ pub fn update_max_time(mut global_max: usize, max: usize) -> usize {
 }
 
 /// Get the response time that a certain number of percent of the requests finished within.
-pub fn calculate_response_time_percentile(
+pub(crate) fn calculate_response_time_percentile(
     response_times: &BTreeMap<usize, usize>,
     total_requests: usize,
     min: usize,
@@ -1193,7 +1193,7 @@ pub fn calculate_response_time_percentile(
 }
 
 /// Helper to count and aggregate seen status codes.
-pub fn prepare_status_codes(
+pub(crate) fn prepare_status_codes(
     status_code_counts: &HashMap<u16, usize>,
     aggregate_counts: &mut Option<&mut HashMap<u16, usize>>,
 ) -> String {


### PR DESCRIPTION
While reviewing the latest [Goose docs](https://docs.rs/goose) I noticed it's a bit cluttered with functions and structures that aren't useful to consumers of the Goose library. In those cases I've changed their scope from `pub` to `pub(crate)` thereby removing them from the documentation.

 - documentation cleanup
 - de-scope internal-only documentation from docs.rs
 - improve public-facing documentation and provide more and better examples