### PR TITLE
introduce --error-file and --error-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@
   - When displaying metrics (via the cli and the html report) show both "raw" (actual) metrics and "coordinated omission mitigation" (back-filled with statistically generated) metrics, and the standard deviation between the average times for each
   - introduce `GooseLog` enum for sending `GooseDebug`, `GooseRequestMetric` and `GooseTaskMetric` objects to the Logger thread for logging to file
   - introduce `--tasks-file` run-time option for logging `GooseTaskMetric`s to file
-  - introduce `GooseLogFormat` enum for formatting all logs; add `--task-format` using new enum, update `--requests-format` and `--debug-format`.
+  - rename `GooseTaskMetric` to `GooseTaskMetricAggregate`, and introduce `GooseTaskMetric` which is a subset of `GooseRequestMetric` only used for logging
+  - introduce `--error-file` run-time option for logging `GooseErrorMetric`s to file
+  - introduce `GooseLogFormat` enum for formatting all logs; add `--task-format` and `--error-format` using new enum, update `--requests-format` and `--debug-format`.
 
 ## 0.11.2 June 10, 2021
  - introduce telnet Controller allowing real-time control of load test, optionally disable with `--no-telnet`, supports the following commands:

--- a/README.md
+++ b/README.md
@@ -223,12 +223,14 @@ Metrics:
   --no-metrics               Doesn't track metrics
   --no-task-metrics          Doesn't track task metrics
   --no-error-summary         Doesn't display an error summary
-  -R, --report-file NAME     Create an html-formatted report
-  -m, --requests-file NAME   Sets requests log file name
+  --report-file NAME         Create an html-formatted report
+  -R, --requests-file NAME   Sets requests log file name
   --requests-format FORMAT   Sets requests log format (csv, json, raw)
   -T, --tasks-file NAME      Sets tasks log file name
   --tasks-format FORMAT      Sets tasks log format (csv, json, raw)
-  -d, --debug-file NAME      Sets debug log file name
+  -E, --error-file NAME      Sets error log file name
+  --error-format FORMAT      Sets error log format (csv, json, raw)
+  -D, --debug-file NAME      Sets debug log file name
   --debug-format FORMAT      Sets debug log format (csv, json, raw)
   --no-debug-body            Do not include the response body in the debug log
   --status-codes             Tracks additional status code metrics
@@ -731,6 +733,34 @@ $ cargo run --example simple -- --host http://local.dev/ -u100 -r20 -v --throttl
 
 In this example, Goose will launch 100 GooseUser threads, but the throttle will prevent them from generating a combined total of more than 5 requests per second. The `--throttle-requests` command line option imposes a maximum number of requests, not a minimum number of requests.
 
+## Logging Load Test Errors
+
+Goose can optionally log details about all load test errors to a file. To enable, add the `--error-file=error.log` command line option, where `error.log` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
+
+When operating in Gaggle-mode, the `--error-file` option can only be enabled on the Worker processes, configuring Goose to spread out the overhead of writing logs.
+
+By default, logs are written in JSON Lines format. For example:
+
+```json
+{"elapsed":2239,"error":"503 Service Unavailable: /comment/reply/8151","final_url":"http://apache/comment/reply/8151","method":"Post","name":"(Auth) comment form","redirected":false,"response_time":26,"status_code":503,"url":"http://apache/comment/reply/8151","user":1}
+{"elapsed":2261,"error":"503 Service Unavailable: /node/9577","final_url":"http://apache/node/9577","method":"Get","name":"(Anon) node page","redirected":false,"response_time":143,"status_code":503,"url":"http://apache/node/9577","user":2}
+{"elapsed":2267,"error":"503 Service Unavailable: /","final_url":"http://apache/","method":"Get","name":"(Auth) front page","redirected":false,"response_time":138,"status_code":503,"url":"http://apache/","user":1}
+{"elapsed":2404,"error":"503 Service Unavailable: /user/4375","final_url":"http://apache/user/4375","method":"Get","name":"(Anon) user page","redirected":false,"response_time":5,"status_code":503,"url":"http://apache/user/4375","user":2}
+```
+
+Logs include the entire [`GooseErrorMetric`] object as defined in `src/goose.rs`, which are created when requests result in an error.
+
+By default Goose logs errors in JSON Lines format. The `--errors-format` option can be used to log in `csv`, `json` or `raw` format. The `raw` format is Rust's debug output of the entire [`GooseErrorMetric`] object.
+
+For example, `csv` output of similar errors as those logged above would like like:
+```csv
+elapsed,method,name,url,final_url,redirected,response_time,status_code,user,error
+6250,GET,"(Auth) node page","http://apache/node/3781","http://apache/node/3781",false,5,503,1,"503 Service Unavailable: /node/3781"
+6256,GET,"(Auth) front page","http://apache/","http://apache/",false,5,503,1,"503 Service Unavailable: /"
+6262,GET,"(Auth) node page","http://apache/node/5452","http://apache/node/5452",false,8,503,1,"503 Service Unavailable: /node/5452"
+6265,GET,"(Anon) node page","http://apache/node/1819","http://apache/node/1819",false,5,503,0,"503 Service Unavailable: /node/1819"
+```
+
 ## Logging Load Test Requests
 
 Goose can optionally log details about all load test requests to a file. To enable, add the `--requests-file=requests.log` command line option, where `requests.log` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
@@ -746,7 +776,7 @@ By default, logs are written in JSON Lines format. For example:
 {"coordinated_omission_cadence":2514,"coordinated_omission_elapsed":0,"elapsed":24171,"error":"","final_url":"http://local.dev/themes/bartik/logo.png","method":"Get","name":"static asset","redirected":false,"response_time":11,"status_code":200,"success":true,"update":false,"url":"http://local.dev/themes/bartik/logo.png","user":4}
 ```
 
-Logs include the entire [`GooseRequestMetric`] object as defined in `src/goose.rs`, which are created on all requests. This object includes the following fields:
+Logs include the entire [`GooseRequestMetric`] object as defined in `src/goose.rs`, which are created on all requests.
 
 In the first line of the above example, `GooseUser` thread 7 made a successful `GET` request for `/misc/feed.png`, which takes 4 milliseconds. The second line is `GooseUser` thread 2 making a successful `GET` request for `/user/4816`, which takes 28 milliseconds.
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -420,6 +420,13 @@ impl GooseConfiguration {
                 self.debug_file = default_debug_file;
             }
         }
+        // Configure error_file path if enabled.
+        if self.error_file.is_empty() {
+            // Set default, if configured.
+            if let Some(default_error_file) = defaults.error_file.clone() {
+                self.error_file = default_error_file;
+            }
+        }
         // Configure requests_file path if enabled.
         if self.requests_file.is_empty() {
             // Set default, if configured.
@@ -450,7 +457,10 @@ impl GooseConfiguration {
         self.configure_loggers(defaults);
 
         // If no longger is enabled, return immediately without launching logger thread.
-        if self.debug_file.is_empty() && self.requests_file.is_empty() && self.tasks_file.is_empty()
+        if self.debug_file.is_empty()
+            && self.requests_file.is_empty()
+            && self.tasks_file.is_empty()
+            && self.error_file.is_empty()
         {
             return Ok((None, None));
         }
@@ -614,12 +624,6 @@ impl GooseConfiguration {
             let _ = debug_log_file.flush().await;
         };
 
-        // Flush error logs to disk if enabled.
-        if let Some(error_log_file) = error_file.as_mut() {
-            info!("flushing error_file: {}", &self.error_file);
-            let _ = error_log_file.flush().await;
-        };
-
         // Flush requests log to disk if enabled.
         if let Some(requests_log_file) = requests_file.as_mut() {
             info!("flushing requests_file: {}", &self.requests_file);
@@ -627,10 +631,16 @@ impl GooseConfiguration {
         }
 
         // Flush tasks log to disk if enabled.
-        if let Some(log_file) = tasks_file.as_mut() {
+        if let Some(tasks_log_file) = tasks_file.as_mut() {
             info!("flushing tasks_file: {}", &self.tasks_file);
-            let _ = log_file.flush().await;
+            let _ = tasks_log_file.flush().await;
         }
+
+        // Flush error logs to disk if enabled.
+        if let Some(error_log_file) = error_file.as_mut() {
+            info!("flushing error_file: {}", &self.error_file);
+            let _ = error_log_file.flush().await;
+        };
 
         Ok(())
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use std::{thread, time};
 
 use crate::metrics::{
-    self, GooseErrorMetric, GooseErrorMetrics, GooseRequestMetricAggregate, GooseRequestMetrics,
-    GooseTaskMetricAggregate, GooseTaskMetrics,
+    self, GooseErrorMetricAggregate, GooseErrorMetrics, GooseRequestMetricAggregate,
+    GooseRequestMetrics, GooseTaskMetricAggregate, GooseTaskMetrics,
 };
 use crate::util;
 use crate::worker::GaggleMetrics;
@@ -152,9 +152,9 @@ fn merge_requests_from_worker(
 
 /// Merge per-Worker errors into global Manager metrics
 fn merge_errors_from_worker(
-    manager_error: &GooseErrorMetric,
-    worker_error: &GooseErrorMetric,
-) -> GooseErrorMetric {
+    manager_error: &GooseErrorMetricAggregate,
+    worker_error: &GooseErrorMetricAggregate,
+) -> GooseErrorMetricAggregate {
     // Make a mutable copy where we can merge things
     let mut merged_error = manager_error.clone();
     // Add in how many additional times this happened on the Worker.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,6 +22,7 @@ use std::{f32, fmt};
 use tokio::io::AsyncWriteExt;
 
 use crate::goose::{GooseMethod, GooseTaskSet};
+use crate::logger::GooseLog;
 use crate::report;
 use crate::util;
 #[cfg(feature = "gaggle")]
@@ -37,16 +38,14 @@ use crate::{AttackMode, GooseAttack, GooseAttackRunState, GooseConfiguration, Go
 ///
 /// The parent process will spend up to 80% of its time receiving and aggregating
 /// these metrics. The parent process aggregates [`GooseRequestMetric`]s into
-/// [`GooseRequestMetricAggregate`], and [`GooseTaskMetric`]s into
-/// [`GooseTaskMetricAggregate`]. [`GooseErrorMetric`]s do not require any further
-/// aggregation. Aggregation happens in the parent process so the individual
-/// [`GooseUser`](../goose/struct.GooseUser.html) threads can spend all their time
-/// generating and validating load.
+/// [`GooseRequestMetricAggregate`], [`GooseTaskMetric`]s into [`GooseTaskMetricAggregate`],
+/// and [`GooseErrorMetric`]s into [`GooseErrorMetricAggregate`]. Aggregation happens in the
+/// parent process so the individual [`GooseUser`](../goose/struct.GooseUser.html) threads
+/// can spend all their time generating and validating load.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum GooseMetric {
     Request(GooseRequestMetric),
     Task(GooseTaskMetric),
-    Error(GooseErrorMetric),
 }
 
 /// Mitigate the loss of data (coordinated omission) due to stalls on the upstream server.
@@ -222,8 +221,8 @@ pub type GooseTaskMetrics = Vec<Vec<GooseTaskMetricAggregate>>;
 /// All errors detected during a load test.
 ///
 /// By default Goose tracks all errors detected during the load test. Each error is stored
-/// as a [`GooseErrorMetric`](./struct.GooseErrorMetric.html), and they are all stored
-/// together within a `BTreeMap` which is returned by
+/// as a [`GooseErrorMetricAggregate`](./struct.GooseErrorMetricAggregate.html), and they
+/// are all stored together within a `BTreeMap` which is returned by
 /// [`GooseAttack::execute()`](../struct.GooseAttack.html#method.execute) when a load test
 /// completes.
 ///
@@ -242,7 +241,7 @@ pub type GooseTaskMetrics = Vec<Vec<GooseTaskMetricAggregate>>;
 /// 715           POST (Auth) front page: 503 Service Unavailable: /user
 /// 36            GET (Anon) front page: error sending request for url (http://example.com/): connection closed before message completed
 /// ```
-pub type GooseErrorMetrics = BTreeMap<String, GooseErrorMetric>;
+pub type GooseErrorMetrics = BTreeMap<String, GooseErrorMetricAggregate>;
 
 /// For tracking and counting requests made during a load test.
 ///
@@ -2011,6 +2010,38 @@ impl fmt::Display for GooseMetrics {
     }
 }
 
+/// For tracking and counting requests made during a load test.
+///
+/// The request that Goose is making. User threads send this data to the parent thread
+/// when metrics are enabled. This request object must be provided to calls to
+/// [`set_success`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_success)
+/// or
+/// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_failure)
+/// so Goose knows which request is being updated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GooseErrorMetric {
+    /// How many milliseconds the load test has been running.
+    pub elapsed: u64,
+    /// The method that was used (ie, Get, Post, etc).
+    pub method: GooseMethod,
+    /// The optional name of the request.
+    pub name: String,
+    /// The full URL that was requested.
+    pub url: String,
+    /// The final full URL that was requested, after redirects.
+    pub final_url: String,
+    /// Whether or not the request was redirected.
+    pub redirected: bool,
+    /// How many milliseconds the request took.
+    pub response_time: u64,
+    /// The HTTP response code (optional).
+    pub status_code: u16,
+    /// Which GooseUser thread processed the request.
+    pub user: usize,
+    /// The error caused by this request.
+    pub error: String,
+}
+
 /// For tracking and counting errors detected during a load test.
 ///
 /// When a load test completes, by default it will include a summary of all errors that
@@ -2039,7 +2070,7 @@ impl fmt::Display for GooseMetrics {
 /// }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub struct GooseErrorMetric {
+pub struct GooseErrorMetricAggregate {
     /// The method that resulted in an error.
     pub method: GooseMethod,
     /// The optional name of the request.
@@ -2049,9 +2080,9 @@ pub struct GooseErrorMetric {
     /// A counter reflecting how many times this error occurred.
     pub occurrences: usize,
 }
-impl GooseErrorMetric {
+impl GooseErrorMetricAggregate {
     pub(crate) fn new(method: GooseMethod, name: String, error: String) -> Self {
-        GooseErrorMetric {
+        GooseErrorMetricAggregate {
             method,
             name,
             error,
@@ -2239,7 +2270,7 @@ impl GooseAttack {
                 GooseMetric::Request(request_metric) => {
                     // If there was an error, store it.
                     if !request_metric.error.is_empty() {
-                        self.record_error(&request_metric);
+                        self.record_error(&request_metric, goose_attack_run_state)?;
                     }
 
                     // If coordinated_omission_elapsed is non-zero, this was a statistically
@@ -2274,25 +2305,6 @@ impl GooseAttack {
                         self.record_request_metric(&request_metric).await;
                     }
                 }
-                GooseMetric::Error(raw_error) => {
-                    // Recreate the string used to uniquely identify errors.
-                    let error_key = format!(
-                        "{}.{}.{}",
-                        raw_error.error, raw_error.method, raw_error.name
-                    );
-                    let mut merge_error = match self.metrics.errors.get(&error_key) {
-                        Some(error) => error.clone(),
-                        None => GooseErrorMetric::new(
-                            raw_error.method.clone(),
-                            raw_error.name.to_string(),
-                            raw_error.error.to_string(),
-                        ),
-                    };
-                    merge_error.occurrences += raw_error.occurrences;
-                    self.metrics
-                        .errors
-                        .insert(error_key.to_string(), merge_error);
-                }
                 GooseMetric::Task(raw_task) => {
                     // Store a new metric.
                     self.metrics.tasks[raw_task.taskset_index][raw_task.task_index]
@@ -2310,10 +2322,33 @@ impl GooseAttack {
     }
 
     /// Update error metrics.
-    pub(crate) fn record_error(&mut self, raw_request: &GooseRequestMetric) {
-        // If the error summary is disabled, return immediately without collecting errors.
+    pub(crate) fn record_error(
+        &mut self,
+        raw_request: &GooseRequestMetric,
+        goose_attack_run_state: &mut GooseAttackRunState,
+    ) -> Result<(), GooseError> {
+        // If error-file is enabled, convert the raw request to a GooseErrorMetric and send it
+        // to the logger thread.
+        if !self.configuration.error_file.is_empty() {
+            if let Some(logger) = goose_attack_run_state.all_threads_logger_tx.as_ref() {
+                logger.send(Some(GooseLog::Error(GooseErrorMetric {
+                    elapsed: raw_request.elapsed,
+                    method: raw_request.method.clone(),
+                    name: raw_request.name.clone(),
+                    url: raw_request.url.clone(),
+                    final_url: raw_request.final_url.clone(),
+                    redirected: raw_request.redirected,
+                    response_time: raw_request.response_time,
+                    status_code: raw_request.status_code,
+                    user: raw_request.user,
+                    error: raw_request.error.clone(),
+                })))?;
+            }
+        }
+
+        // If the error summary is disabled, return without collecting errors.
         if self.configuration.no_error_summary {
-            return;
+            return Ok(());
         }
 
         // Create a string to uniquely identify errors for tracking metrics.
@@ -2326,7 +2361,7 @@ impl GooseAttack {
             // We've seen this error before.
             Some(m) => m.clone(),
             // First time we've seen this error.
-            None => GooseErrorMetric::new(
+            None => GooseErrorMetricAggregate::new(
                 raw_request.method.clone(),
                 raw_request.name.to_string(),
                 raw_request.error.to_string(),
@@ -2334,6 +2369,7 @@ impl GooseAttack {
         };
         error_metrics.occurrences += 1;
         self.metrics.errors.insert(error_string, error_metrics);
+        Ok(())
     }
 
     // Update metrics showing how long the load test has been running.

--- a/src/report.rs
+++ b/src/report.rs
@@ -393,7 +393,7 @@ pub fn errors_template(error_rows: &str) -> String {
 }
 
 /// Build an individual error row in the html report.
-pub fn error_row(error: &metrics::GooseErrorMetric) -> String {
+pub fn error_row(error: &metrics::GooseErrorMetricAggregate) -> String {
     format!(
         r#"<tr>
         <td>{occurrences}</td>

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -228,6 +228,18 @@ pub(crate) async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     // The requests_format option is configured on the Worker.
     worker_goose_attack.configuration.requests_format =
         goose_attack.configuration.requests_format.clone();
+    // The tasks_file option is configured on the Worker.
+    worker_goose_attack.configuration.tasks_file =
+        goose_attack.configuration.tasks_file.to_string();
+    // The tasks_format option is configured on the Worker.
+    worker_goose_attack.configuration.tasks_format =
+        goose_attack.configuration.tasks_format.clone();
+    // The error_file option is configured on the Worker.
+    worker_goose_attack.configuration.error_file =
+        goose_attack.configuration.error_file.to_string();
+    // The error_format option is configured on the Worker.
+    worker_goose_attack.configuration.error_format =
+        goose_attack.configuration.error_format.clone();
     // The debug_file option is configured on the Worker.
     worker_goose_attack.configuration.debug_file =
         goose_attack.configuration.debug_file.to_string();

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -19,12 +19,23 @@ const EXPECT_WORKERS: usize = 2;
 
 // There are multiple test variations in this file.
 enum TestType {
-    // Test with metrics log enabled.
-    Metrics,
+    // Test with requests log enabled.
+    Requests,
+    // Test with tasks log enabled.
+    Tasks,
+    // Test with error log enabled.
+    Error,
     // Test with debug log enabled.
     Debug,
-    // Test with metrics log and debug log both enabled.
-    MetricsAndDebug,
+    // Test with all log files enabled.
+    All,
+}
+
+struct LogFiles<'a> {
+    requests_files: &'a [String],
+    tasks_files: &'a [String],
+    error_files: &'a [String],
+    debug_files: &'a [String],
 }
 
 // Implement fmt::Display for TestType to uniquely name the log files generated
@@ -32,9 +43,11 @@ enum TestType {
 impl fmt::Display for TestType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let printable = match *self {
-            TestType::Metrics => "metrics",
+            TestType::Requests => "requests",
+            TestType::Tasks => "tasks",
+            TestType::Error => "error",
             TestType::Debug => "debug",
-            TestType::MetricsAndDebug => "metrics-and-debug",
+            TestType::All => "all",
         };
         write!(f, "{}", printable)
     }
@@ -93,8 +106,7 @@ fn validate_test(
     goose_metrics: GooseMetrics,
     mock_endpoints: &[MockRef],
     test_type: &TestType,
-    requests_files: &[String],
-    debug_files: &[String],
+    log_files: &LogFiles,
 ) {
     // Confirm that we loaded the mock endpoints. This confirms that we started
     // both users, which also verifies that hatch_rate was properly set.
@@ -108,61 +120,111 @@ fn validate_test(
     match test_type {
         TestType::Debug => {
             // Debug file must exist.
-            assert!(!debug_files.is_empty());
+            assert!(!log_files.debug_files.is_empty());
 
             // Confirm the debug log files actually exist.
             let mut debug_file_lines = 0;
-            for debug_file in debug_files {
+            for debug_file in log_files.debug_files {
                 assert!(std::path::Path::new(debug_file).exists());
                 debug_file_lines += common::file_length(debug_file);
             }
             // Debug file must not be empty.
             assert!(debug_file_lines > 0);
         }
-        TestType::Metrics => {
-            // Metrics file must exist.
-            assert!(!requests_files.is_empty());
+        TestType::Requests => {
+            // Requests file must exist.
+            assert!(!log_files.requests_files.is_empty());
 
-            // Confirm the metrics log files actually exist.
+            // Confirm the requests log files actually exist.
             let mut requests_file_lines = 0;
-            for requests_file in requests_files {
+            for requests_file in log_files.requests_files {
                 assert!(std::path::Path::new(requests_file).exists());
                 requests_file_lines += common::file_length(requests_file);
             }
             // Metrics file must not be empty.
             assert!(requests_file_lines > 0);
         }
-        TestType::MetricsAndDebug => {
+        TestType::Tasks => {
+            // Tasks file must exist.
+            assert!(!log_files.tasks_files.is_empty());
+
+            // Confirm the tasks log files actually exist.
+            let mut tasks_file_lines = 0;
+            for tasks_file in log_files.tasks_files {
+                assert!(std::path::Path::new(tasks_file).exists());
+                tasks_file_lines += common::file_length(tasks_file);
+            }
+            // Tasks file must not be empty.
+            assert!(tasks_file_lines > 0);
+        }
+        TestType::Error => {
+            // Error file must exist.
+            assert!(!log_files.error_files.is_empty());
+
+            // Confirm the error log files actually exist.
+            let mut error_file_lines = 0;
+            for error_file in log_files.error_files {
+                assert!(std::path::Path::new(error_file).exists());
+                error_file_lines += common::file_length(error_file);
+            }
+            // Error file must not be empty.
+            assert!(error_file_lines > 0);
+        }
+        TestType::All => {
             // Debug file must exist.
-            assert!(!debug_files.is_empty());
-            // Metrics file must exist.
-            assert!(!requests_files.is_empty());
+            assert!(!log_files.debug_files.is_empty());
+            // Error file must exist.
+            assert!(!log_files.error_files.is_empty());
+            // Requests file must exist.
+            assert!(!log_files.requests_files.is_empty());
+            // Tasks file must exist.
+            assert!(!log_files.tasks_files.is_empty());
 
             // Confirm the debug log files actually exist.
             let mut debug_file_lines = 0;
-            for debug_file in debug_files {
+            for debug_file in log_files.debug_files {
                 assert!(std::path::Path::new(debug_file).exists());
                 debug_file_lines += common::file_length(debug_file);
             }
             // Debug file must not be empty.
             assert!(debug_file_lines > 0);
 
-            // Confirm the metrics log files actually exist.
+            // Confirm the error log files actually exist.
+            let mut error_file_lines = 0;
+            for error_file in log_files.error_files {
+                assert!(std::path::Path::new(error_file).exists());
+                error_file_lines += common::file_length(error_file);
+            }
+            // Error file must not be empty.
+            assert!(error_file_lines > 0);
+
+            // Confirm the requests log files actually exist.
             let mut requests_file_lines = 0;
-            for requests_file in requests_files {
+            for requests_file in log_files.requests_files {
                 assert!(std::path::Path::new(requests_file).exists());
                 requests_file_lines += common::file_length(requests_file);
             }
-            // Metrics file must not be empty.
+            // Requests file must not be empty.
             assert!(requests_file_lines > 0);
+
+            // Confirm the tasks log files actually exist.
+            let mut tasks_file_lines = 0;
+            for tasks_file in log_files.tasks_files {
+                assert!(std::path::Path::new(tasks_file).exists());
+                tasks_file_lines += common::file_length(tasks_file);
+            }
+            // Task file must not be empty.
+            assert!(tasks_file_lines > 0);
         }
     }
 }
 
 // Helper to run all standalone tests.
 fn run_standalone_test(test_type: TestType, format: &str) {
-    let requests_file = test_type.to_string() + "-metrics-log." + format;
+    let requests_file = test_type.to_string() + "-requests-log." + format;
+    let tasks_file = test_type.to_string() + "-tasks-log." + format;
     let debug_file = test_type.to_string() + "-debug-log." + format;
+    let error_file = test_type.to_string() + "-error-log." + format;
 
     let server = MockServer::start();
 
@@ -170,16 +232,26 @@ fn run_standalone_test(test_type: TestType, format: &str) {
 
     let mut configuration_flags = match test_type {
         TestType::Debug => vec!["--debug-file", &debug_file, "--debug-format", format],
-        TestType::Metrics => vec![
+        TestType::Error => vec!["--error-file", &error_file, "--error-format", format],
+        TestType::Requests => vec![
             "--requests-file",
             &requests_file,
             "--requests-format",
             format,
         ],
-        TestType::MetricsAndDebug => vec![
+        TestType::Tasks => vec!["--tasks-file", &tasks_file, "--tasks-format", format],
+        TestType::All => vec![
             "--requests-file",
             &requests_file,
             "--requests-format",
+            format,
+            "--tasks-file",
+            &tasks_file,
+            "--tasks-format",
+            format,
+            "--error-file",
+            &error_file,
+            "--error-format",
             format,
             "--debug-file",
             &debug_file,
@@ -196,20 +268,23 @@ fn run_standalone_test(test_type: TestType, format: &str) {
         None,
     );
 
-    validate_test(
-        goose_metrics,
-        &mock_endpoints,
-        &test_type,
-        &[requests_file.to_string()],
-        &[debug_file.to_string()],
-    );
+    let log_files = LogFiles {
+        requests_files: &[requests_file.to_string()],
+        tasks_files: &[tasks_file.to_string()],
+        error_files: &[error_file.to_string()],
+        debug_files: &[debug_file.to_string()],
+    };
 
-    common::cleanup_files(vec![&requests_file, &debug_file]);
+    validate_test(goose_metrics, &mock_endpoints, &test_type, &log_files);
+
+    common::cleanup_files(vec![&requests_file, &tasks_file, &error_file, &debug_file]);
 }
 
 // Helper to run all gaggle tests.
 fn run_gaggle_test(test_type: TestType, format: &str) {
-    let requests_file = test_type.to_string() + "-gaggle-metrics-log." + format;
+    let requests_file = test_type.to_string() + "-gaggle-requests-log." + format;
+    let tasks_file = test_type.to_string() + "-gaggle-tasks-log." + format;
+    let error_file = test_type.to_string() + "-gaggle-error-log." + format;
     let debug_file = test_type.to_string() + "-gaggle-debug-log." + format;
 
     let server = MockServer::start();
@@ -219,13 +294,19 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
     // Launch each worker in its own thread, storing the join handles.
     let mut worker_handles = Vec::new();
     let mut requests_files = Vec::new();
+    let mut tasks_files = Vec::new();
+    let mut error_files = Vec::new();
     let mut debug_files = Vec::new();
     for i in 0..EXPECT_WORKERS {
         // Name files different per-Worker thread.
         let worker_requests_file = requests_file.clone() + &i.to_string();
+        let worker_tasks_file = tasks_file.clone() + &i.to_string();
+        let worker_error_file = error_file.clone() + &i.to_string();
         let worker_debug_file = debug_file.clone() + &i.to_string();
         // Store filenames to cleanup at end of test.
         requests_files.push(worker_requests_file.clone());
+        tasks_files.push(worker_tasks_file.clone());
+        error_files.push(worker_error_file.clone());
         debug_files.push(worker_debug_file.clone());
         // Build appropriate configuration.
         let worker_configuration_flags = match test_type {
@@ -236,18 +317,40 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
                 "--debug-format",
                 format,
             ],
-            TestType::Metrics => vec![
+            TestType::Error => vec![
+                "--worker",
+                "--error-file",
+                &worker_error_file,
+                "--error-format",
+                format,
+            ],
+            TestType::Requests => vec![
                 "--worker",
                 "--requests-file",
                 &worker_requests_file,
                 "--requests-format",
                 format,
             ],
-            TestType::MetricsAndDebug => vec![
+            TestType::Tasks => vec![
+                "--worker",
+                "--tasks-file",
+                &worker_tasks_file,
+                "--tasks-format",
+                format,
+            ],
+            TestType::All => vec![
                 "--worker",
                 "--requests-file",
                 &worker_requests_file,
                 "--requests-format",
+                format,
+                "--tasks-file",
+                &worker_tasks_file,
+                "--tasks-format",
+                format,
+                "--error-file",
+                &worker_error_file,
+                "--error-format",
                 format,
                 "--debug-file",
                 &worker_debug_file,
@@ -287,15 +390,22 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles));
 
-    validate_test(
-        goose_metrics,
-        &mock_endpoints,
-        &test_type,
-        &requests_files,
-        &debug_files,
-    );
+    let log_files = LogFiles {
+        requests_files: &requests_files,
+        tasks_files: &tasks_files,
+        error_files: &error_files,
+        debug_files: &debug_files,
+    };
+
+    validate_test(goose_metrics, &mock_endpoints, &test_type, &log_files);
 
     for file in requests_files {
+        common::cleanup_files(vec![&file]);
+    }
+    for file in tasks_files {
+        common::cleanup_files(vec![&file]);
+    }
+    for file in error_files {
         common::cleanup_files(vec![&file]);
     }
     for file in debug_files {
@@ -304,45 +414,129 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
 }
 
 #[test]
-// Enable json-formatted metrics log.
-fn test_metrics_logs_json() {
-    run_standalone_test(TestType::Metrics, "json");
+// Enable json-formatted requests log.
+fn test_requests_logs_json() {
+    run_standalone_test(TestType::Requests, "json");
 }
 
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-// Enable json-formatted metrics log, in Gaggle mode.
-fn test_metrics_logs_json_gaggle() {
-    run_gaggle_test(TestType::Metrics, "json");
+// Enable json-formatted requests log, in Gaggle mode.
+fn test_requests_logs_json_gaggle() {
+    run_gaggle_test(TestType::Requests, "json");
 }
 
 #[test]
-// Enable csv-formatted metrics log.
-fn test_metrics_logs_csv() {
-    run_standalone_test(TestType::Metrics, "csv");
-}
-
-#[test]
-#[serial]
-#[cfg_attr(not(feature = "gaggle"), ignore)]
-// Enable csv-formatted metrics log, in Gaggle mode.
-fn test_metrics_logs_csv_gaggle() {
-    run_gaggle_test(TestType::Metrics, "csv");
-}
-
-#[test]
-// Enable raw-formatted metrics log.
-fn test_metrics_logs_raw() {
-    run_standalone_test(TestType::Metrics, "raw");
+// Enable csv-formatted requests log.
+fn test_requests_logs_csv() {
+    run_standalone_test(TestType::Requests, "csv");
 }
 
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-// Enable raw-formatted metrics log, in Gaggle mode.
-fn test_metrics_logs_raw_gaggle() {
-    run_gaggle_test(TestType::Metrics, "raw");
+// Enable csv-formatted requests log, in Gaggle mode.
+fn test_requests_logs_csv_gaggle() {
+    run_gaggle_test(TestType::Requests, "csv");
+}
+
+#[test]
+// Enable raw-formatted requests log.
+fn test_requests_logs_raw() {
+    run_standalone_test(TestType::Requests, "raw");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable raw-formatted requests log, in Gaggle mode.
+fn test_requests_logs_raw_gaggle() {
+    run_gaggle_test(TestType::Requests, "raw");
+}
+
+#[test]
+// Enable json-formatted tasks log.
+fn test_tasks_logs_json() {
+    run_standalone_test(TestType::Tasks, "json");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable json-formatted tasks log, in Gaggle mode.
+fn test_tasks_logs_json_gaggle() {
+    run_gaggle_test(TestType::Tasks, "json");
+}
+
+#[test]
+// Enable csv-formatted tasks log.
+fn test_tasks_logs_csv() {
+    run_standalone_test(TestType::Tasks, "csv");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable csv-formatted tasks log, in Gaggle mode.
+fn test_tasks_logs_csv_gaggle() {
+    run_gaggle_test(TestType::Tasks, "csv");
+}
+
+#[test]
+// Enable raw-formatted tasks log.
+fn test_tasks_logs_raw() {
+    run_standalone_test(TestType::Tasks, "raw");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable raw-formatted tasks log, in Gaggle mode.
+fn test_tasks_logs_raw_gaggle() {
+    run_gaggle_test(TestType::Tasks, "raw");
+}
+
+#[test]
+// Enable raw-formatted error log.
+fn test_error_logs_raw() {
+    run_standalone_test(TestType::Error, "raw");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable raw-formatted error log, in Gaggle mode.
+fn test_error_logs_raw_gaggle() {
+    run_gaggle_test(TestType::Error, "raw");
+}
+
+#[test]
+// Enable json-formatted error log.
+fn test_error_logs_json() {
+    run_standalone_test(TestType::Error, "json");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable json-formatted error log, in Gaggle mode.
+fn test_error_logs_json_gaggle() {
+    run_gaggle_test(TestType::Error, "json");
+}
+
+#[test]
+// Enable csv-formatted error log.
+fn test_error_logs_csv() {
+    run_standalone_test(TestType::Error, "csv");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable csv-formatted error log, in Gaggle mode.
+fn test_error_logs_csv_gaggle() {
+    run_gaggle_test(TestType::Error, "csv");
 }
 
 #[test]
@@ -374,15 +568,29 @@ fn test_debug_logs_json_gaggle() {
 }
 
 #[test]
+// Enable csv-formatted debug log.
+fn test_debug_logs_csv() {
+    run_standalone_test(TestType::Debug, "csv");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable csv-formatted debug log, in Gaggle mode.
+fn test_debug_logs_csv_gaggle() {
+    run_gaggle_test(TestType::Debug, "csv");
+}
+
+#[test]
 // Enable raw-formatted debug log and metrics log.
-fn test_metrics_and_debug_logs() {
-    run_standalone_test(TestType::MetricsAndDebug, "raw");
+fn test_all_logs_raw() {
+    run_standalone_test(TestType::All, "raw");
 }
 
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted debug log and metrics log, in Gaggle mode.
-fn test_metrics_and_debug_logs_gaggle() {
-    run_gaggle_test(TestType::MetricsAndDebug, "raw");
+fn test_all_logs_raw_gaggle() {
+    run_gaggle_test(TestType::All, "raw");
 }


### PR DESCRIPTION
  - introduce `--error-file` run-time option for logging `GooseErrorMetric`s to file
  - introduce `--error-format` for changing the format of the error log
  - renamed `GooseErrorMetric` to `GooseErrorMetricAggregate` matching other metrics
  - introduced new `GooseErrorMetric` object used for writing the error log

@TODO: tests