### PR TITLE
more consistent log names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   - rename `GooseTaskMetric` to `GooseTaskMetricAggregate`, and introduce `GooseTaskMetric` which is a subset of `GooseRequestMetric` only used for logging
   - introduce `--error-file` run-time option for logging `GooseErrorMetric`s to file
   - introduce `GooseLogFormat` enum for formatting all logs; add `--task-format` and `--error-format` using new enum, update `--requests-format` and `--debug-format`.
+  - renamed `--log-file` to `--goose-log`, `--requests-file` to `--request-log`, `--requests-format` to `--request-format`, `--tasks-file` to `--task-log`, `--tasks-format` to `--task-format`, `--error-file` to `--error-log`, and `--debug-file` to `--debug-log`
 
 ## 0.11.2 June 10, 2021
  - introduce telnet Controller allowing real-time control of load test, optionally disable with `--no-telnet`, supports the following commands:

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1633,7 +1633,7 @@ impl GooseUser {
 
     fn send_request_metric_to_parent(&self, request_metric: GooseRequestMetric) -> GooseTaskResult {
         // If requests-file is enabled, send a copy of the raw request to the logger thread.
-        if !self.config.requests_file.is_empty() {
+        if !self.config.request_log.is_empty() {
             if let Some(logger) = self.logger.as_ref() {
                 logger.send(Some(GooseLog::Request(request_metric.clone())))?;
             }
@@ -1871,7 +1871,7 @@ impl GooseUser {
         headers: Option<&header::HeaderMap>,
         body: Option<&str>,
     ) -> GooseTaskResult {
-        if !self.config.debug_file.is_empty() {
+        if !self.config.debug_log.is_empty() {
             // Logger is not defined when running
             // [`test_start`](../struct.GooseAttack.html#method.test_start),
             // [`test_stop`](../struct.GooseAttack.html#method.test_stop), and during testing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -692,8 +692,8 @@ pub struct GooseDefaults {
     run_time: Option<usize>,
     /// An optional default log level.
     log_level: Option<u8>,
-    /// An optional default for the log file name.
-    log_file: Option<String>,
+    /// An optional default for the goose log file name.
+    goose_log: Option<String>,
     /// An optional default value for verbosity level.
     verbose: Option<u8>,
     /// An optional default for printing running metrics.
@@ -709,19 +709,19 @@ pub struct GooseDefaults {
     /// An optional default for the html-formatted report file name.
     report_file: Option<String>,
     /// An optional default for the requests log file name.
-    requests_file: Option<String>,
+    request_log: Option<String>,
     /// An optional default for the requests log file format.
-    requests_format: Option<GooseLogFormat>,
+    request_format: Option<GooseLogFormat>,
     /// An optional default for the tasks log file name.
-    tasks_file: Option<String>,
+    task_log: Option<String>,
     /// An optional default for the tasks log file format.
-    tasks_format: Option<GooseLogFormat>,
+    task_format: Option<GooseLogFormat>,
     /// An optional default for the error log file name.
-    error_file: Option<String>,
+    error_log: Option<String>,
     /// An optional default for the error log format.
     error_format: Option<GooseLogFormat>,
     /// An optional default for the debug log file name.
-    debug_file: Option<String>,
+    debug_log: Option<String>,
     /// An optional default for the debug log format.
     debug_format: Option<GooseLogFormat>,
     /// An optional default for not logging response body in debug log.
@@ -780,7 +780,7 @@ pub enum GooseDefault {
     /// An optional default log level.
     LogLevel,
     /// An optional default for the log file name.
-    LogFile,
+    GooseLog,
     /// An optional default value for verbosity level.
     Verbose,
     /// An optional default for printing running metrics.
@@ -796,19 +796,19 @@ pub enum GooseDefault {
     /// An optional default for the report file name.
     ReportFile,
     /// An optional default for the requests log file name.
-    RequestsFile,
+    RequestLog,
     /// An optional default for the requests log file format.
     RequestsFormat,
     /// An optional default for the tasks log file name.
-    TasksFile,
+    TaskLog,
     /// An optional default for the tasks log file format.
-    TasksFormat,
+    TaskFormat,
     /// An optional default for the error log file name.
-    ErrorFile,
+    ErrorLog,
     /// An optional default for the error log format.
     ErrorFormat,
     /// An optional default for the debug log file name.
-    DebugFile,
+    DebugLog,
     /// An optional default for the debug log format.
     DebugFormat,
     /// An optional default for not logging the response body in the debug log.
@@ -1038,21 +1038,21 @@ impl GooseAttack {
             _ => LevelFilter::Trace,
         };
 
-        let log_file: Option<PathBuf>;
+        let goose_log: Option<PathBuf>;
         // Use --log-file if set.
-        if !self.configuration.log_file.is_empty() {
-            log_file = Some(PathBuf::from(&self.configuration.log_file));
+        if !self.configuration.goose_log.is_empty() {
+            goose_log = Some(PathBuf::from(&self.configuration.goose_log));
         }
-        // Otherwise use goose_attack.defaults.log_file if set.
-        else if let Some(default_log_file) = &self.defaults.log_file {
-            log_file = Some(PathBuf::from(default_log_file));
+        // Otherwise use goose_attack.defaults.goose_log if set.
+        else if let Some(default_goose_log) = &self.defaults.goose_log {
+            goose_log = Some(PathBuf::from(default_goose_log));
         }
         // Otherwise disable the log.
         else {
-            log_file = None;
+            goose_log = None;
         }
 
-        if let Some(log_to_file) = log_file {
+        if let Some(log_to_file) = goose_log {
             match CombinedLogger::init(vec![
                 SimpleLogger::new(debug_level, Config::default()),
                 WriteLogger::new(
@@ -1457,10 +1457,10 @@ impl GooseAttack {
                 });
             }
 
-            if !self.configuration.debug_file.is_empty() {
+            if !self.configuration.debug_log.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: "--debug-file".to_string(),
-                    value: self.configuration.debug_file.clone(),
+                    value: self.configuration.debug_log.clone(),
                     detail:
                         "The --debug-file option can not be set together with the --manager flag."
                             .to_string(),
@@ -2186,7 +2186,7 @@ impl GooseAttack {
             }
 
             // There is nothing to log if metrics are disabled.
-            if !self.configuration.requests_file.is_empty() {
+            if !self.configuration.request_log.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: key.to_string(),
                     value: value.to_string(),
@@ -2287,32 +2287,32 @@ impl GooseAttack {
     }
 
     // Configure requests log format.
-    fn set_requests_format(&mut self) -> Result<(), GooseError> {
+    fn set_request_format(&mut self) -> Result<(), GooseError> {
         // Track how value gets set so we can return a meaningful error if necessary.
-        let mut key = "configuration.requests_format";
+        let mut key = "configuration.request_format";
         let mut value = Some(GooseLogFormat::Json);
 
-        if self.configuration.requests_format.is_some() {
+        if self.configuration.request_format.is_some() {
             key = "--requests-format";
-            value = self.configuration.requests_format.clone();
-        } else if let Some(default_requests_format) = self.defaults.requests_format.as_ref() {
-            // In Gaggles, requests_format is only set on Worker.
+            value = self.configuration.request_format.clone();
+        } else if let Some(default_request_format) = self.defaults.request_format.as_ref() {
+            // In Gaggles, request_format is only set on Worker.
             if self.attack_mode != AttackMode::Manager {
                 key = "set_default(GooseDefault::RequestsFormat)";
-                value = Some(default_requests_format.clone());
-                self.configuration.requests_format = Some(default_requests_format.clone());
+                value = Some(default_request_format.clone());
+                self.configuration.request_format = Some(default_request_format.clone());
             }
         }
 
         // Otherwise default to GooseLogFormat::Json.
-        if !self.configuration.requests_file.is_empty()
-            && self.configuration.requests_format.is_none()
+        if !self.configuration.request_log.is_empty()
+            && self.configuration.request_format.is_none()
             && self.attack_mode != AttackMode::Manager
         {
-            self.configuration.requests_format = value.clone();
+            self.configuration.request_format = value.clone();
         }
 
-        if self.configuration.requests_format.is_some() {
+        if self.configuration.request_format.is_some() {
             // Log format isn't relevant if metrics aren't enabled.
             if self.configuration.no_metrics {
                 return Err(GooseError::InvalidOption {
@@ -2322,7 +2322,7 @@ impl GooseAttack {
                 });
             }
             // Log format isn't relevant if log not enabled.
-            else if self.configuration.requests_file.is_empty() {
+            else if self.configuration.request_log.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: key.to_string(),
                     value: format!("{:?}", value),
@@ -2335,32 +2335,32 @@ impl GooseAttack {
     }
 
     // Configure tasks log format.
-    fn set_tasks_format(&mut self) -> Result<(), GooseError> {
+    fn set_task_format(&mut self) -> Result<(), GooseError> {
         // Track how value gets set so we can return a meaningful error if necessary.
-        let mut key = "configuration.tasks_format";
+        let mut key = "configuration.task_format";
         let mut value = Some(GooseLogFormat::Json);
 
-        if self.configuration.tasks_format.is_some() {
+        if self.configuration.task_format.is_some() {
             key = "--tasks-format";
-            value = self.configuration.tasks_format.clone();
-        } else if let Some(default_tasks_format) = self.defaults.tasks_format.as_ref() {
-            // In Gaggles, tasks_format is only set on Worker.
+            value = self.configuration.task_format.clone();
+        } else if let Some(default_task_format) = self.defaults.task_format.as_ref() {
+            // In Gaggles, task_format is only set on Worker.
             if self.attack_mode != AttackMode::Manager {
-                key = "set_default(GooseDefault::TasksFormat)";
-                value = Some(default_tasks_format.clone());
-                self.configuration.tasks_format = Some(default_tasks_format.clone());
+                key = "set_default(GooseDefault::TaskFormat)";
+                value = Some(default_task_format.clone());
+                self.configuration.task_format = Some(default_task_format.clone());
             }
         }
 
         // Otherwise default to GooseLogFormat::Json.
-        if !self.configuration.tasks_file.is_empty()
-            && self.configuration.tasks_format.is_none()
+        if !self.configuration.task_log.is_empty()
+            && self.configuration.task_format.is_none()
             && self.attack_mode != AttackMode::Manager
         {
-            self.configuration.tasks_format = value.clone();
+            self.configuration.task_format = value.clone();
         }
 
-        if self.configuration.tasks_format.is_some() {
+        if self.configuration.task_format.is_some() {
             // Log format isn't relevant if metrics aren't enabled.
             if self.configuration.no_metrics {
                 return Err(GooseError::InvalidOption {
@@ -2370,7 +2370,7 @@ impl GooseAttack {
                 });
             }
             // Log format isn't relevant if log not enabled.
-            else if self.configuration.tasks_file.is_empty() {
+            else if self.configuration.task_log.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: key.to_string(),
                     value: format!("{:?}", value),
@@ -2401,7 +2401,7 @@ impl GooseAttack {
         }
 
         // Otherwise default to GooseLogFormat::Json.
-        if !self.configuration.error_file.is_empty()
+        if !self.configuration.error_log.is_empty()
             && self.configuration.error_format.is_none()
             && self.attack_mode != AttackMode::Manager
         {
@@ -2418,7 +2418,7 @@ impl GooseAttack {
                 });
             }
             // Log format isn't relevant if log not enabled.
-            else if self.configuration.error_file.is_empty() {
+            else if self.configuration.error_log.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: key.to_string(),
                     value: format!("{:?}", value),
@@ -2449,7 +2449,7 @@ impl GooseAttack {
         }
 
         // Otherwise default to GooseLogFormat::Json.
-        if !self.configuration.debug_file.is_empty()
+        if !self.configuration.debug_log.is_empty()
             && self.configuration.debug_format.is_none()
             && self.attack_mode != AttackMode::Manager
         {
@@ -2458,7 +2458,7 @@ impl GooseAttack {
 
         if self.configuration.debug_format.is_some() {
             // Log format isn't relevant if log not enabled.
-            if self.configuration.debug_file.is_empty() {
+            if self.configuration.debug_log.is_empty() {
                 return Err(GooseError::InvalidOption {
                     option: key.to_string(),
                     value: format!("{:?}", value),
@@ -2664,10 +2664,10 @@ impl GooseAttack {
         self.set_hatch_rate()?;
 
         // Configure the requests log format.
-        self.set_requests_format()?;
+        self.set_request_format()?;
 
         // Configure the tasks log format.
-        self.set_tasks_format()?;
+        self.set_task_format()?;
 
         // Configure the tasks log format.
         self.set_error_format()?;
@@ -3580,11 +3580,11 @@ impl GooseAttack {
 /// The following run-time options can be configured with a custom default using a
 /// borrowed string slice (`&str`):
 ///  - [GooseDefault::Host](../goose/enum.GooseDefault.html#variant.Host)
-///  - [GooseDefault::LogFile](../goose/enum.GooseDefault.html#variant.LogFile)
+///  - [GooseDefault::GooseLog](../goose/enum.GooseDefault.html#variant.GooseLog)
 ///  - [GooseDefault::RequestsFormat](../goose/enum.GooseDefault.html#variant.RequestsFormat)
-///  - [GooseDefault::TasksFile](../goose/enum.GooseDefault.html#variant.TasksFile)
-///  - [GooseDefault::ErrorFile](../goose/enum.GooseDefault.html#variant.ErrorFile)
-///  - [GooseDefault::DebugFile](../goose/enum.GooseDefault.html#variant.DebugFile)
+///  - [GooseDefault::TaskLog](../goose/enum.GooseDefault.html#variant.TaskLog)
+///  - [GooseDefault::ErrorLog](../goose/enum.GooseDefault.html#variant.ErrorLog)
+///  - [GooseDefault::DebugLog](../goose/enum.GooseDefault.html#variant.DebugLog)
 ///  - [GooseDefault::TelnetHost](../goose/enum.GooseDefault.html#variant.TelnetHost)
 ///  - [GooseDefault::WebSocketHost](../goose/enum.GooseDefault.html#variant.WebSocketHost)
 ///  - [GooseDefault::ManagerBindHost](../goose/enum.GooseDefault.html#variant.ManagerBindHost)
@@ -3623,8 +3623,8 @@ impl GooseAttack {
 ///
 /// The following run-time flags can be configured with a custom default using a
 /// `GooseLogFormat`.
-///  - [GooseDefault::RequestsFile](../goose/enum.GooseDefault.html#variant.RequestsFile)
-///  - [GooseDefault::TasksFile](../goose/enum.GooseDefault.html#variant.TasksFile)
+///  - [GooseDefault::RequestLog](../goose/enum.GooseDefault.html#variant.RequestLog)
+///  - [GooseDefault::TaskLog](../goose/enum.GooseDefault.html#variant.TaskLog)
 ///  - [GooseDefault::DebugFormat](../goose/enum.GooseDefault.html#variant.DebugFormat)
 /// # Another Example
 /// ```rust
@@ -3636,8 +3636,8 @@ impl GooseAttack {
 ///         .set_default(GooseDefault::NoResetMetrics, true)?
 ///         // Display info level logs while the test runs.
 ///         .set_default(GooseDefault::Verbose, 1)?
-///         // Log all requests made during the test to `./goose-metrics.log`.
-///         .set_default(GooseDefault::RequestsFile, "goose-metrics.log")?;
+///         // Log all requests made during the test to `./goose-request.log`.
+///         .set_default(GooseDefault::RequestLog, "goose-request.log")?;
 ///
 ///     Ok(())
 /// }
@@ -3651,12 +3651,12 @@ impl GooseDefaultType<&str> for GooseAttack {
             // Set valid defaults.
             GooseDefault::HatchRate => self.defaults.hatch_rate = Some(value.to_string()),
             GooseDefault::Host => self.defaults.host = Some(value.to_string()),
-            GooseDefault::LogFile => self.defaults.log_file = Some(value.to_string()),
+            GooseDefault::GooseLog => self.defaults.goose_log = Some(value.to_string()),
             GooseDefault::ReportFile => self.defaults.report_file = Some(value.to_string()),
-            GooseDefault::RequestsFile => self.defaults.requests_file = Some(value.to_string()),
-            GooseDefault::TasksFile => self.defaults.tasks_file = Some(value.to_string()),
-            GooseDefault::ErrorFile => self.defaults.error_file = Some(value.to_string()),
-            GooseDefault::DebugFile => self.defaults.debug_file = Some(value.to_string()),
+            GooseDefault::RequestLog => self.defaults.request_log = Some(value.to_string()),
+            GooseDefault::TaskLog => self.defaults.task_log = Some(value.to_string()),
+            GooseDefault::ErrorLog => self.defaults.error_log = Some(value.to_string()),
+            GooseDefault::DebugLog => self.defaults.debug_log = Some(value.to_string()),
             GooseDefault::TelnetHost => self.defaults.telnet_host = Some(value.to_string()),
             GooseDefault::WebSocketHost => self.defaults.websocket_host = Some(value.to_string()),
             GooseDefault::ManagerBindHost => {
@@ -3708,7 +3708,7 @@ impl GooseDefaultType<&str> for GooseAttack {
             }
             GooseDefault::DebugFormat
             | GooseDefault::ErrorFormat
-            | GooseDefault::TasksFormat
+            | GooseDefault::TaskFormat
             | GooseDefault::RequestsFormat => {
                 return Err(GooseError::InvalidOption {
                     option: format!("GooseDefault::{:?}", key),
@@ -3750,12 +3750,12 @@ impl GooseDefaultType<usize> for GooseAttack {
             // Otherwise display a helpful and explicit error.
             GooseDefault::Host
             | GooseDefault::HatchRate
-            | GooseDefault::LogFile
+            | GooseDefault::GooseLog
             | GooseDefault::ReportFile
-            | GooseDefault::RequestsFile
-            | GooseDefault::TasksFile
-            | GooseDefault::ErrorFile
-            | GooseDefault::DebugFile
+            | GooseDefault::RequestLog
+            | GooseDefault::TaskLog
+            | GooseDefault::ErrorLog
+            | GooseDefault::DebugLog
             | GooseDefault::TelnetHost
             | GooseDefault::WebSocketHost
             | GooseDefault::ManagerBindHost
@@ -3794,7 +3794,7 @@ impl GooseDefaultType<usize> for GooseAttack {
             GooseDefault::RequestsFormat
             | GooseDefault::DebugFormat
             | GooseDefault::ErrorFormat
-            | GooseDefault::TasksFormat => {
+            | GooseDefault::TaskFormat => {
                 return Err(GooseError::InvalidOption {
                     option: format!("GooseDefault::{:?}", key),
                     value: value.to_string(),
@@ -3836,13 +3836,13 @@ impl GooseDefaultType<bool> for GooseAttack {
             GooseDefault::Worker => self.defaults.worker = Some(value),
             // Otherwise display a helpful and explicit error.
             GooseDefault::Host
-            | GooseDefault::LogFile
+            | GooseDefault::GooseLog
             | GooseDefault::ReportFile
-            | GooseDefault::RequestsFile
-            | GooseDefault::TasksFile
+            | GooseDefault::RequestLog
+            | GooseDefault::TaskLog
             | GooseDefault::RunningMetrics
-            | GooseDefault::ErrorFile
-            | GooseDefault::DebugFile
+            | GooseDefault::ErrorLog
+            | GooseDefault::DebugLog
             | GooseDefault::TelnetHost
             | GooseDefault::WebSocketHost
             | GooseDefault::ManagerBindHost
@@ -3879,7 +3879,7 @@ impl GooseDefaultType<bool> for GooseAttack {
             GooseDefault::RequestsFormat
             | GooseDefault::DebugFormat
             | GooseDefault::ErrorFormat
-            | GooseDefault::TasksFormat => {
+            | GooseDefault::TaskFormat => {
                 return Err(GooseError::InvalidOption {
                     option: format!("GooseDefault::{:?}", key),
                     value: value.to_string(),
@@ -3935,13 +3935,13 @@ impl GooseDefaultType<GooseCoordinatedOmissionMitigation> for GooseAttack {
                 })
             }
             GooseDefault::Host
-            | GooseDefault::LogFile
+            | GooseDefault::GooseLog
             | GooseDefault::ReportFile
-            | GooseDefault::RequestsFile
-            | GooseDefault::TasksFile
+            | GooseDefault::RequestLog
+            | GooseDefault::TaskLog
             | GooseDefault::RunningMetrics
-            | GooseDefault::ErrorFile
-            | GooseDefault::DebugFile
+            | GooseDefault::ErrorLog
+            | GooseDefault::DebugLog
             | GooseDefault::TelnetHost
             | GooseDefault::WebSocketHost
             | GooseDefault::ManagerBindHost
@@ -3978,7 +3978,7 @@ impl GooseDefaultType<GooseCoordinatedOmissionMitigation> for GooseAttack {
             GooseDefault::RequestsFormat
             | GooseDefault::DebugFormat
             | GooseDefault::ErrorFormat
-            | GooseDefault::TasksFormat => {
+            | GooseDefault::TaskFormat => {
                 return Err(GooseError::InvalidOption {
                     option: format!("GooseDefault::{:?}", key),
                     value: format!("{:?}", value),
@@ -3999,10 +3999,10 @@ impl GooseDefaultType<GooseLogFormat> for GooseAttack {
         value: GooseLogFormat,
     ) -> Result<Box<Self>, GooseError> {
         match key {
-            GooseDefault::RequestsFormat => self.defaults.requests_format = Some(value),
+            GooseDefault::RequestsFormat => self.defaults.request_format = Some(value),
             GooseDefault::DebugFormat => self.defaults.debug_format = Some(value),
             GooseDefault::ErrorFormat => self.defaults.error_format = Some(value),
-            GooseDefault::TasksFormat => self.defaults.tasks_format = Some(value),
+            GooseDefault::TaskFormat => self.defaults.task_format = Some(value),
             // Otherwise display a helpful and explicit error.
             GooseDefault::NoResetMetrics
             | GooseDefault::NoMetrics
@@ -4027,13 +4027,13 @@ impl GooseDefaultType<GooseLogFormat> for GooseAttack {
                 })
             }
             GooseDefault::Host
-            | GooseDefault::LogFile
+            | GooseDefault::GooseLog
             | GooseDefault::ReportFile
-            | GooseDefault::RequestsFile
-            | GooseDefault::TasksFile
+            | GooseDefault::RequestLog
+            | GooseDefault::TaskLog
             | GooseDefault::RunningMetrics
-            | GooseDefault::ErrorFile
-            | GooseDefault::DebugFile
+            | GooseDefault::ErrorLog
+            | GooseDefault::DebugLog
             | GooseDefault::TelnetHost
             | GooseDefault::WebSocketHost
             | GooseDefault::ManagerBindHost
@@ -4108,17 +4108,17 @@ pub struct GooseConfiguration {
     /// Stops after (30s, 20m, 3h, 1h30m, etc)
     #[options(short = "t", meta = "TIME")]
     pub run_time: String,
-    /// Sets log level (-g, -gg, etc)
+    /// Enables Goose log file and sets name
+    #[options(short = "G", meta = "NAME")]
+    pub goose_log: String,
+    /// Sets Goose log level (-g, -gg, etc)
     #[options(short = "g", count)]
     pub log_level: u8,
-    /// Enables log file and sets name
-    #[options(meta = "NAME")]
-    pub log_file: String,
     #[options(
         count,
         short = "v",
         // Add a blank line and then a 'Metrics:' header after this option
-        help = "Sets debug level (-v, -vv, etc)\n\nMetrics:"
+        help = "Sets Goose verbosity (-v, -vv, etc)\n\nMetrics:"
     )]
     pub verbose: u8,
 
@@ -4140,27 +4140,27 @@ pub struct GooseConfiguration {
     /// Create an html-formatted report
     #[options(no_short, meta = "NAME")]
     pub report_file: String,
-    /// Sets requests log file name
+    /// Sets request log file name
     #[options(short = "R", meta = "NAME")]
-    pub requests_file: String,
-    /// Sets requests log format (csv, json, raw)
+    pub request_log: String,
+    /// Sets request log format (csv, json, raw)
     #[options(no_short, meta = "FORMAT")]
-    pub requests_format: Option<GooseLogFormat>,
-    /// Sets tasks log file name
+    pub request_format: Option<GooseLogFormat>,
+    /// Sets task log file name
     #[options(short = "T", meta = "NAME")]
-    pub tasks_file: String,
-    /// Sets tasks log format (csv, json, raw)
+    pub task_log: String,
+    /// Sets task log format (csv, json, raw)
     #[options(no_short, meta = "FORMAT")]
-    pub tasks_format: Option<GooseLogFormat>,
+    pub task_format: Option<GooseLogFormat>,
     /// Sets error log file name
     #[options(short = "E", meta = "NAME")]
-    pub error_file: String,
+    pub error_log: String,
     /// Sets error log format (csv, json, raw)
     #[options(no_short, meta = "FORMAT")]
     pub error_format: Option<GooseLogFormat>,
     /// Sets debug log file name
     #[options(short = "D", meta = "NAME")]
-    pub debug_file: String,
+    pub debug_log: String,
     /// Sets debug log format (csv, json, raw)
     #[options(no_short, meta = "FORMAT")]
     pub debug_format: Option<GooseLogFormat>,
@@ -4495,12 +4495,13 @@ mod test {
         let run_time: usize = 10;
         let hatch_rate = "2".to_string();
         let log_level: usize = 1;
-        let log_file = "custom-goose.log".to_string();
+        let goose_log = "custom-goose.log".to_string();
         let verbose: usize = 0;
         let report_file = "custom-goose-report.html".to_string();
-        let requests_file = "custom-goose-metrics.log".to_string();
-        let debug_file = "custom-goose-debug.log".to_string();
-        let error_file = "custom-goose-error.log".to_string();
+        let request_log = "custom-goose-request.log".to_string();
+        let task_log = "custom-goose-task.log".to_string();
+        let debug_log = "custom-goose-debug.log".to_string();
+        let error_log = "custom-goose-error.log".to_string();
         let throttle_requests: usize = 25;
         let expect_workers: usize = 5;
         let manager_bind_host = "127.0.0.1".to_string();
@@ -4520,7 +4521,7 @@ mod test {
             .unwrap()
             .set_default(GooseDefault::LogLevel, log_level)
             .unwrap()
-            .set_default(GooseDefault::LogFile, log_file.as_str())
+            .set_default(GooseDefault::GooseLog, goose_log.as_str())
             .unwrap()
             .set_default(GooseDefault::Verbose, verbose)
             .unwrap()
@@ -4542,15 +4543,19 @@ mod test {
             .unwrap()
             .set_default(GooseDefault::ReportFile, report_file.as_str())
             .unwrap()
-            .set_default(GooseDefault::RequestsFile, requests_file.as_str())
+            .set_default(GooseDefault::RequestLog, request_log.as_str())
             .unwrap()
             .set_default(GooseDefault::RequestsFormat, GooseLogFormat::Raw)
             .unwrap()
-            .set_default(GooseDefault::ErrorFile, error_file.as_str())
+            .set_default(GooseDefault::TaskLog, task_log.as_str())
+            .unwrap()
+            .set_default(GooseDefault::TaskFormat, GooseLogFormat::Raw)
+            .unwrap()
+            .set_default(GooseDefault::ErrorLog, error_log.as_str())
             .unwrap()
             .set_default(GooseDefault::ErrorFormat, GooseLogFormat::Csv)
             .unwrap()
-            .set_default(GooseDefault::DebugFile, debug_file.as_str())
+            .set_default(GooseDefault::DebugLog, debug_log.as_str())
             .unwrap()
             .set_default(GooseDefault::DebugFormat, GooseLogFormat::Csv)
             .unwrap()
@@ -4589,7 +4594,7 @@ mod test {
         assert!(goose_attack.defaults.run_time == Some(run_time));
         assert!(goose_attack.defaults.hatch_rate == Some(hatch_rate));
         assert!(goose_attack.defaults.log_level == Some(log_level as u8));
-        assert!(goose_attack.defaults.log_file == Some(log_file));
+        assert!(goose_attack.defaults.goose_log == Some(goose_log));
         assert!(goose_attack.defaults.no_debug_body == Some(true));
         assert!(goose_attack.defaults.verbose == Some(verbose as u8));
         assert!(goose_attack.defaults.running_metrics == Some(15));
@@ -4601,11 +4606,11 @@ mod test {
         assert!(goose_attack.defaults.no_websocket == Some(true));
         assert!(goose_attack.defaults.no_autostart == Some(true));
         assert!(goose_attack.defaults.report_file == Some(report_file));
-        assert!(goose_attack.defaults.requests_file == Some(requests_file));
-        assert!(goose_attack.defaults.requests_format == Some(GooseLogFormat::Raw));
-        assert!(goose_attack.defaults.error_file == Some(error_file));
+        assert!(goose_attack.defaults.request_log == Some(request_log));
+        assert!(goose_attack.defaults.request_format == Some(GooseLogFormat::Raw));
+        assert!(goose_attack.defaults.error_log == Some(error_log));
         assert!(goose_attack.defaults.error_format == Some(GooseLogFormat::Csv));
-        assert!(goose_attack.defaults.debug_file == Some(debug_file));
+        assert!(goose_attack.defaults.debug_log == Some(debug_log));
         assert!(goose_attack.defaults.debug_format == Some(GooseLogFormat::Csv));
         assert!(goose_attack.defaults.status_codes == Some(true));
         assert!(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2329,7 +2329,7 @@ impl GooseAttack {
     ) {
         // If error-file is enabled, convert the raw request to a GooseErrorMetric and send it
         // to the logger thread.
-        if !self.configuration.error_file.is_empty() {
+        if !self.configuration.error_log.is_empty() {
             if let Some(logger) = goose_attack_run_state.all_threads_logger_tx.as_ref() {
                 // This is a best effort logger attempt, if the logger has alrady shut down it
                 // will fail which we ignore.

--- a/src/user.rs
+++ b/src/user.rs
@@ -187,7 +187,7 @@ async fn invoke_task_function(
     }
 
     // If tasks-file is enabled, send a copy of the raw task metric to the logger thread.
-    if !thread_user.config.tasks_file.is_empty() {
+    if !thread_user.config.task_log.is_empty() {
         if let Some(logger) = thread_user.logger.as_ref() {
             logger.send(Some(GooseLog::Task(raw_task.clone())))?;
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -222,27 +222,23 @@ pub(crate) async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
     // This is a Worker instance, not a Manager instance.
     worker_goose_attack.configuration.manager = false;
     worker_goose_attack.configuration.worker = true;
-    // The requests_file option is configured on the Worker.
-    worker_goose_attack.configuration.requests_file =
-        goose_attack.configuration.requests_file.to_string();
-    // The requests_format option is configured on the Worker.
-    worker_goose_attack.configuration.requests_format =
-        goose_attack.configuration.requests_format.clone();
-    // The tasks_file option is configured on the Worker.
-    worker_goose_attack.configuration.tasks_file =
-        goose_attack.configuration.tasks_file.to_string();
-    // The tasks_format option is configured on the Worker.
-    worker_goose_attack.configuration.tasks_format =
-        goose_attack.configuration.tasks_format.clone();
-    // The error_file option is configured on the Worker.
-    worker_goose_attack.configuration.error_file =
-        goose_attack.configuration.error_file.to_string();
+    // The request_log option is configured on the Worker.
+    worker_goose_attack.configuration.request_log =
+        goose_attack.configuration.request_log.to_string();
+    // The request_format option is configured on the Worker.
+    worker_goose_attack.configuration.request_format =
+        goose_attack.configuration.request_format.clone();
+    // The task_log option is configured on the Worker.
+    worker_goose_attack.configuration.task_log = goose_attack.configuration.task_log.to_string();
+    // The task_format option is configured on the Worker.
+    worker_goose_attack.configuration.task_format = goose_attack.configuration.task_format.clone();
+    // The error_log option is configured on the Worker.
+    worker_goose_attack.configuration.error_log = goose_attack.configuration.error_log.to_string();
     // The error_format option is configured on the Worker.
     worker_goose_attack.configuration.error_format =
         goose_attack.configuration.error_format.clone();
-    // The debug_file option is configured on the Worker.
-    worker_goose_attack.configuration.debug_file =
-        goose_attack.configuration.debug_file.to_string();
+    // The debug_log option is configured on the Worker.
+    worker_goose_attack.configuration.debug_log = goose_attack.configuration.debug_log.to_string();
     // The debug_format option is configured on the Worker.
     worker_goose_attack.configuration.debug_format =
         goose_attack.configuration.debug_format.clone();

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -32,10 +32,10 @@ enum TestType {
 }
 
 struct LogFiles<'a> {
-    requests_files: &'a [String],
-    tasks_files: &'a [String],
-    error_files: &'a [String],
-    debug_files: &'a [String],
+    request_logs: &'a [String],
+    task_logs: &'a [String],
+    error_logs: &'a [String],
+    debug_logs: &'a [String],
 }
 
 // Implement fmt::Display for TestType to uniquely name the log files generated
@@ -120,11 +120,11 @@ fn validate_test(
     match test_type {
         TestType::Debug => {
             // Debug file must exist.
-            assert!(!log_files.debug_files.is_empty());
+            assert!(!log_files.debug_logs.is_empty());
 
             // Confirm the debug log files actually exist.
             let mut debug_file_lines = 0;
-            for debug_file in log_files.debug_files {
+            for debug_file in log_files.debug_logs {
                 assert!(std::path::Path::new(debug_file).exists());
                 debug_file_lines += common::file_length(debug_file);
             }
@@ -133,24 +133,24 @@ fn validate_test(
         }
         TestType::Requests => {
             // Requests file must exist.
-            assert!(!log_files.requests_files.is_empty());
+            assert!(!log_files.request_logs.is_empty());
 
             // Confirm the requests log files actually exist.
             let mut requests_file_lines = 0;
-            for requests_file in log_files.requests_files {
-                assert!(std::path::Path::new(requests_file).exists());
-                requests_file_lines += common::file_length(requests_file);
+            for request_log in log_files.request_logs {
+                assert!(std::path::Path::new(request_log).exists());
+                requests_file_lines += common::file_length(request_log);
             }
             // Metrics file must not be empty.
             assert!(requests_file_lines > 0);
         }
         TestType::Tasks => {
             // Tasks file must exist.
-            assert!(!log_files.tasks_files.is_empty());
+            assert!(!log_files.task_logs.is_empty());
 
             // Confirm the tasks log files actually exist.
             let mut tasks_file_lines = 0;
-            for tasks_file in log_files.tasks_files {
+            for tasks_file in log_files.task_logs {
                 assert!(std::path::Path::new(tasks_file).exists());
                 tasks_file_lines += common::file_length(tasks_file);
             }
@@ -159,11 +159,11 @@ fn validate_test(
         }
         TestType::Error => {
             // Error file must exist.
-            assert!(!log_files.error_files.is_empty());
+            assert!(!log_files.error_logs.is_empty());
 
             // Confirm the error log files actually exist.
             let mut error_file_lines = 0;
-            for error_file in log_files.error_files {
+            for error_file in log_files.error_logs {
                 assert!(std::path::Path::new(error_file).exists());
                 error_file_lines += common::file_length(error_file);
             }
@@ -172,46 +172,46 @@ fn validate_test(
         }
         TestType::All => {
             // Debug file must exist.
-            assert!(!log_files.debug_files.is_empty());
+            assert!(!log_files.debug_logs.is_empty());
             // Error file must exist.
-            assert!(!log_files.error_files.is_empty());
+            assert!(!log_files.error_logs.is_empty());
             // Requests file must exist.
-            assert!(!log_files.requests_files.is_empty());
+            assert!(!log_files.request_logs.is_empty());
             // Tasks file must exist.
-            assert!(!log_files.tasks_files.is_empty());
+            assert!(!log_files.task_logs.is_empty());
 
             // Confirm the debug log files actually exist.
             let mut debug_file_lines = 0;
-            for debug_file in log_files.debug_files {
-                assert!(std::path::Path::new(debug_file).exists());
-                debug_file_lines += common::file_length(debug_file);
+            for debug_log in log_files.debug_logs {
+                assert!(std::path::Path::new(debug_log).exists());
+                debug_file_lines += common::file_length(debug_log);
             }
             // Debug file must not be empty.
             assert!(debug_file_lines > 0);
 
             // Confirm the error log files actually exist.
             let mut error_file_lines = 0;
-            for error_file in log_files.error_files {
-                assert!(std::path::Path::new(error_file).exists());
-                error_file_lines += common::file_length(error_file);
+            for error_log in log_files.error_logs {
+                assert!(std::path::Path::new(error_log).exists());
+                error_file_lines += common::file_length(error_log);
             }
             // Error file must not be empty.
             assert!(error_file_lines > 0);
 
             // Confirm the requests log files actually exist.
             let mut requests_file_lines = 0;
-            for requests_file in log_files.requests_files {
-                assert!(std::path::Path::new(requests_file).exists());
-                requests_file_lines += common::file_length(requests_file);
+            for request_log in log_files.request_logs {
+                assert!(std::path::Path::new(request_log).exists());
+                requests_file_lines += common::file_length(request_log);
             }
             // Requests file must not be empty.
             assert!(requests_file_lines > 0);
 
             // Confirm the tasks log files actually exist.
             let mut tasks_file_lines = 0;
-            for tasks_file in log_files.tasks_files {
-                assert!(std::path::Path::new(tasks_file).exists());
-                tasks_file_lines += common::file_length(tasks_file);
+            for tasks_log in log_files.task_logs {
+                assert!(std::path::Path::new(tasks_log).exists());
+                tasks_file_lines += common::file_length(tasks_log);
             }
             // Task file must not be empty.
             assert!(tasks_file_lines > 0);
@@ -221,40 +221,35 @@ fn validate_test(
 
 // Helper to run all standalone tests.
 fn run_standalone_test(test_type: TestType, format: &str) {
-    let requests_file = test_type.to_string() + "-requests-log." + format;
-    let tasks_file = test_type.to_string() + "-tasks-log." + format;
-    let debug_file = test_type.to_string() + "-debug-log." + format;
-    let error_file = test_type.to_string() + "-error-log." + format;
+    let request_log = test_type.to_string() + "-request-log." + format;
+    let task_log = test_type.to_string() + "-task-log." + format;
+    let debug_log = test_type.to_string() + "-debug-log." + format;
+    let error_log = test_type.to_string() + "-error-log." + format;
 
     let server = MockServer::start();
 
     let mock_endpoints = setup_mock_server_endpoints(&server);
 
     let mut configuration_flags = match test_type {
-        TestType::Debug => vec!["--debug-file", &debug_file, "--debug-format", format],
-        TestType::Error => vec!["--error-file", &error_file, "--error-format", format],
-        TestType::Requests => vec![
-            "--requests-file",
-            &requests_file,
-            "--requests-format",
-            format,
-        ],
-        TestType::Tasks => vec!["--tasks-file", &tasks_file, "--tasks-format", format],
+        TestType::Debug => vec!["--debug-log", &debug_log, "--debug-format", format],
+        TestType::Error => vec!["--error-log", &error_log, "--error-format", format],
+        TestType::Requests => vec!["--request-log", &request_log, "--request-format", format],
+        TestType::Tasks => vec!["--task-log", &task_log, "--task-format", format],
         TestType::All => vec![
-            "--requests-file",
-            &requests_file,
-            "--requests-format",
+            "--request-log",
+            &request_log,
+            "--request-format",
             format,
-            "--tasks-file",
-            &tasks_file,
-            "--tasks-format",
+            "--task-log",
+            &task_log,
+            "--task-format",
             format,
-            "--error-file",
-            &error_file,
+            "--error-log",
+            &error_log,
             "--error-format",
             format,
-            "--debug-file",
-            &debug_file,
+            "--debug-log",
+            &debug_log,
             "--debug-format",
             format,
         ],
@@ -269,21 +264,21 @@ fn run_standalone_test(test_type: TestType, format: &str) {
     );
 
     let log_files = LogFiles {
-        requests_files: &[requests_file.to_string()],
-        tasks_files: &[tasks_file.to_string()],
-        error_files: &[error_file.to_string()],
-        debug_files: &[debug_file.to_string()],
+        request_logs: &[request_log.to_string()],
+        task_logs: &[task_log.to_string()],
+        error_logs: &[error_log.to_string()],
+        debug_logs: &[debug_log.to_string()],
     };
 
     validate_test(goose_metrics, &mock_endpoints, &test_type, &log_files);
 
-    common::cleanup_files(vec![&requests_file, &tasks_file, &error_file, &debug_file]);
+    common::cleanup_files(vec![&request_log, &task_log, &error_log, &debug_log]);
 }
 
 // Helper to run all gaggle tests.
 fn run_gaggle_test(test_type: TestType, format: &str) {
-    let requests_file = test_type.to_string() + "-gaggle-requests-log." + format;
-    let tasks_file = test_type.to_string() + "-gaggle-tasks-log." + format;
+    let requests_file = test_type.to_string() + "-gaggle-request-log." + format;
+    let tasks_file = test_type.to_string() + "-gaggle-task-log." + format;
     let error_file = test_type.to_string() + "-gaggle-error-log." + format;
     let debug_file = test_type.to_string() + "-gaggle-debug-log." + format;
 
@@ -312,47 +307,47 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
         let worker_configuration_flags = match test_type {
             TestType::Debug => vec![
                 "--worker",
-                "--debug-file",
+                "--debug-log",
                 &worker_debug_file,
                 "--debug-format",
                 format,
             ],
             TestType::Error => vec![
                 "--worker",
-                "--error-file",
+                "--error-log",
                 &worker_error_file,
                 "--error-format",
                 format,
             ],
             TestType::Requests => vec![
                 "--worker",
-                "--requests-file",
+                "--request-log",
                 &worker_requests_file,
-                "--requests-format",
+                "--request-format",
                 format,
             ],
             TestType::Tasks => vec![
                 "--worker",
-                "--tasks-file",
+                "--task-log",
                 &worker_tasks_file,
-                "--tasks-format",
+                "--task-format",
                 format,
             ],
             TestType::All => vec![
                 "--worker",
-                "--requests-file",
+                "--request-log",
                 &worker_requests_file,
-                "--requests-format",
+                "--request-format",
                 format,
-                "--tasks-file",
+                "--task-log",
                 &worker_tasks_file,
-                "--tasks-format",
+                "--task-format",
                 format,
-                "--error-file",
+                "--error-log",
                 &worker_error_file,
                 "--error-format",
                 format,
-                "--debug-file",
+                "--debug-log",
                 &worker_debug_file,
                 "--debug-format",
                 format,
@@ -391,10 +386,10 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
     let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles));
 
     let log_files = LogFiles {
-        requests_files: &requests_files,
-        tasks_files: &tasks_files,
-        error_files: &error_files,
-        debug_files: &debug_files,
+        request_logs: &requests_files,
+        task_logs: &tasks_files,
+        error_logs: &error_files,
+        debug_logs: &debug_files,
     };
 
     validate_test(goose_metrics, &mock_endpoints, &test_type, &log_files);


### PR DESCRIPTION
It was confusing that `requests` and `tasks` were plural, while `error` was singular. It was also confusing what `--log-file` was compared to the many other log files Goose can generate, so lots of renaming for consistency:

 - renamed `--log-file` to `--goose-log`, `--requests-file` to `--request-log`, `--requests-format` to `--request-format`, `--tasks-file` to `--task-log`, `--tasks-format` to `--task-format`, `--error-file` to `--error-log`, and `--debug-file` to `--debug-log`