### PR TITLE
include the request headers in GooseRequestMetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) support and set Accept-Encoding header by default in the client; disable with `--no-gzip` or `GooseDefault::NoGzip`
   - document how to add custom cookies (https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#custom-cookies)
   - update [`rustc_version`](https://docs.rs/rustc_version) dependency to `0.4`
+  - include client request headers in `GooseRequestMetric` so they show up in the request log and the debug log
 
 ## 0.12.1 July 15, 2021
  - rename `rustls` feature to `rustls-tls` so `tests/controller.rs` can build with the `rustls` library; update `tungstenite` to `0.14` and `tokio-tungstenite` = `0.15` to allow building with `rustls`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
-## 0.12.2-dev
+## 0.13.0-dev
   - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) support and set Accept-Encoding header by default in the client; disable with `--no-gzip` or `GooseDefault::NoGzip`
   - document how to add custom cookies (https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#custom-cookies)
   - update [`rustc_version`](https://docs.rs/rustc_version) dependency to `0.4`
   - include client request headers in `GooseRequestMetric` so they show up in the request log and the debug log
+  - introduce `GooseRawMetric` which contains the `method`, `url`, `headers` and `body` of the client request made, and is now contained in `raw` field of the `GooseRequestMetric` (API change)
+  - introduce `--request-body` (and `GooseDefault::RequestBody`) which when enabled shows up in the `body` field of the `GooseRawMetric`
+  - add `GooseRawMetric` to the request log, debug log and error log
 
 ## 0.12.1 July 15, 2021
  - rename `rustls` feature to `rustls-tls` so `tests/controller.rs` can build with the `rustls` library; update `tungstenite` to `0.14` and `tokio-tungstenite` = `0.15` to allow building with `rustls`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.12.2-dev"
+version = "0.13.0-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Metrics:
   --report-file NAME         Create an html-formatted report
   -R, --request-log NAME     Sets request log file name
   --request-format FORMAT    Sets request log format (csv, json, raw)
+  --request-body             Include the request body in the request log
   -T, --task-log NAME        Sets task log file name
   --task-format FORMAT       Sets task log format (csv, json, raw)
   -E, --error-log NAME       Sets error log file name
@@ -617,57 +618,37 @@ When operating in Gaggle-mode, the `--error-file` option can only be enabled on 
 By default, logs are written in JSON Lines format. For example:
 
 ```json
-{"elapsed":2239,"error":"503 Service Unavailable: /comment/reply/8151","final_url":"http://apache/comment/reply/8151","method":"Post","name":"(Auth) comment form","redirected":false,"response_time":26,"status_code":503,"url":"http://apache/comment/reply/8151","user":1}
-{"elapsed":2261,"error":"503 Service Unavailable: /node/9577","final_url":"http://apache/node/9577","method":"Get","name":"(Anon) node page","redirected":false,"response_time":143,"status_code":503,"url":"http://apache/node/9577","user":2}
-{"elapsed":2267,"error":"503 Service Unavailable: /","final_url":"http://apache/","method":"Get","name":"(Auth) front page","redirected":false,"response_time":138,"status_code":503,"url":"http://apache/","user":1}
-{"elapsed":2404,"error":"503 Service Unavailable: /user/4375","final_url":"http://apache/user/4375","method":"Get","name":"(Anon) user page","redirected":false,"response_time":5,"status_code":503,"url":"http://apache/user/4375","user":2}
+{"elapsed":9318,"error":"503 Service Unavailable: /","final_url":"http://apache/","name":"(Auth) front page","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/"},"redirected":false,"response_time":6,"status_code":503,"user":1}
+{"elapsed":9318,"error":"503 Service Unavailable: /node/8211","final_url":"http://apache/node/8211","name":"(Anon) node page","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/node/8211"},"redirected":false,"response_time":6,"status_code":503,"user":3}
 ```
 
 Logs include the entire [`GooseErrorMetric`] object as defined in `src/goose.rs`, which are created when requests result in an error.
 
 By default Goose logs errors in JSON Lines format. The `--errors-format` option can be used to log in `csv`, `json` or `raw` format. The `raw` format is Rust's debug output of the entire [`GooseErrorMetric`] object.
 
-For example, `csv` output of similar errors as those logged above would like like:
-```csv
-elapsed,method,name,url,final_url,redirected,response_time,status_code,user,error
-6250,GET,"(Auth) node page","http://apache/node/3781","http://apache/node/3781",false,5,503,1,"503 Service Unavailable: /node/3781"
-6256,GET,"(Auth) front page","http://apache/","http://apache/",false,5,503,1,"503 Service Unavailable: /"
-6262,GET,"(Auth) node page","http://apache/node/5452","http://apache/node/5452",false,8,503,1,"503 Service Unavailable: /node/5452"
-6265,GET,"(Anon) node page","http://apache/node/1819","http://apache/node/1819",false,5,503,0,"503 Service Unavailable: /node/1819"
-```
-
 ## Logging Load Test Requests
 
-Goose can optionally log details about all load test requests to a file. To enable, add the `--request-log=request.log` command line option, where `request.log` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
+Goose can optionally log details about all load test requests to a file. To enable, add the `--request-log request.log` command line option, where `request.log` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
+
+If `--request-body` is enabled, the request log will also include the entire body of any client requests.
 
 When operating in Gaggle-mode, the `--request-log` option can only be enabled on the Worker processes, configuring Goose to spread out the overhead of writing logs.
 
-By default, logs are written in JSON Lines format. For example:
+By default, logs are written in JSON Lines format. For example (in this case with `--request-body` also enabled):
 
 ```json
-{"coordinated_omission_elapsed":0,"elapsed":23189,"error":"","final_url":"http://apache/misc/drupal.js?q9apdy","method":"Get","name":"static asset","redirected":false,"response_time":8,"status_code":200,"success":true,"update":false,"url":"http://apache/misc/drupal.js?q9apdy","user":5,"user_cadence":0}
-{"coordinated_omission_elapsed":0,"elapsed":23192,"error":"","final_url":"http://apache/misc/jquery.once.js?v=1.2","method":"Get","name":"static asset","redirected":false,"response_time":6,"status_code":200,"success":true,"update":false,"url":"http://apache/misc/jquery.once.js?v=1.2","user":6,"user_cadence":0}
-{"coordinated_omission_elapsed":0,"elapsed":23181,"error":"","final_url":"http://apache/misc/jquery-extend-3.4.0.js?v=1.4.4","method":"Get","name":"static asset","redirected":false,"response_time":16,"status_code":200,"success":true,"update":false,"url":"http://apache/misc/jquery-extend-3.4.0.js?v=1.4.4","user":1,"user_cadence":0}
+{"coordinated_omission_elapsed":0,"elapsed":13219,"error":"","final_url":"http://apache/misc/jquery-extend-3.4.0.js?v=1.4.4","name":"static asset","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/misc/jquery-extend-3.4.0.js?v=1.4.4"},"redirected":false,"response_time":7,"status_code":200,"success":true,"update":false,"user":4,"user_cadence":0}
+{"coordinated_omission_elapsed":0,"elapsed":13055,"error":"","final_url":"http://apache/node/1786#comment-114852","name":"(Auth) comment form","raw":{"body":"subject=this+is+a+test+comment+subject&comment_body%5Bund%5D%5B0%5D%5Bvalue%5D=this+is+a+test+comment+body&comment_body%5Bund%5D%5B0%5D%5Bformat%5D=filtered_html&form_build_id=form-U0L3wm2SsIKAhVhaHpxeL1TLUHW64DXKifmQeZsUsss&form_token=VKDel_jiYzjqPrekL1FrP2_4EqHTlsaqLjMUJ6pn-sE&form_id=comment_node_article_form&op=Save","headers":["(\"content-type\", \"application/x-www-form-urlencoded\")"],"method":"Post","url":"http://apache/comment/reply/1786"},"redirected":true,"response_time":172,"status_code":200,"success":true,"update":false,"user":1,"user_cadence":0}
+{"coordinated_omission_elapsed":0,"elapsed":13219,"error":"","final_url":"http://apache/misc/drupal.js?q9apdy","name":"static asset","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/misc/drupal.js?q9apdy"},"redirected":false,"response_time":7,"status_code":200,"success":true,"update":false,"user":0,"user_cadence":0}
 ```
 
-Logs include the entire [`GooseRequestMetric`] object as defined in `src/goose.rs`, which are created on all requests.
-
-In the first line of the above example, `GooseUser` thread 7 made a successful `GET` request for `/misc/feed.png`, which takes 4 milliseconds. The second line is `GooseUser` thread 2 making a successful `GET` request for `/user/4816`, which takes 28 milliseconds.
+Logs include the entire [`GooseRequestMetric`] object which also includes the entire [`GooseRawRequest`] object, both defined in `src/goose.rs` and created for all client requests.
 
 By default Goose logs requests in JSON Lines format. The `--request-format` option can be used to log in `csv`, `json` or `raw` format. The `raw` format is Rust's debug output of the entire [`GooseRequestMetric`] object.
 
-For example, `csv` output of similar requests as those logged above would like like:
-```csv
-elapsed,method,name,url,final_url,redirected,response_time,status_code,success,update,user,error,coordinated_omission_elapsed,user_cadence
-22143,GET,"(Anon) user page","http://apache/user/4","http://apache/user/4",false,25,200,true,false,3,,0,0
-22153,GET,"static asset","http://apache/misc/jquery-extend-3.4.0.js?v=1.4.4","http://apache/misc/jquery-extend-3.4.0.js?v=1.4.4",false,16,200,true,false,6,,0,0
-22165,GET,"static asset","http://apache/misc/jquery.js?v=1.4.4","http://apache/misc/jquery.js?v=1.4.4",false,3,200,true,false,0,,0,0
-22165,GET,"static asset","http://apache/misc/feed.png","http://apache/misc/feed.png",false,4,200,true,false,1,,0,0
-```
-
 ## Logging Load Test Tasks
 
-Goose can optionally log details about all load test tasks to a file. To enable, add the `--task-log=task.log` command line option, where `task.log` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
+Goose can optionally log details about all load test tasks to a file. To enable, add the `--task-log task.log` command line option, where `task.log` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
 
 When operating in Gaggle-mode, the `--task-log` option can only be enabled on the Worker processes, configuring Goose to spread out the overhead of writing logs.
 
@@ -707,13 +688,13 @@ See `examples/drupal_loadtest` for an example of how you might invoke log_debug 
 
 Calls to `client.set_failure(tag, Option<request>, Option<headers>, Option<body>)` can be used to tell Goose that a request failed even though the server returned a successful status code, and will automatically invoke `log_debug()` for you. See `examples/drupal_loadtest` and `examples/umami` to see how you might use `set_failure` to generate useful debug logs.
 
-When the load test is run with the `--debug-log=foo` command line option, where `foo` is either a relative or an absolute path, Goose will log all debug generated by calls to `client.log_debug()` (or to `client.set_failure()`) to this file. If the file already exists it will be overwritten. The following is an example debug log file entry:
+When the load test is run with the `--debug-log foo` command line option, where `foo` is either a relative or an absolute path, Goose will log all debug generated by calls to `client.log_debug()` (or to `client.set_failure()`) to this file. If the file already exists it will be overwritten. The following is an example debug log file entry:
 
 ```json
-{"body":"<!DOCTYPE html>\n<html>\n  <head>\n    <title>503 Backend fetch failed</title>\n  </head>\n  <body>\n    <h1>Error 503 Backend fetch failed</h1>\n    <p>Backend fetch failed</p>\n    <h3>Guru Meditation:</h3>\n    <p>XID: 923425</p>\n    <hr>\n    <p>Varnish cache server</p>\n  </body>\n</html>\n","header":"{\"date\": \"Wed, 01 Jul 2020 10:27:31 GMT\", \"server\": \"Varnish\", \"content-type\": \"text/html; charset=utf-8\", \"retry-after\": \"5\", \"x-varnish\": \"923424\", \"age\": \"0\", \"via\": \"1.1 varnish (Varnish/6.1)\", \"x-varnish-cache\": \"MISS\", \"x-varnish-cookie\": \"SESSd7e04cba6a8ba148c966860632ef3636=hejsW1mQnnsHlua0AicCjEpUjnCRTkOLubwL33UJXRU\", \"content-length\": \"283\", \"connection\": \"keep-alive\"}","request":{"elapsed":4192,"final_url":"http://local.dev/node/3247","method":"GET","name":"(Auth) comment form","redirected":false,"response_time":8,"status_code":503,"success":false,"update":false,"url":"http://local.dev/node/3247","user":4},"tag":"post_comment: no form_build_id found on node/3247"}
+{"body":"<!DOCTYPE html>\n<html>\n  <head>\n    <title>503 Backend fetch failed</title>\n  </head>\n  <body>\n    <h1>Error 503 Backend fetch failed</h1>\n    <p>Backend fetch failed</p>\n    <h3>Guru Meditation:</h3>\n    <p>XID: 1506620</p>\n    <hr>\n    <p>Varnish cache server</p>\n  </body>\n</html>\n","header":"{\"date\": \"Mon, 19 Jul 2021 09:21:58 GMT\", \"server\": \"Varnish\", \"content-type\": \"text/html; charset=utf-8\", \"retry-after\": \"5\", \"x-varnish\": \"1506619\", \"age\": \"0\", \"via\": \"1.1 varnish (Varnish/6.1)\", \"x-varnish-cache\": \"MISS\", \"x-varnish-cookie\": \"SESSd7e04cba6a8ba148c966860632ef3636=Z50aRHuIzSE5a54pOi-dK_wbxYMhsMwrG0s2WM2TS20\", \"content-length\": \"284\", \"connection\": \"keep-alive\"}","request":{"coordinated_omission_elapsed":0,"elapsed":9162,"error":"503 Service Unavailable: /node/1439","final_url":"http://apache/node/1439","name":"(Auth) comment form","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/node/1439"},"redirected":false,"response_time":5,"status_code":503,"success":false,"update":false,"user":1,"user_cadence":0},"tag":"post_comment: no form_build_id found on node/1439"}
 ```
 
-If `--debug-log=foo` is not specified at run time, nothing will be logged and there is no measurable overhead in your load test.
+If `--debug-log foo` is not specified at run time, nothing will be logged and there is no measurable overhead in your load test.
 
 By default Goose writes debug logs in JSON Lines format. The `--debug-format` option can be used to log in `json` or `raw` format. The `raw` format is Rust's debug output of the `GooseDebug` object.
 

--- a/examples/umami/admin.rs
+++ b/examples/umami/admin.rs
@@ -36,7 +36,7 @@ pub async fn log_in(user: &GooseUser) -> GooseTaskResult {
                     let title = "Log in";
                     if !common::valid_title(&html, title) {
                         return user.set_failure(
-                            &format!("{}: title not found: {}", &goose.request.url, title),
+                            &format!("{}: title not found: {}", &goose.request.raw.url, title),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -51,7 +51,7 @@ pub async fn log_in(user: &GooseUser) -> GooseTaskResult {
                     let form_build_id = common::get_form_value(&html, "form_build_id");
                     if form_build_id.is_none() {
                         return user.set_failure(
-                            &format!("{}: no form_build_id on page", goose.request.url),
+                            &format!("{}: no form_build_id on page", goose.request.raw.url),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -84,7 +84,7 @@ pub async fn log_in(user: &GooseUser) -> GooseTaskResult {
                 }
                 Err(e) => {
                     return user.set_failure(
-                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
                         &mut goose.request,
                         Some(&headers),
                         None,
@@ -94,7 +94,7 @@ pub async fn log_in(user: &GooseUser) -> GooseTaskResult {
         }
         Err(e) => {
             return user.set_failure(
-                &format!("{}: no response from server: {}", goose.request.url, e),
+                &format!("{}: no response from server: {}", goose.request.raw.url, e),
                 &mut goose.request,
                 None,
                 None,
@@ -131,7 +131,7 @@ pub async fn edit_article(user: &GooseUser) -> GooseTaskResult {
                     let title = "Edit Article";
                     if !common::valid_title(&html, title) {
                         return user.set_failure(
-                            &format!("{}: title not found: {}", &goose.request.url, title),
+                            &format!("{}: title not found: {}", &goose.request.raw.url, title),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -146,7 +146,7 @@ pub async fn edit_article(user: &GooseUser) -> GooseTaskResult {
                     let form_build_id = common::get_form_value(&html, "form_build_id");
                     if form_build_id.is_none() {
                         return user.set_failure(
-                            &format!("{}: no form_build_id on page", goose.request.url),
+                            &format!("{}: no form_build_id on page", goose.request.raw.url),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -155,7 +155,7 @@ pub async fn edit_article(user: &GooseUser) -> GooseTaskResult {
                     let form_token = common::get_form_value(&html, "form_token");
                     if form_token.is_none() {
                         return user.set_failure(
-                            &format!("{}: no form_token on page", goose.request.url),
+                            &format!("{}: no form_token on page", goose.request.raw.url),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -186,7 +186,7 @@ pub async fn edit_article(user: &GooseUser) -> GooseTaskResult {
                 }
                 Err(e) => {
                     return user.set_failure(
-                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
                         &mut goose.request,
                         Some(&headers),
                         None,
@@ -196,7 +196,7 @@ pub async fn edit_article(user: &GooseUser) -> GooseTaskResult {
         }
         Err(e) => {
             return user.set_failure(
-                &format!("{}: no response from server: {}", goose.request.url, e),
+                &format!("{}: no response from server: {}", goose.request.raw.url, e),
                 &mut goose.request,
                 None,
                 None,

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -462,7 +462,7 @@ pub async fn validate_and_load_static_assets(
                 Ok(html) => {
                     if !valid_title(&html, &title) {
                         return user.set_failure(
-                            &format!("{}: title not found: {}", goose.request.url, title),
+                            &format!("{}: title not found: {}", goose.request.raw.url, title),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -473,7 +473,7 @@ pub async fn validate_and_load_static_assets(
                 }
                 Err(e) => {
                     return user.set_failure(
-                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
                         &mut goose.request,
                         Some(&headers),
                         None,
@@ -483,7 +483,7 @@ pub async fn validate_and_load_static_assets(
         }
         Err(e) => {
             return user.set_failure(
-                &format!("{}: no response from server: {}", goose.request.url, e),
+                &format!("{}: no response from server: {}", goose.request.raw.url, e),
                 &mut goose.request,
                 None,
                 None,
@@ -529,7 +529,7 @@ pub async fn anonymous_contact_form(user: &GooseUser, english: bool) -> GooseTas
                     };
                     if !valid_title(&html, title) {
                         return user.set_failure(
-                            &format!("{}: title not found: {}", goose.request.url, title),
+                            &format!("{}: title not found: {}", goose.request.raw.url, title),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -544,7 +544,7 @@ pub async fn anonymous_contact_form(user: &GooseUser, english: bool) -> GooseTas
                     let form_build_id = get_form_value(&html, "form_build_id");
                     if form_build_id.is_none() {
                         return user.set_failure(
-                            &format!("{}: no form_build_id on page", goose.request.url),
+                            &format!("{}: no form_build_id on page", goose.request.raw.url),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -570,7 +570,7 @@ pub async fn anonymous_contact_form(user: &GooseUser, english: bool) -> GooseTas
                 }
                 Err(e) => {
                     return user.set_failure(
-                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
                         &mut goose.request,
                         Some(&headers),
                         None,
@@ -580,7 +580,7 @@ pub async fn anonymous_contact_form(user: &GooseUser, english: bool) -> GooseTas
         }
         Err(e) => {
             return user.set_failure(
-                &format!("{}: no response from server: {}", goose.request.url, e),
+                &format!("{}: no response from server: {}", goose.request.raw.url, e),
                 &mut goose.request,
                 None,
                 None,
@@ -614,7 +614,7 @@ pub async fn anonymous_contact_form(user: &GooseUser, english: bool) -> GooseTas
                 }
                 Err(e) => {
                     return user.set_failure(
-                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
                         &mut goose.request,
                         Some(&headers),
                         None,
@@ -624,7 +624,7 @@ pub async fn anonymous_contact_form(user: &GooseUser, english: bool) -> GooseTas
         }
         Err(e) => {
             return user.set_failure(
-                &format!("{}: no response from server: {}", goose.request.url, e),
+                &format!("{}: no response from server: {}", goose.request.raw.url, e),
                 &mut goose.request,
                 None,
                 None,
@@ -661,7 +661,7 @@ pub async fn search(user: &GooseUser, english: bool) -> GooseTaskResult {
                     let title = if english { "Search" } else { "Buscar" };
                     if !valid_title(&html, title) {
                         return user.set_failure(
-                            &format!("{}: title not found: {}", goose.request.url, title),
+                            &format!("{}: title not found: {}", goose.request.raw.url, title),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -676,7 +676,7 @@ pub async fn search(user: &GooseUser, english: bool) -> GooseTaskResult {
                     let form_build_id = get_form_value(&html, "form_build_id");
                     if form_build_id.is_none() {
                         return user.set_failure(
-                            &format!("{}: no form_build_id on page", goose.request.url),
+                            &format!("{}: no form_build_id on page", goose.request.raw.url),
                             &mut goose.request,
                             Some(&headers),
                             Some(&html),
@@ -709,7 +709,7 @@ pub async fn search(user: &GooseUser, english: bool) -> GooseTaskResult {
                 }
                 Err(e) => {
                     return user.set_failure(
-                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
                         &mut goose.request,
                         Some(&headers),
                         None,
@@ -719,7 +719,7 @@ pub async fn search(user: &GooseUser, english: bool) -> GooseTaskResult {
         }
         Err(e) => {
             return user.set_failure(
-                &format!("{}: no response from server: {}", goose.request.url, e),
+                &format!("{}: no response from server: {}", goose.request.raw.url, e),
                 &mut goose.request,
                 None,
                 None,
@@ -737,7 +737,7 @@ pub async fn search(user: &GooseUser, english: bool) -> GooseTaskResult {
                         return user.set_failure(
                             &format!(
                                 "{}: search terms ({}) not on page",
-                                goose.request.url, &search_phrase
+                                goose.request.raw.url, &search_phrase
                             ),
                             &mut goose.request,
                             Some(&headers),
@@ -750,7 +750,7 @@ pub async fn search(user: &GooseUser, english: bool) -> GooseTaskResult {
                 }
                 Err(e) => {
                     return user.set_failure(
-                        &format!("{}: failed to parse page: {}", goose.request.url, e),
+                        &format!("{}: failed to parse page: {}", goose.request.raw.url, e),
                         &mut goose.request,
                         Some(&headers),
                         None,
@@ -760,7 +760,7 @@ pub async fn search(user: &GooseUser, english: bool) -> GooseTaskResult {
         }
         Err(e) => {
             return user.set_failure(
-                &format!("{}: no response from server: {}", goose.request.url, e),
+                &format!("{}: no response from server: {}", goose.request.raw.url, e),
                 &mut goose.request,
                 None,
                 None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,7 @@ const DEFAULT_PORT: &str = "5115";
 /// --report-file NAME         Create an html-formatted report
 /// -R, --request-log NAME     Sets request log file name
 /// --request-format FORMAT    Sets request log format (csv, json, raw)
+/// --request-body             Include the request body in the request log
 /// -T, --task-log NAME        Sets task log file name
 /// --task-format FORMAT       Sets task log format (csv, json, raw)
 /// -E, --error-log NAME       Sets error log file name
@@ -156,6 +157,9 @@ pub struct GooseConfiguration {
     /// Sets request log format (csv, json, raw)
     #[options(no_short, meta = "FORMAT")]
     pub request_format: Option<GooseLogFormat>,
+    /// Include the request body in the request log
+    #[options(no_short)]
+    pub request_body: bool,
     /// Sets task log file name
     #[options(short = "T", meta = "NAME")]
     pub task_log: String,
@@ -278,6 +282,8 @@ pub(crate) struct GooseDefaults {
     pub request_log: Option<String>,
     /// An optional default for the requests log file format.
     pub request_format: Option<GooseLogFormat>,
+    /// An optional default for logging the request body.
+    pub request_body: Option<bool>,
     /// An optional default for the tasks log file name.
     pub task_log: Option<String>,
     /// An optional default for the tasks log file format.
@@ -370,6 +376,8 @@ pub enum GooseDefault {
     RequestLog,
     /// An optional default for the request log file format.
     RequestFormat,
+    /// An optional default for logging the request body.
+    RequestBody,
     /// An optional default for the task log file name.
     TaskLog,
     /// An optional default for the task log file format.
@@ -487,6 +495,7 @@ pub enum GooseDefault {
 ///  - [`GooseDefault::NoResetMetrics`]
 ///  - [`GooseDefault::NoMetrics`]
 ///  - [`GooseDefault::NoTaskMetrics`]
+///  - [`GooseDefault::RequestsBody`]
 ///  - [`GooseDefault::NoErrorSummary`]
 ///  - [`GooseDefault::NoDebugBody`]
 ///  - [`GooseDefault::NoTelnet`]
@@ -573,6 +582,7 @@ impl GooseDefaultType<&str> for GooseAttack {
             | GooseDefault::NoResetMetrics
             | GooseDefault::NoMetrics
             | GooseDefault::NoTaskMetrics
+            | GooseDefault::RequestBody
             | GooseDefault::NoErrorSummary
             | GooseDefault::NoDebugBody
             | GooseDefault::NoTelnet
@@ -660,6 +670,7 @@ impl GooseDefaultType<usize> for GooseAttack {
             GooseDefault::NoResetMetrics
             | GooseDefault::NoMetrics
             | GooseDefault::NoTaskMetrics
+            | GooseDefault::RequestBody
             | GooseDefault::NoErrorSummary
             | GooseDefault::NoDebugBody
             | GooseDefault::NoTelnet
@@ -714,6 +725,7 @@ impl GooseDefaultType<bool> for GooseAttack {
             GooseDefault::NoResetMetrics => self.defaults.no_reset_metrics = Some(value),
             GooseDefault::NoMetrics => self.defaults.no_metrics = Some(value),
             GooseDefault::NoTaskMetrics => self.defaults.no_task_metrics = Some(value),
+            GooseDefault::RequestBody => self.defaults.request_body = Some(value),
             GooseDefault::NoErrorSummary => self.defaults.no_error_summary = Some(value),
             GooseDefault::NoDebugBody => self.defaults.no_debug_body = Some(value),
             GooseDefault::NoTelnet => self.defaults.no_telnet = Some(value),
@@ -807,6 +819,7 @@ impl GooseDefaultType<GooseCoordinatedOmissionMitigation> for GooseAttack {
             GooseDefault::NoResetMetrics
             | GooseDefault::NoMetrics
             | GooseDefault::NoTaskMetrics
+            | GooseDefault::RequestBody
             | GooseDefault::NoErrorSummary
             | GooseDefault::NoDebugBody
             | GooseDefault::NoTelnet
@@ -901,6 +914,7 @@ impl GooseDefaultType<GooseLogFormat> for GooseAttack {
             GooseDefault::NoResetMetrics
             | GooseDefault::NoMetrics
             | GooseDefault::NoTaskMetrics
+            | GooseDefault::RequestBody
             | GooseDefault::NoErrorSummary
             | GooseDefault::NoDebugBody
             | GooseDefault::NoTelnet
@@ -2234,6 +2248,8 @@ mod test {
             .unwrap()
             .set_default(GooseDefault::RequestFormat, GooseLogFormat::Raw)
             .unwrap()
+            .set_default(GooseDefault::RequestBody, true)
+            .unwrap()
             .set_default(GooseDefault::TaskLog, task_log.as_str())
             .unwrap()
             .set_default(GooseDefault::TaskFormat, GooseLogFormat::Raw)
@@ -2282,6 +2298,7 @@ mod test {
         assert!(goose_attack.defaults.hatch_rate == Some(hatch_rate));
         assert!(goose_attack.defaults.log_level == Some(log_level as u8));
         assert!(goose_attack.defaults.goose_log == Some(goose_log));
+        assert!(goose_attack.defaults.request_body == Some(true));
         assert!(goose_attack.defaults.no_debug_body == Some(true));
         assert!(goose_attack.defaults.verbose == Some(verbose as u8));
         assert!(goose_attack.defaults.running_metrics == Some(15));

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1417,9 +1417,17 @@ impl GooseUser {
         let method = goose_method_from_method(request.method().clone())?;
         let request_name = self.get_request_name(&path, request_name);
 
+        // Grab a copy of any headers set by this request, included in the request log
+        // and the debug log.
+        let mut headers: Vec<String> = Vec::new();
+        for header in request.headers() {
+            headers.push(format!("{:?}", header));
+        }
+
         // Record information about the request.
         let mut request_metric = GooseRequestMetric::new(
             method,
+            headers,
             &request_name,
             &request.url().to_string(),
             self.started.elapsed().as_millis(),

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -287,16 +287,18 @@
 use http::method::Method;
 use reqwest::{header, Client, ClientBuilder, RequestBuilder, Response};
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::{fmt, str};
 use std::{future::Future, pin::Pin, time::Instant};
 use tokio::sync::{Mutex, RwLock};
 use url::Url;
 
 use crate::logger::GooseLog;
-use crate::metrics::{GooseCoordinatedOmissionMitigation, GooseMetric, GooseRequestMetric};
+use crate::metrics::{
+    GooseCoordinatedOmissionMitigation, GooseMetric, GooseRawRequest, GooseRequestMetric,
+};
 use crate::{GooseConfiguration, GooseError, WeightedGooseTasks};
 
 /// By default Goose sets the following User-Agent header when making requests.
@@ -1424,12 +1426,27 @@ impl GooseUser {
             headers.push(format!("{:?}", header));
         }
 
+        // If enabled, grab a copy of the request body, included in the request log and
+        // the debug log.
+        let body = if self.config.request_body {
+            // Get a bytes representation of the body, if any.
+            let body_bytes = match request.body() {
+                Some(b) => b.as_bytes().unwrap_or(b""),
+                None => b"",
+            };
+            // Convert the bytes into a &str if valid utf8.
+            str::from_utf8(&body_bytes).unwrap_or("")
+        } else {
+            ""
+        };
+
+        // Record the complete client request, included in the request log and the debug log.
+        let raw_request = GooseRawRequest::new(method, request.url().as_str(), headers, body);
+
         // Record information about the request.
         let mut request_metric = GooseRequestMetric::new(
-            method,
-            headers,
+            raw_request,
             &request_name,
-            &request.url().to_string(),
             self.started.elapsed().as_millis(),
             self.weighted_users_index,
         );
@@ -1451,7 +1468,7 @@ impl GooseUser {
                 request_metric.set_final_url(r.url().as_str());
 
                 // Load test user was redirected.
-                if self.config.sticky_follow && request_metric.url != request_metric.final_url {
+                if self.config.sticky_follow && request_metric.raw.url != request_metric.final_url {
                     let base_url = self.base_url.read().await.to_string();
                     // Check if the URL redirected started with the load test base_url.
                     if !request_metric.final_url.starts_with(&base_url) {
@@ -1612,8 +1629,8 @@ impl GooseUser {
                 info!(
                     "{:.3}s into goose attack: \"{} {}\" [{}] took abnormally long ({} ms){}",
                     request_metric.elapsed as f64 / 1_000.0,
-                    request_metric.method,
-                    request_metric.url,
+                    request_metric.raw.method,
+                    request_metric.raw.url,
                     request_metric.status_code,
                     request_metric.response_time,
                     task_name,
@@ -2747,7 +2764,7 @@ mod tests {
             .expect("get returned unexpected error");
         let status = goose.response.unwrap().status();
         assert_eq!(status, 200);
-        assert_eq!(goose.request.method, GooseMethod::Get);
+        assert_eq!(goose.request.raw.method, GooseMethod::Get);
         assert_eq!(goose.request.name, INDEX_PATH);
         assert!(goose.request.success);
         assert!(!goose.request.update);
@@ -2769,7 +2786,7 @@ mod tests {
             .expect("get returned unexpected error");
         let status = goose.response.unwrap().status();
         assert_eq!(status, 404);
-        assert_eq!(goose.request.method, GooseMethod::Get);
+        assert_eq!(goose.request.raw.method, GooseMethod::Get);
         assert_eq!(goose.request.name, NO_SUCH_PATH);
         assert!(!goose.request.success);
         assert!(!goose.request.update);
@@ -2794,7 +2811,7 @@ mod tests {
         assert_eq!(status, 200);
         let body = unwrapped_response.text().await.unwrap();
         assert_eq!(body, "foo");
-        assert_eq!(goose.request.method, GooseMethod::Post);
+        assert_eq!(goose.request.raw.method, GooseMethod::Post);
         assert_eq!(goose.request.name, COMMENT_PATH);
         assert!(goose.request.success);
         assert!(!goose.request.update);

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -221,9 +221,10 @@ fn error_csv_header() -> String {
 fn requests_csv_header() -> String {
     // No quotes needed in header.
     format!(
-        "{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
+        "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
         "elapsed",
         "method",
+        "headers",
         "name",
         "url",
         "final_url",
@@ -351,9 +352,10 @@ impl GooseLogger<GooseRequestMetric> for GooseConfiguration {
     fn prepare_csv(&self, request: &GooseRequestMetric) -> String {
         format!(
             // Put quotes around name, url and final_url as they are strings.
-            "{},{},\"{}\",\"{}\",\"{}\",{},{},{},{},{},{},{},{},{}",
+            "{},{},\"{:?}\",\"{}\",\"{}\",\"{}\",{},{},{},{},{},{},{},{},{}",
             request.elapsed,
             request.method,
+            request.headers,
             request.name,
             request.url,
             request.final_url,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -704,7 +704,17 @@ impl GooseConfiguration {
 
         // If the request_log is enabled, allocate a buffer and open the file.
         let mut request_log = self
-            .open_log_file(&self.request_log, "request log", 64 * 1024)
+            .open_log_file(
+                &self.request_log,
+                "request log",
+                if self.request_body {
+                    // Allocate a larger 8M buffer if logging request body.
+                    8 * 1024 * 1024
+                } else {
+                    // Allocate a smaller 64K buffer if not logging request body.
+                    64 * 1024
+                },
+            )
             .await;
         // If the request_log is a CSV, write the header.
         if self.request_format == Some(GooseLogFormat::Csv) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -264,6 +264,8 @@ pub struct GooseRequestMetric {
     pub elapsed: u64,
     /// The method being used (ie, Get, Post, etc).
     pub method: GooseMethod,
+    /// Any headers set by the client when making the request.
+    pub headers: Vec<String>,
     /// The optional name of the request.
     pub name: String,
     /// The full URL that was requested.
@@ -295,6 +297,7 @@ pub struct GooseRequestMetric {
 impl GooseRequestMetric {
     pub(crate) fn new(
         method: GooseMethod,
+        headers: Vec<String>,
         name: &str,
         url: &str,
         elapsed: u128,
@@ -303,6 +306,7 @@ impl GooseRequestMetric {
         GooseRequestMetric {
             elapsed: elapsed as u64,
             method,
+            headers,
             name: name.to_string(),
             url: url.to_string(),
             final_url: "".to_string(),
@@ -3065,7 +3069,7 @@ mod test {
     #[test]
     fn goose_raw_request() {
         const PATH: &str = "http://127.0.0.1/";
-        let mut raw_request = GooseRequestMetric::new(GooseMethod::Get, "/", PATH, 0, 0);
+        let mut raw_request = GooseRequestMetric::new(GooseMethod::Get, vec![], "/", PATH, 0, 0);
         assert_eq!(raw_request.method, GooseMethod::Get);
         assert_eq!(raw_request.name, "/".to_string());
         assert_eq!(raw_request.url, PATH.to_string());

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -250,6 +250,37 @@ pub type GooseTaskMetrics = Vec<Vec<GooseTaskMetricAggregate>>;
 /// ```
 pub type GooseErrorMetrics = BTreeMap<String, GooseErrorMetricAggregate>;
 
+/// For tracking and logging requests made during a load test.
+///
+/// The raw request that the GooseClient is making. Is included in the [`GooseRequestMetric`]
+/// when metrics are enabled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GooseRawRequest {
+    /// The method being used (ie, Get, Post, etc).
+    pub method: GooseMethod,
+    /// The full URL that was requested.
+    pub url: String,
+    /// Any headers set by the client when making the request.
+    pub headers: Vec<String>,
+    /// The body of the request made, if `--request-body` is enabled.
+    pub body: String,
+}
+impl GooseRawRequest {
+    pub(crate) fn new(
+        method: GooseMethod,
+        url: &str,
+        headers: Vec<String>,
+        body: &str,
+    ) -> GooseRawRequest {
+        GooseRawRequest {
+            method,
+            url: url.to_string(),
+            headers,
+            body: body.to_string(),
+        }
+    }
+}
+
 /// For tracking and counting requests made during a load test.
 ///
 /// The request that Goose is making. User threads send this data to the parent thread
@@ -262,14 +293,10 @@ pub type GooseErrorMetrics = BTreeMap<String, GooseErrorMetricAggregate>;
 pub struct GooseRequestMetric {
     /// How many milliseconds the load test has been running.
     pub elapsed: u64,
-    /// The method being used (ie, Get, Post, etc).
-    pub method: GooseMethod,
-    /// Any headers set by the client when making the request.
-    pub headers: Vec<String>,
+    /// The raw request that the GooseClient made.
+    pub raw: GooseRawRequest,
     /// The optional name of the request.
     pub name: String,
-    /// The full URL that was requested.
-    pub url: String,
     /// The final full URL that was requested, after redirects.
     pub final_url: String,
     /// How many milliseconds the request took.
@@ -295,20 +322,11 @@ pub struct GooseRequestMetric {
     pub user_cadence: u64,
 }
 impl GooseRequestMetric {
-    pub(crate) fn new(
-        method: GooseMethod,
-        headers: Vec<String>,
-        name: &str,
-        url: &str,
-        elapsed: u128,
-        user: usize,
-    ) -> Self {
+    pub(crate) fn new(raw: GooseRawRequest, name: &str, elapsed: u128, user: usize) -> Self {
         GooseRequestMetric {
             elapsed: elapsed as u64,
-            method,
-            headers,
+            raw,
             name: name.to_string(),
-            url: url.to_string(),
             final_url: "".to_string(),
             redirected: false,
             response_time: 0,
@@ -325,7 +343,7 @@ impl GooseRequestMetric {
     // Record the final URL returned.
     pub(crate) fn set_final_url(&mut self, final_url: &str) {
         self.final_url = final_url.to_string();
-        if self.final_url != self.url {
+        if self.final_url != self.raw.url {
             self.redirected = true;
         }
     }
@@ -2035,12 +2053,10 @@ impl fmt::Display for GooseMetrics {
 pub struct GooseErrorMetric {
     /// How many milliseconds the load test has been running.
     pub elapsed: u64,
-    /// The method that was used (ie, Get, Post, etc).
-    pub method: GooseMethod,
+    /// The raw request that the GooseClient made.
+    pub raw: GooseRawRequest,
     /// The optional name of the request.
     pub name: String,
-    /// The full URL that was requested.
-    pub url: String,
     /// The final full URL that was requested, after redirects.
     pub final_url: String,
     /// Whether or not the request was redirected.
@@ -2222,12 +2238,12 @@ impl GooseAttack {
     // `GooseMetrics.requests` `HashMap`, merging if already existing, or creating new.
     // Also writes it to the request_file if enabled.
     async fn record_request_metric(&mut self, request_metric: &GooseRequestMetric) {
-        let key = format!("{} {}", request_metric.method, request_metric.name);
+        let key = format!("{} {}", request_metric.raw.method, request_metric.name);
         let mut merge_request = match self.metrics.requests.get(&key) {
             Some(m) => m.clone(),
             None => GooseRequestMetricAggregate::new(
                 &request_metric.name,
-                request_metric.method.clone(),
+                request_metric.raw.method.clone(),
                 0,
             ),
         };
@@ -2348,9 +2364,8 @@ impl GooseAttack {
                 // will fail which we ignore.
                 let _ = logger.send(Some(GooseLog::Error(GooseErrorMetric {
                     elapsed: raw_request.elapsed,
-                    method: raw_request.method.clone(),
+                    raw: raw_request.raw.clone(),
                     name: raw_request.name.clone(),
-                    url: raw_request.url.clone(),
                     final_url: raw_request.final_url.clone(),
                     redirected: raw_request.redirected,
                     response_time: raw_request.response_time,
@@ -2369,7 +2384,7 @@ impl GooseAttack {
         // Create a string to uniquely identify errors for tracking metrics.
         let error_string = format!(
             "{}.{}.{}",
-            raw_request.error, raw_request.method, raw_request.name
+            raw_request.error, raw_request.raw.method, raw_request.name
         );
 
         let mut error_metrics = match self.metrics.errors.get(&error_string) {
@@ -2377,7 +2392,7 @@ impl GooseAttack {
             Some(m) => m.clone(),
             // First time we've seen this error.
             None => GooseErrorMetricAggregate::new(
-                raw_request.method.clone(),
+                raw_request.raw.method.clone(),
                 raw_request.name.to_string(),
                 raw_request.error.to_string(),
             ),
@@ -3069,34 +3084,35 @@ mod test {
     #[test]
     fn goose_raw_request() {
         const PATH: &str = "http://127.0.0.1/";
-        let mut raw_request = GooseRequestMetric::new(GooseMethod::Get, vec![], "/", PATH, 0, 0);
-        assert_eq!(raw_request.method, GooseMethod::Get);
-        assert_eq!(raw_request.name, "/".to_string());
-        assert_eq!(raw_request.url, PATH.to_string());
-        assert_eq!(raw_request.response_time, 0);
-        assert_eq!(raw_request.status_code, 0);
-        assert!(raw_request.success);
-        assert!(!raw_request.update);
+        let raw_request = GooseRawRequest::new(GooseMethod::Get, PATH, vec![], "");
+        let mut request_metric = GooseRequestMetric::new(raw_request, "/", 0, 0);
+        assert_eq!(request_metric.raw.method, GooseMethod::Get);
+        assert_eq!(request_metric.raw.url, PATH.to_string());
+        assert_eq!(request_metric.name, "/".to_string());
+        assert_eq!(request_metric.response_time, 0);
+        assert_eq!(request_metric.status_code, 0);
+        assert!(request_metric.success);
+        assert!(!request_metric.update);
 
         let response_time = 123;
-        raw_request.set_response_time(response_time);
-        assert_eq!(raw_request.method, GooseMethod::Get);
-        assert_eq!(raw_request.name, "/".to_string());
-        assert_eq!(raw_request.url, PATH.to_string());
-        assert_eq!(raw_request.response_time, response_time as u64);
-        assert_eq!(raw_request.status_code, 0);
-        assert!(raw_request.success);
-        assert!(!raw_request.update);
+        request_metric.set_response_time(response_time);
+        assert_eq!(request_metric.raw.method, GooseMethod::Get);
+        assert_eq!(request_metric.name, "/".to_string());
+        assert_eq!(request_metric.raw.url, PATH.to_string());
+        assert_eq!(request_metric.response_time, response_time as u64);
+        assert_eq!(request_metric.status_code, 0);
+        assert!(request_metric.success);
+        assert!(!request_metric.update);
 
         let status_code = http::StatusCode::OK;
-        raw_request.set_status_code(Some(status_code));
-        assert_eq!(raw_request.method, GooseMethod::Get);
-        assert_eq!(raw_request.name, "/".to_string());
-        assert_eq!(raw_request.url, PATH.to_string());
-        assert_eq!(raw_request.response_time, response_time as u64);
-        assert_eq!(raw_request.status_code, 200);
-        assert!(raw_request.success);
-        assert!(!raw_request.update);
+        request_metric.set_status_code(Some(status_code));
+        assert_eq!(request_metric.raw.method, GooseMethod::Get);
+        assert_eq!(request_metric.name, "/".to_string());
+        assert_eq!(request_metric.raw.url, PATH.to_string());
+        assert_eq!(request_metric.response_time, response_time as u64);
+        assert_eq!(request_metric.status_code, 200);
+        assert!(request_metric.success);
+        assert!(!request_metric.update);
     }
 
     #[test]


### PR DESCRIPTION
  - add all client request `headers` to the `GooseRequestMetric`, so they are included in the request log and the debug log
  - introduce `GooseRawMetric` which contains the `method`, `url`, `headers` and `body` of the client request made, and is now contained in `raw` field of the `GooseRequestMetric` (API change)
  - introduce `--request-body` (and `GooseDefault::RequestBody`) which when enabled shows up in the `body` field of the `GooseRawMetric`
  - add `GooseRawMetric` to the request log, debug log and error log
  - fix #332 

This shows up in the Request log (see the second entry which is a POST and therefor has a request body and header):
```json
{"coordinated_omission_elapsed":0,"elapsed":13047,"error":"","final_url":"http://apache/node/84","name":"(Anon) node page","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/node/84"},"redirected":false,"response_time":142,"status_code":200,"success":true,"update":false,"user":4,"user_cadence":0}
{"coordinated_omission_elapsed":0,"elapsed":13055,"error":"","final_url":"http://apache/node/1786#comment-114852","name":"(Auth) comment form","raw":{"body":"subject=this+is+a+test+comment+subject&comment_body%5Bund%5D%5B0%5D%5Bvalue%5D=this+is+a+test+comment+body&comment_body%5Bund%5D%5B0%5D%5Bformat%5D=filtered_html&form_build_id=form-U0L3wm2SsIKAhVhaHpxeL1TLUHW64DXKifmQeZsUsss&form_token=VKDel_jiYzjqPrekL1FrP2_4EqHTlsaqLjMUJ6pn-sE&form_id=comment_node_article_form&op=Save","headers":["(\"content-type\", \"application/x-www-form-urlencoded\")"],"method":"Post","url":"http://apache/comment/reply/1786"},"redirected":true,"response_time":172,"status_code":200,"success":true,"update":false,"user":1,"user_cadence":0}
```

And in the Error log:
```json
{"elapsed":9372,"error":"503 Service Unavailable: /","final_url":"http://apache/","name":"(Auth) front page","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/"},"redirected":false,"response_time":5,"status_code":503,"user":1}
{"elapsed":9377,"error":"503 Service Unavailable: /node/7759","final_url":"http://apache/node/7759","name":"(Anon) node page","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/node/7759"},"redirected":false,"response_time":6,"status_code":503,"user":3}
{"elapsed":9378,"error":"503 Service Unavailable: /node/7297","final_url":"http://apache/node/7297","name":"(Auth) node page","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/node/7297"},"redirected":false,"response_time":5,"status_code":503,"user":1}
```

And in the Debug log:
```json
{"body":"<!DOCTYPE html>\n<html>\n  <head>\n    <title>503 Backend fetch failed</title>\n  </head>\n  <body>\n    <h1>Error 503 Backend fetch failed</h1>\n    <p>Backend fetch failed</p>\n    <h3>Guru Meditation:</h3>\n    <p>XID: 1506690</p>\n    <hr>\n    <p>Varnish cache server</p>\n  </body>\n</html>\n","header":"{\"date\": \"Mon, 19 Jul 2021 09:21:58 GMT\", \"server\": \"Varnish\", \"content-type\": \"text/html; charset=utf-8\", \"retry-after\": \"5\", \"x-varnish\": \"1506689\", \"age\": \"0\", \"via\": \"1.1 varnish (Varnish/6.1)\", \"x-varnish-cache\": \"MISS\", \"x-varnish-cookie\": \"SESSd7e04cba6a8ba148c966860632ef3636=Z50aRHuIzSE5a54pOi-dK_wbxYMhsMwrG0s2WM2TS20\", \"content-length\": \"284\", \"connection\": \"keep-alive\"}","request":{"coordinated_omission_elapsed":0,"elapsed":9391,"error":"503 Service Unavailable: /node/3062","final_url":"http://apache/node/3062","name":"(Auth) comment form","raw":{"body":"","headers":[],"method":"Get","url":"http://apache/node/3062"},"redirected":false,"response_time":6,"status_code":503,"success":false,"update":false,"user":1,"user_cadence":0},"tag":"post_comment: no form_build_id found on node/3062"}
```
