### PR TITLE
fix a documentation error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Build
       run: cargo build --verbose --all-features
     - name: Docs
-      run: cargo rustdoc --lib --examples
+      run: cargo rustdoc --lib --all-features --examples
     - name: Run tests
       run: cargo test --verbose --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.13.1-dev
  - add test to confirm a `base_url` can include a path and be joined with a relative path
+ - fix documentation typo
 
 ## 0.13.0 July 19, 2021
   - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) support and set Accept-Encoding header by default in the client; disable with `--no-gzip` or `GooseDefault::NoGzip`

--- a/src/config.rs
+++ b/src/config.rs
@@ -495,7 +495,7 @@ pub enum GooseDefault {
 ///  - [`GooseDefault::NoResetMetrics`]
 ///  - [`GooseDefault::NoMetrics`]
 ///  - [`GooseDefault::NoTaskMetrics`]
-///  - [`GooseDefault::RequestsBody`]
+///  - [`GooseDefault::RequestBody`]
 ///  - [`GooseDefault::NoErrorSummary`]
 ///  - [`GooseDefault::NoDebugBody`]
 ///  - [`GooseDefault::NoTelnet`]


### PR DESCRIPTION
 - fix typo where `GooseDefault::RequestBody` was incorrectly referenced as `GooseDefault::RequestsBody`