### PR TITLE
fix to compile on Linux

### DIFF
--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -48,14 +48,7 @@ struct TestState {
     telnet_stream: Option<TcpStream>,
     // A TCP socket if testing the WebSocket Controller.
     #[cfg(not(feature = "rustls-tls"))]
-    websocket_stream: Option<
-        tungstenite::WebSocket<
-            tungstenite::stream::Stream<
-                std::net::TcpStream,
-                native_tls::TlsStream<std::net::TcpStream>,
-            >,
-        >,
-    >,
+    websocket_stream: Option<tungstenite::WebSocket<std::net::TcpStream>>,
     #[cfg(feature = "rustls-tls")]
     websocket_stream: Option<
         tungstenite::WebSocket<


### PR DESCRIPTION
 - fix to compile on Linux

I'm currently developing on Mac OS X, and realized that it _never_ has OpenSSL. When I tested on Linux I realized Goose no longer compiled: fixed.

Goose should be testing more targets to catch this.

On Linux, with the `rustls-tls` feature enabled:

```
jandrews@goose:~/loadtest-test$ cargo tree | grep openssl
    │   │   │   ├── openssl-probe v0.1.4
jandrews@goose:~/loadtest-test$ cargo tree | grep tls
    │   ├── hyper-rustls v0.22.1
    │   │   ├── rustls v0.19.1
    │   │   ├── tokio-rustls v0.22.0
    │   │   │   ├── rustls v0.19.1 (*)
    │   ├── rustls v0.19.1 (*)
    │   ├── tokio-rustls v0.22.0 (*)
    │   ├── rustls v0.19.1 (*)
    │   ├── tokio-rustls v0.22.0 (*)
    │   │   ├── rustls v0.19.1 (*)
    │   │   ├── rustls-native-certs v0.5.0
    │   │   │   └── rustls v0.19.1 (*)
```

And without the `rustls-tls` feature:
```
jandrews@goose:~/loadtest-test$ cargo tree | grep openssl
    │   │   │   ├── openssl v0.10.35
    │   │   │   │   └── openssl-sys v0.9.65
    │   │   │   ├── openssl-probe v0.1.4
    │   │   │   └── openssl-sys v0.9.65 (*)
jandrews@goose:~/loadtest-test$ cargo tree | grep tls
    │   ├── hyper-tls v0.5.0
    │   │   ├── native-tls v0.2.7
    │   │   └── tokio-native-tls v0.3.0
    │   │       ├── native-tls v0.2.7 (*)
    │   ├── native-tls v0.2.7 (*)
    │   ├── tokio-native-tls v0.3.0 (*)

```