### PR TITLE
release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.13.0-dev
+## 0.13.0 July 19, 2021
   - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) support and set Accept-Encoding header by default in the client; disable with `--no-gzip` or `GooseDefault::NoGzip`
   - document how to add custom cookies (https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#custom-cookies)
   - update [`rustc_version`](https://docs.rs/rustc_version) dependency to `0.4`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.13.0-dev"
+version = "0.13.0"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This creates a new directory named `loadtest/` containing `loadtest/Cargo.toml` 
 
 ```toml
 [dependencies]
-goose = "^0.12"
+goose = "^0.13"
 ```
 
 At this point it's possible to compile all dependencies, though the resulting binary only displays "Hello, world!":
@@ -50,9 +50,9 @@ At this point it's possible to compile all dependencies, though the resulting bi
 ```
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.12.1
+  Downloaded goose v0.13.0
       ...
-   Compiling goose v0.12.1
+   Compiling goose v0.13.0
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`
@@ -537,7 +537,7 @@ Trying 127.0.0.1...
 Connected to localhost.
 Escape character is '^]'.
 goose> ?
-goose 0.12.1 controller commands:
+goose 0.13.0 controller commands:
  help (?)           this help
  exit (quit)        exit controller
  start              start an idle load test
@@ -830,7 +830,7 @@ When writing load test applications, you can default to compiling in the Gaggle 
 
 ```toml
 [dependencies]
-goose = { version = "^0.12", features = ["gaggle"] }
+goose = { version = "^0.13", features = ["gaggle"] }
 ```
 
 ### Gaggle Manager
@@ -890,5 +890,5 @@ By default Reqwest (and therefore Goose) uses the system-native transport layer 
 
 ```toml
 [dependencies]
-goose = { version = "^0.12", default-features = false, features = ["rustls-tls"] }
+goose = { version = "^0.13", default-features = false, features = ["rustls-tls"] }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! goose = "0.12"
+//! goose = "0.13"
 //! ```
 //!
 //! Add the following boilerplate `use` declaration at the top of your `src/main.rs`:


### PR DESCRIPTION
## 0.13.0 July 19, 2021
  - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) support and set Accept-Encoding header by default in the client; disable with `--no-gzip` or `GooseDefault::NoGzip`
  - document how to add custom cookies (https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#custom-cookies)
  - update [`rustc_version`](https://docs.rs/rustc_version) dependency to `0.4`
  - include client request headers in `GooseRequestMetric` so they show up in the request log and the debug log
  - introduce `GooseRawMetric` which contains the `method`, `url`, `headers` and `body` of the client request made, and is now contained in `raw` field of the `GooseRequestMetric` (API change)
  - introduce `--request-body` (and `GooseDefault::RequestBody`) which when enabled shows up in the `body` field of the `GooseRawMetric`
  - add `GooseRawMetric` to the request log, debug log and error log
