### PR TITLE
introduce `pretty` log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.13.1-dev
  - add test to confirm a `base_url` can include a path and be joined with a relative path
  - fix documentation typo
+ - introduce `pretty` log format for `--error-format`, `--debug-format`, `--request-format`, and `--task-format`
 
 ## 0.13.0 July 19, 2021
   - enable [`gzip`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.gzip) support and set Accept-Encoding header by default in the client; disable with `--no-gzip` or `GooseDefault::NoGzip`

--- a/README.md
+++ b/README.md
@@ -225,14 +225,14 @@ Metrics:
   --no-error-summary         Doesn't display an error summary
   --report-file NAME         Create an html-formatted report
   -R, --request-log NAME     Sets request log file name
-  --request-format FORMAT    Sets request log format (csv, json, raw)
+  --request-format FORMAT    Sets request log format (csv, json, raw, pretty)
   --request-body             Include the request body in the request log
   -T, --task-log NAME        Sets task log file name
-  --task-format FORMAT       Sets task log format (csv, json, raw)
+  --task-format FORMAT       Sets task log format (csv, json, raw, pretty)
   -E, --error-log NAME       Sets error log file name
-  --error-format FORMAT      Sets error log format (csv, json, raw)
+  --error-format FORMAT      Sets error log format (csv, json, raw, pretty)
   -D, --debug-log NAME       Sets debug log file name
-  --debug-format FORMAT      Sets debug log format (csv, json, raw)
+  --debug-format FORMAT      Sets debug log format (csv, json, raw, pretty)
   --no-debug-body            Do not include the response body in the debug log
   --status-codes             Tracks additional status code metrics
 
@@ -624,7 +624,7 @@ By default, logs are written in JSON Lines format. For example:
 
 Logs include the entire [`GooseErrorMetric`] object as defined in `src/goose.rs`, which are created when requests result in an error.
 
-By default Goose logs errors in JSON Lines format. The `--errors-format` option can be used to log in `csv`, `json` or `raw` format. The `raw` format is Rust's debug output of the entire [`GooseErrorMetric`] object.
+By default Goose logs errors in JSON Lines format. The `--errors-format` option can be used to log in `csv`, `json`, `raw` or `pretty` format. The `raw` format is Rust's debug output of the entire [`GooseErrorMetric`] object.
 
 ## Logging Load Test Requests
 
@@ -644,7 +644,7 @@ By default, logs are written in JSON Lines format. For example (in this case wit
 
 Logs include the entire [`GooseRequestMetric`] object which also includes the entire [`GooseRawRequest`] object, both defined in `src/goose.rs` and created for all client requests.
 
-By default Goose logs requests in JSON Lines format. The `--request-format` option can be used to log in `csv`, `json` or `raw` format. The `raw` format is Rust's debug output of the entire [`GooseRequestMetric`] object.
+By default Goose logs requests in JSON Lines format. The `--request-format` option can be used to log in `csv`, `json`, `raw` or `pretty` format. The `raw` format is Rust's debug output of the entire [`GooseRequestMetric`] object.
 
 ## Logging Load Test Tasks
 
@@ -666,7 +666,7 @@ Logs include the entire [`GooseTaskMetric`] object as defined in `src/goose.rs`,
 
 In the first line of the above example, `GooseUser` thread 0 succesfully ran the `(Anon) front page` task in 97 milliseconds. In the second line `GooseUser` thread 5 succesfully ran the `(Anon) node page` task in 41 milliseconds.
 
-By default Goose logs tass in JSON Lines format. The `--task-format` option can be used to log in `csv`, `json` or `raw` format. The `raw` format is Rust's debug output of the entire [`GooseTaskMetric`] object.
+By default Goose logs tass in JSON Lines format. The `--task-format` option can be used to log in `csv`, `json`, `raw` or `pretty` format. The `raw` format is Rust's debug output of the entire [`GooseTaskMetric`] object.
 
 For example, `csv` output of similar tasks as those logged above would like like:
 ```csv
@@ -696,7 +696,7 @@ When the load test is run with the `--debug-log foo` command line option, where 
 
 If `--debug-log foo` is not specified at run time, nothing will be logged and there is no measurable overhead in your load test.
 
-By default Goose writes debug logs in JSON Lines format. The `--debug-format` option can be used to log in `json` or `raw` format. The `raw` format is Rust's debug output of the `GooseDebug` object.
+By default Goose writes debug logs in JSON Lines format. The `--debug-format` option can be used to log in `json`, `raw` or `pretty` format. The `raw` format is Rust's debug output of the `GooseDebug` object.
 
 ## Coordinated Omission Mitigation
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,14 +58,14 @@ const DEFAULT_PORT: &str = "5115";
 /// --no-error-summary         Doesn't display an error summary
 /// --report-file NAME         Create an html-formatted report
 /// -R, --request-log NAME     Sets request log file name
-/// --request-format FORMAT    Sets request log format (csv, json, raw)
+/// --request-format FORMAT    Sets request log format (csv, json, raw, pretty)
 /// --request-body             Include the request body in the request log
 /// -T, --task-log NAME        Sets task log file name
-/// --task-format FORMAT       Sets task log format (csv, json, raw)
+/// --task-format FORMAT       Sets task log format (csv, json, raw, pretty)
 /// -E, --error-log NAME       Sets error log file name
-/// --error-format FORMAT      Sets error log format (csv, json, raw)
+/// --error-format FORMAT      Sets error log format (csv, json, raw, pretty)
 /// -D, --debug-log NAME       Sets debug log file name
-/// --debug-format FORMAT      Sets debug log format (csv, json, raw)
+/// --debug-format FORMAT      Sets debug log format (csv, json, raw, pretty)
 /// --no-debug-body            Do not include the response body in the debug log
 /// --status-codes             Tracks additional status code metrics
 ///
@@ -154,7 +154,7 @@ pub struct GooseConfiguration {
     /// Sets request log file name
     #[options(short = "R", meta = "NAME")]
     pub request_log: String,
-    /// Sets request log format (csv, json, raw)
+    /// Sets request log format (csv, json, raw, pretty)
     #[options(no_short, meta = "FORMAT")]
     pub request_format: Option<GooseLogFormat>,
     /// Include the request body in the request log
@@ -163,19 +163,19 @@ pub struct GooseConfiguration {
     /// Sets task log file name
     #[options(short = "T", meta = "NAME")]
     pub task_log: String,
-    /// Sets task log format (csv, json, raw)
+    /// Sets task log format (csv, json, raw, pretty)
     #[options(no_short, meta = "FORMAT")]
     pub task_format: Option<GooseLogFormat>,
     /// Sets error log file name
     #[options(short = "E", meta = "NAME")]
     pub error_log: String,
-    /// Sets error log format (csv, json, raw)
+    /// Sets error log format (csv, json, raw, pretty)
     #[options(no_short, meta = "FORMAT")]
     pub error_format: Option<GooseLogFormat>,
     /// Sets debug log file name
     #[options(short = "D", meta = "NAME")]
     pub debug_log: String,
-    /// Sets debug log format (csv, json, raw)
+    /// Sets debug log format (csv, json, raw, pretty)
     #[options(no_short, meta = "FORMAT")]
     pub debug_format: Option<GooseLogFormat>,
     /// Do not include the response body in the debug log

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -166,6 +166,7 @@ pub enum GooseLogFormat {
     Csv,
     Json,
     Raw,
+    Pretty,
 }
 /// Allow setting log formats from the command line by impleenting [`FromStr`].
 impl FromStr for GooseLogFormat {
@@ -174,8 +175,13 @@ impl FromStr for GooseLogFormat {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Use a [`RegexSet`] to match string representations of `GooseCoordinatedOmissionMitigation`,
         // returning the appropriate enum value. Also match a wide range of abbreviations and synonyms.
-        let log_format = RegexSet::new(&[r"(?i)^csv$", r"(?i)^(json|jsn)$", r"(?i)^raw$"])
-            .expect("failed to compile log_format RegexSet");
+        let log_format = RegexSet::new(&[
+            r"(?i)^csv$",
+            r"(?i)^(json|jsn)$",
+            r"(?i)^raw$",
+            r"(?i)^pretty$",
+        ])
+        .expect("failed to compile log_format RegexSet");
         let matches = log_format.matches(&s);
         if matches.matched(0) {
             Ok(GooseLogFormat::Csv)
@@ -183,6 +189,8 @@ impl FromStr for GooseLogFormat {
             Ok(GooseLogFormat::Json)
         } else if matches.matched(2) {
             Ok(GooseLogFormat::Raw)
+        } else if matches.matched(3) {
+            Ok(GooseLogFormat::Pretty)
         } else {
             Err(GooseError::InvalidOption {
                 option: format!("GooseLogFormat::{:?}", s),
@@ -270,6 +278,8 @@ impl GooseLogger<GooseDebug> for GooseConfiguration {
                 GooseLogFormat::Json => json!(message).to_string(),
                 // Raw format is Debug output for GooseRawRequest structure.
                 GooseLogFormat::Raw => format!("{:?}", message),
+                // Pretty format is Debug Pretty output for GooseRawRequest structure.
+                GooseLogFormat::Pretty => format!("{:#?}", message),
                 // Not yet implemented.
                 GooseLogFormat::Csv => self.prepare_csv(&message),
             }
@@ -299,6 +309,8 @@ impl GooseLogger<GooseErrorMetric> for GooseConfiguration {
                 GooseLogFormat::Json => json!(message).to_string(),
                 // Raw format is Debug output for GooseErrorMetric structure.
                 GooseLogFormat::Raw => format!("{:?}", message),
+                // Pretty format is Debug Pretty output for GooseErrorMetric structure.
+                GooseLogFormat::Pretty => format!("{:#?}", message),
                 // Not yet implemented.
                 GooseLogFormat::Csv => self.prepare_csv(&message),
             }
@@ -335,6 +347,8 @@ impl GooseLogger<GooseRequestMetric> for GooseConfiguration {
                 GooseLogFormat::Json => json!(message).to_string(),
                 // Raw format is Debug output for GooseRequestMetric structure.
                 GooseLogFormat::Raw => format!("{:?}", message),
+                // Pretty format is Debug Pretty output for GooseRequestMetric structure.
+                GooseLogFormat::Pretty => format!("{:#?}", message),
                 // Not yet implemented.
                 GooseLogFormat::Csv => self.prepare_csv(&message),
             }
@@ -375,6 +389,8 @@ impl GooseLogger<GooseTaskMetric> for GooseConfiguration {
                 GooseLogFormat::Json => json!(message).to_string(),
                 // Raw format is Debug output for GooseTaskMetric structure.
                 GooseLogFormat::Raw => format!("{:?}", message),
+                // Pretty format is Debug Pretty output for GooseTaskMetric structure.
+                GooseLogFormat::Pretty => format!("{:#?}", message),
                 // Not yet implemented.
                 GooseLogFormat::Csv => self.prepare_csv(&message),
             }

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -451,6 +451,20 @@ fn test_requests_logs_raw_gaggle() {
 }
 
 #[test]
+// Enable pretty-formatted requests log.
+fn test_requests_logs_pretty() {
+    run_standalone_test(TestType::Requests, "pretty");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable pretty-formatted requests log, in Gaggle mode.
+fn test_requests_logs_pretty_gaggle() {
+    run_gaggle_test(TestType::Requests, "pretty");
+}
+
+#[test]
 // Enable json-formatted tasks log.
 fn test_tasks_logs_json() {
     run_standalone_test(TestType::Tasks, "json");
@@ -577,7 +591,7 @@ fn test_debug_logs_csv_gaggle() {
 }
 
 #[test]
-// Enable raw-formatted debug log and metrics log.
+// Enable raw-formatted logs.
 fn test_all_logs_raw() {
     run_standalone_test(TestType::All, "raw");
 }
@@ -585,7 +599,21 @@ fn test_all_logs_raw() {
 #[test]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
-// Enable raw-formatted debug log and metrics log, in Gaggle mode.
+// Enable raw-formatted logs, in Gaggle mode.
 fn test_all_logs_raw_gaggle() {
     run_gaggle_test(TestType::All, "raw");
+}
+
+#[test]
+// Enable pretty-formatted logs.
+fn test_all_logs_pretty() {
+    run_standalone_test(TestType::All, "pretty");
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+// Enable pretty-formatted logs, in Gaggle mode.
+fn test_all_logs_pretty_gaggle() {
+    run_gaggle_test(TestType::All, "pretty");
 }


### PR DESCRIPTION
 - introduce `pretty` log format for `--error-format`, `--debug-format`, `--request-format`, and `--task-format`

For example, here's a request log "line" that's pretty formatted:
```
GooseRequestMetric {
    elapsed: 2,
    raw: GooseRawRequest {
        method: Get,
        url: "http://apache/",
        headers: [],
        body: "",
    },
    name: "(Anon) front page",
    final_url: "http://apache/",
    redirected: false,
    response_time: 124,
    status_code: 200,
    success: true,
    update: false,
    user: 0,
    error: "",
    coordinated_omission_elapsed: 0,
    user_cadence: 0,
}
```