### PR TITLE
enable gzip and deflate in http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - documentation cleanup; properly rename `GooseDefault::RequestFormat` and fix links
   - always configure `GooseConfiguration.manager` and `GooseConfiguration.worker`; confirm Manager is enabled when setting `--expect-workers`
   - moved `GooseConfiguration`, `GooseDefault`, and `GooseDefaultType` into new `src/config.rs` file; standardized configuration precedence through internal `GooseConfigure` trait defining `get_value()` for all supported types; general improvements to configuration documentation
+  - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) and [`deflate`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.deflate) support in the client
 
 ## 0.12.0 July 8, 2021
  - remove internal-only functions and structures from documentation, exposing only what's useful to consumers of the Goose library (API change)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
+## 0.12.2-dev
+  - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) support and set Accept-Encoding header by default in the client; disable with `--no-gzip` or `GooseDefault::NoGzip`
+
 ## 0.12.1 July 15, 2021
  - rename `rustls` feature to `rustls-tls` so `tests/controller.rs` can build with the `rustls` library; update `tungstenite` to `0.14` and `tokio-tungstenite` = `0.15` to allow building with `rustls`
   - documentation cleanup; properly rename `GooseDefault::RequestFormat` and fix links
   - always configure `GooseConfiguration.manager` and `GooseConfiguration.worker`; confirm Manager is enabled when setting `--expect-workers`
   - moved `GooseConfiguration`, `GooseDefault`, and `GooseDefaultType` into new `src/config.rs` file; standardized configuration precedence through internal `GooseConfigure` trait defining `get_value()` for all supported types; general improvements to configuration documentation
-  - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) and [`deflate`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.deflate) support in the client
 
 ## 0.12.0 July 8, 2021
  - remove internal-only functions and structures from documentation, exposing only what's useful to consumers of the Goose library (API change)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.12.1"
+version = "0.12.2-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ rand = "0.8"
 regex = "1"
 reqwest = { version = "0.11",  default-features = false, features = [
     "cookies",
-    "deflate",
     "gzip",
     "json",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ rand = "0.8"
 regex = "1"
 reqwest = { version = "0.11",  default-features = false, features = [
     "cookies",
+    "deflate",
+    "gzip",
     "json",
 ] }
 serde = { version = "1.0", features = [

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1913,7 +1913,8 @@ impl GooseUser {
     ///
     /// let builder = Client::builder()
     ///   .user_agent(APP_USER_AGENT)
-    ///   .cookie_store(true);
+    ///   .cookie_store(true)
+    ///   .gzip(true);
     /// ```
     ///
     /// Alternatively, you can use this function to manually build a
@@ -1968,6 +1969,24 @@ impl GooseUser {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// Reqwest also supports
+    /// [`brotli`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.brotli) and
+    /// [`deflate`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.deflate) compression.
+    ///
+    /// To enable either, you must enable the features in your load test's `Cargo.toml`, for example:
+    /// ```text
+    /// reqwest = { version = "^0.11.4",  default-features = false, features = [
+    ///     "brotli",
+    ///     "cookies",
+    ///     "deflate",
+    ///     "gzip",
+    ///     "json",
+    /// ] }
+    /// ```
+    ///
+    /// Once enabled, you can add `.brotli(true)` and/or `.deflate(true)` to your custom Client::builder(),
+    /// similar to how is documented above.
     pub async fn set_client_builder(&self, builder: ClientBuilder) -> Result<(), GooseTaskError> {
         *self.client.lock().await = builder.build()?;
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -871,6 +871,8 @@ impl GooseUser {
         let client = Client::builder()
             .user_agent(APP_USER_AGENT)
             .cookie_store(true)
+            .deflate(true)
+            .gzip(true)
             .build()?;
 
         Ok(GooseUser {
@@ -1929,8 +1931,8 @@ impl GooseUser {
     ///    will only affect requests made during test teardown;
     ///  - A manually built client is specific to a single Goose thread -- if you are
     ///    generating a large load test with many users, each will need to manually build their
-    ///    own client (typically you'd do this in a Task that is registered with `set_on_start()`
-    ///    in each Task Set requiring a custom client;
+    ///    own client (typically you'd do this in a Task that is registered with
+    ///   [`GooseTask::set_on_start()`] in each Task Set requiring a custom client;
     ///  - Manually building a client will completely replace the automatically built client
     ///    with a brand new one, so any configuration, cookies or headers set in the previously
     ///    built client will be gone;
@@ -1940,7 +1942,8 @@ impl GooseUser {
     ///    [`.cookie_store(true)`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.cookie_store).
     ///
     /// In the following example, the Goose client is configured with a different user agent,
-    /// sets a default header on every request, and stores cookies.
+    /// sets a default header on every request, stores cookies, and supports gzip and deflate
+    /// compression.
     ///
     /// # Example
     /// ```rust
@@ -1958,7 +1961,9 @@ impl GooseUser {
     ///     let builder = Client::builder()
     ///         .default_headers(headers)
     ///         .user_agent("custom user agent")
-    ///         .cookie_store(true);
+    ///         .cookie_store(true)
+    ///         .deflate(true)
+    ///         .gzip(true);
     ///
     ///     user.set_client_builder(builder).await?;
     ///

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -871,8 +871,8 @@ impl GooseUser {
         let client = Client::builder()
             .user_agent(APP_USER_AGENT)
             .cookie_store(true)
-            .deflate(true)
-            .gzip(true)
+            // Enable gzip unless `--no-gzip` flag is enabled.
+            .gzip(!configuration.no_gzip)
             .build()?;
 
         Ok(GooseUser {
@@ -1942,8 +1942,7 @@ impl GooseUser {
     ///    [`.cookie_store(true)`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.cookie_store).
     ///
     /// In the following example, the Goose client is configured with a different user agent,
-    /// sets a default header on every request, stores cookies, and supports gzip and deflate
-    /// compression.
+    /// sets a default header on every request, stores cookies, and supports gzip compression.
     ///
     /// # Example
     /// ```rust
@@ -1962,7 +1961,6 @@ impl GooseUser {
     ///         .default_headers(headers)
     ///         .user_agent("custom user agent")
     ///         .cookie_store(true)
-    ///         .deflate(true)
     ///         .gzip(true);
     ///
     ///     user.set_client_builder(builder).await?;


### PR DESCRIPTION
  - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) support in the http client
  - can be disabled with `--no-gzip` or `GooseDefault::NoGzip`
  - documented how to manually enable [`deflate`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.deflate) and/or [`brotli`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.brotli) compression

