### PR TITLE
update tungstenite so it's possible to build without openssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.12.1-dev
+ - rename `rustls` feature to `rustls-tls` so `tests/controller.rs` can build with the `rustls` library; update `tungstenite` to `0.14` and `tokio-tungstenite` = `0.15` to allow building with `rustls`
 
 ## 0.12.0 July 8, 2021
  - remove internal-only functions and structures from documentation, exposing only what's useful to consumers of the Goose library (API change)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ nng = { version = "1.0", optional = true }
 [features]
 default = ["reqwest/default-tls"]
 gaggle = ["nng"]
-rustls = ["reqwest/rustls-tls"]
+rustls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls-tls"]
 
 [build-dependencies]
 rustc_version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ tokio = { version = "1", features = [
     "time",
     "sync",
 ] }
-tokio-tungstenite = "0.14"
-tungstenite = "0.13"
+tokio-tungstenite = "0.15"
+tungstenite = "0.14"
 url = "2"
 
 # optional dependencies
@@ -55,7 +55,7 @@ nng = { version = "1.0", optional = true }
 [features]
 default = ["reqwest/default-tls"]
 gaggle = ["nng"]
-rustls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls-tls"]
 
 [build-dependencies]
 rustc_version = "0.3"
@@ -64,3 +64,4 @@ rustc_version = "0.3"
 httpmock = "0.5"
 serial_test = "0.5"
 native-tls = "0.2"
+rustls = "0.19"

--- a/README.md
+++ b/README.md
@@ -905,9 +905,9 @@ Workers initiate all network connections, and push metrics to the Manager proces
 
 ## RustLS
 
-By default Reqwest (and therefore Goose) uses the system-native transport layer security to make HTTPS requests. This means `schannel` on Windows, `Security-Framework` on macOS, and `OpenSSL` on Linux. If you'd prefer to use a [pure Rust TLS implementation](https://github.com/ctz/rustls), disable default features and enable `rustls` in `Cargo.toml` as follows:
+By default Reqwest (and therefore Goose) uses the system-native transport layer security to make HTTPS requests. This means `schannel` on Windows, `Security-Framework` on macOS, and `OpenSSL` on Linux. If you'd prefer to use a [pure Rust TLS implementation](https://github.com/ctz/rustls), disable default features and enable `rustls-tls` in `Cargo.toml` as follows:
 
 ```toml
 [dependencies]
-goose = { version = "^0.12", default-features = false, features = ["rustls"] }
+goose = { version = "^0.12", default-features = false, features = ["rustls-tls"] }
 ```

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -47,11 +47,21 @@ struct TestState {
     // A TCP socket if testing the telnet Controller.
     telnet_stream: Option<TcpStream>,
     // A TCP socket if testing the WebSocket Controller.
+    #[cfg(not(feature = "rustls-tls"))]
     websocket_stream: Option<
         tungstenite::WebSocket<
             tungstenite::stream::Stream<
                 std::net::TcpStream,
                 native_tls::TlsStream<std::net::TcpStream>,
+            >,
+        >,
+    >,
+    #[cfg(feature = "rustls-tls")]
+    websocket_stream: Option<
+        tungstenite::WebSocket<
+            tungstenite::stream::Stream<
+                std::net::TcpStream,
+                rustls::StreamOwned<rustls::ClientSession, TcpStream>,
             >,
         >,
     >,


### PR DESCRIPTION
- start with #321
- update `tungstenite` to `0.14` and `tokio-tungstenite` = "0.15"
- add `rustls` as development dependency for `tests/controller.rs`
- rename Goose `rustls` feature to `rustls-tls` as feature and library can't share the same name