### PR TITLE
[Add][Doc] Goose book deploy job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,29 +7,52 @@ on:
     branches: [ main ]
 
 env:
-    RUST_BACKTRACE: 1
+  RUST_BACKTRACE: 1
 
 jobs:
   style:
-    name: verify formatting and style
+    name: Verify formatting and style
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Verify code formatting
-      run: cargo fmt -- --check
-    - name: Verify code style
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      - uses: actions/checkout@v2
+      - name: Verify code formatting
+        run: cargo fmt -- --check
+      - name: Verify code style
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   build:
-    name: build and run tests
+    name: Build and run tests
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose --all-features
-    - name: Docs
-      run: cargo rustdoc --lib --examples
-    - name: Run tests
-      run: cargo test --verbose --all-features
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose --all-features
+      - name: Docs
+        run: cargo rustdoc --lib --examples
+      - name: Run tests
+        run: cargo test --verbose --all-features
+
+  deploy:
+    name: Build and deploy book
+    runs-on: ubuntu-latest
+    needs: [style, build]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup mdbook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: "0.4.10"
+      - name: Build and test Goose book
+        run: mdbook build book && mdbook test book
+      - name: Deploy Goose book
+        uses: peaceiris/actions-gh-pages@v3.5.4-6
+        # Workaround https://github.com/peaceiris/actions-gh-pages/issues/627
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_dir: ./book/html
+          publish_branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /settings.json.code-workspace
 **swp
 /Cargo.lock
+book/html


### PR DESCRIPTION
Close issue #315

What?
One element of issue #306. Github job to build, test and deploy the
Goose book to GitHub Pages.
We .gitignore the compiled pages.

Why?
We build static HTML using GitHub actions then deploy the
book to GitHub Pages.

How?
We use the GitHub action-mdbook.
Deployment uses SSH keys fro two reasons:

1. this avoids a subtle issue with Github tokens
2. this allows forks of the project to run the full workflow. This
assists developers who contribute to the documentation by
allowing them to run the complete workflow before making
a pull request. In turn, this reduces the maintenance burden.

Signed-off-by: Begley Brothers Inc <begleybrothers@gmail.com>