### PR TITLE
test coverage to confirm base_url can include path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.13.1-dev
+ - add test to confirm a `base_url` can include a path and be joined with a relative path
+
 ## 0.13.0 July 19, 2021
   - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) support and set Accept-Encoding header by default in the client; disable with `--no-gzip` or `GooseDefault::NoGzip`
   - document how to add custom cookies (https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#custom-cookies)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.13.0"
+version = "0.13.1-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -2741,6 +2741,23 @@ mod tests {
         assert_eq!(built_request.method(), &Method::HEAD);
         assert_eq!(built_request.url().as_str(), server.url("/path/to/head"));
         assert_eq!(built_request.timeout(), None);
+
+        // Confirm Goose can build a base_url that includes a path.
+        const HOST_WITH_PATH: &str = "http://example.com/with/path/";
+        let base_url = get_base_url(Some(HOST_WITH_PATH.to_string()), None, None).unwrap();
+        let user = GooseUser::new(0, base_url, 0, 0, &configuration, 0).unwrap();
+
+        // Confirm the URLs are correctly built using the default_host that includes a path.
+        let url = user.build_url("foo").await.unwrap();
+        assert_eq!(&url, &[HOST_WITH_PATH, "foo"].concat());
+        let url = user.build_url("bar/").await.unwrap();
+        assert_eq!(&url, &[HOST_WITH_PATH, "bar/"].concat());
+        let url = user.build_url("foo/bar").await.unwrap();
+        assert_eq!(&url, &[HOST_WITH_PATH, "foo/bar"].concat());
+
+        // Confirm that URLs are correctly re-written if an absolute path is used.
+        let url = user.build_url("/foo").await.unwrap();
+        assert_eq!(&url, &[HOST, "foo"].concat());
     }
 
     #[tokio::test]


### PR DESCRIPTION
 - add a test to confirm that a `base_url` can include a path, for example `https://example.com/with/path`
 - a relative path will be appended to the above `base_url` including `/with/path/`
 - an absolute path will replace `/with/path/`