### PR TITLE
general documentation cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## 0.13.2-dev
- - fix broken links within the documentation
- - introduce `--startup-time` which can be set together with `--users` instead of using `--hatch-rate` to configure how quickly to start users, fix `--run-time` to always start counting after all users are fully started; include starting and stopping time in addition to running time in text metrics and html report
+ - fix broken links within the documentation; general documentation cleanups
+ - introduce `--startup-time` which can be set together with `--users` instead of using `--hatch-rate` to configure how quickly to start users
+ - fix `--run-time` to always start counting after all users are fully started
+ - include starting and stopping time in addition to running time in text metrics and html report
 
 ## 0.13.1 August 13, 2021
  - add test to confirm a `base_url` can include a path and be joined with a relative path

--- a/src/config.rs
+++ b/src/config.rs
@@ -486,7 +486,7 @@ pub enum GooseDefault {
 /// [`usize`] integer:
 ///  - [`GooseDefault::Users`]
 ///  - [`GooseDefault::HatchRate`]
-///  - [`GooseDefault::StatupTime`]
+///  - [`GooseDefault::StartupTime`]
 ///  - [`GooseDefault::RunTime`]
 ///  - [`GooseDefault::RunningMetrics`]
 ///  - [`GooseDefault::LogLevel`]

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1755,8 +1755,7 @@ impl GooseUser {
     /// or is called on a request that was already an error, only the first error will
     /// be collected.
     ///
-    /// This also calls
-    /// [`log_debug`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.log_debug).
+    /// This also calls [`GooseUser::log_debug`].
     ///
     /// # Example
     /// ```rust
@@ -1829,9 +1828,7 @@ impl GooseUser {
     /// can be set to prevent the debug log from including the response body. When this option
     /// is enabled, the body will always show up as `null` in the debug log.
     ///
-    /// Calls to
-    /// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_failure)
-    /// automatically invoke `log_debug`.
+    /// Calls to [`GooseUser::set_failure`] automatically invoke `log_debug`.
     ///
     /// To enable the debug log, a load test must be run with the `--debug-log-file=foo`
     /// option set, where `foo` is either a relative or an absolute path of the log file

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -49,7 +49,7 @@ pub enum GooseMetric {
     Task(GooseTaskMetric),
 }
 
-/// THIS IS IN EXPERIMENTAL FEATURE, DISABLED BY DEFAULT. Optionally mitigate the loss of data
+/// THIS IS AN EXPERIMENTAL FEATURE, DISABLED BY DEFAULT. Optionally mitigate the loss of data
 /// (coordinated omission) due to stalls on the upstream server.
 ///
 /// Stalling can happen for many reasons, for example: garbage collection, a cache stampede,
@@ -286,10 +286,9 @@ impl GooseRawRequest {
 ///
 /// The request that Goose is making. User threads send this data to the parent thread
 /// when metrics are enabled. This request object must be provided to calls to
-/// [`set_success`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_success)
-/// or
-/// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_failure)
-/// so Goose knows which request is being updated.
+/// [`set_success`](../goose/struct.GooseUser.html#method.set_success) or
+/// [`set_failure`](../goose/struct.GooseUser.html#method.set_failure) so Goose
+/// knows which request is being updated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GooseRequestMetric {
     /// How many milliseconds the load test has been running.
@@ -319,7 +318,7 @@ pub struct GooseRequestMetric {
     pub coordinated_omission_elapsed: u64,
     /// If non-zero, the calculated cadence of looping through all
     /// [`GooseTask`](../goose/struct.GooseTask.html)s by this
-    /// [`GooseUser`](../goose/struct.GooseUser.html).
+    /// [`GooseUser`](../goose/struct.GooseUser.html) thread.
     pub user_cadence: u64,
 }
 impl GooseRequestMetric {
@@ -827,13 +826,14 @@ pub struct GooseMetrics {
     /// A hash of the load test, primarily used to validate all Workers in a Gaggle
     /// are running the same load test.
     pub hash: u64,
-    /// An optional system timestamp indicating when the load test started.
+    /// Tracks when the load test first started with an optional system timestamp.
     pub starting: Option<DateTime<Local>>,
-    /// An optional system timestamp indicating when all GooseUsers started.
+    /// Tracks when all [`GooseUser`](../goose/struct.GooseUser.html) threads fully
+    /// started with an optional system timestamp.
     pub started: Option<DateTime<Local>>,
-    /// An optional system timestamp indicating when the load test began stopping.
+    /// Tracks when the load test first began stopping with an optional system timestamp.
     pub stopping: Option<DateTime<Local>>,
-    /// An optional system timestamp indicating when the load test fully stopped.
+    /// Tracks when the load test stopped with an optional system timestamp.
     pub stopped: Option<DateTime<Local>>,
     /// Total number of seconds the load test ran.
     pub duration: usize,
@@ -2175,10 +2175,9 @@ impl fmt::Display for GooseMetrics {
 ///
 /// The request that Goose is making. User threads send this data to the parent thread
 /// when metrics are enabled. This request object must be provided to calls to
-/// [`set_success`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_success)
-/// or
-/// [`set_failure`](https://docs.rs/goose/*/goose/goose/struct.GooseUser.html#method.set_failure)
-/// so Goose knows which request is being updated.
+/// [`set_success`](../goose/struct.GooseUser.html#method.set_success) or
+/// [`set_failure`](../goose/struct.GooseUser.html#method.set_failure) so Goose knows
+/// which request is being updated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GooseErrorMetric {
     /// How many milliseconds the load test has been running.


### PR DESCRIPTION
 - general documentation cleanup: fix broken links, fix spelling, etc