### PR TITLE
Manager requires ExpectWorkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.12.1-dev
  - rename `rustls` feature to `rustls-tls` so `tests/controller.rs` can build with the `rustls` library; update `tungstenite` to `0.14` and `tokio-tungstenite` = `0.15` to allow building with `rustls`
   - documentation cleanup; properly rename `GooseDefault::RequestFormat` and fix links
+  - always configure `GooseConfiguration.manager` and `GooseConfiguration.worker`; confirm Manager is enabled when setting `--expect-workers`
 
 ## 0.12.0 July 8, 2021
  - remove internal-only functions and structures from documentation, exposing only what's useful to consumers of the Goose library (API change)


### PR DESCRIPTION
  - always configure `GooseConfiguration.manager` and `GooseConfiguration.worker`
  - confirm Manager is enabled when setting `--expect-workers`
  - fixes #292 