### PR TITLE
Make GooseAttack.execute async and remove Tokio runtime initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - update `GooseTaskSet::set_wait_time()` to accept `std::time::Duration` instead of `usize` allowing more granularity (API change)
  - use request name when displaying errors to avoid having a large volume of distinct error for the same endpoint when using path parameters
  - updated `tungstenite` dependency to [`0.15`](https://github.com/snapview/tungstenite-rs/blob/master/CHANGELOG.md)
+ - Make `GooseAttack.execute` async
 
 ## 0.13.3 August 25, 2021
  - document GooseConfiguration fields that were only documented as gumpdrop parameters (in order to generate new lines in the help output) so now they're also documented in the code

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ The function is declared `async` so that we don't block a CPU-core while loading
 We have to tell Goose about our new task function. Edit the `main()` function, setting a return type and replacing the hello world text as follows:
 
 ```rust
-fn main() -> Result<(), GooseError> {
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
     GooseAttack::initialize()?
         .register_taskset(taskset!("LoadtestTasks")
             .register_task(task!(loadtest_index))
@@ -540,7 +541,8 @@ For example, without any run-time options the following load test would automati
         .set_default(GooseDefault::RunTime, 900)?
         .set_default(GooseDefault::RunningMetrics, 60)?
         .set_default(GooseDefault::StatusCodes, true)?
-        .execute()?
+        .execute()
+        .await?
         .print();
 
     Ok(())

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ async fn main() -> Result<(), GooseError> {
         .register_taskset(taskset!("LoadtestTasks")
             .register_task(task!(loadtest_index))
         )
-        .execute()?
+        .execute()
+        .await?
         .print();
 
     Ok(())
@@ -437,7 +438,8 @@ The following simple example helps illustrate how the different schedulers work.
             .register_task(task!(task1))
             .register_task(task!(task2).set_weight(2)?)
         )
-        .execute()?
+        .execute()
+        .await?
         .print();
 
     Ok(())
@@ -477,7 +479,8 @@ All run-time options can be configured with custom defaults. For example, you ma
             .register_task(task!(loadtest_index))
         )
         .set_default(GooseDefault::Host, "http://local.dev/")?
-        .execute()?
+        .execute()
+        .await?
         .print();
 
     Ok(())

--- a/examples/drupal_loadtest.rs
+++ b/examples/drupal_loadtest.rs
@@ -27,7 +27,8 @@ use goose::prelude::*;
 use rand::Rng;
 use regex::Regex;
 
-fn main() -> Result<(), GooseError> {
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
     GooseAttack::initialize()?
         .register_taskset(
             taskset!("AnonBrowsingUser")
@@ -77,7 +78,8 @@ fn main() -> Result<(), GooseError> {
                         .set_name("(Auth) comment form"),
                 ),
         )
-        .execute()?
+        .execute()
+        .await?
         .print();
 
     Ok(())

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -21,7 +21,8 @@ use std::time::Duration;
 
 use goose::prelude::*;
 
-fn main() -> Result<(), GooseError> {
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
     GooseAttack::initialize()?
         // In this example, we only create a single taskset, named "WebsiteUser".
         .register_taskset(
@@ -34,7 +35,8 @@ fn main() -> Result<(), GooseError> {
                 .register_task(task!(website_index))
                 .register_task(task!(website_about)),
         )
-        .execute()?
+        .execute()
+        .await?
         .print();
 
     Ok(())

--- a/examples/simple_closure.rs
+++ b/examples/simple_closure.rs
@@ -22,7 +22,8 @@ use std::boxed::Box;
 use std::sync::Arc;
 use std::time::Duration;
 
-fn main() -> Result<(), GooseError> {
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
     let mut taskset = taskset!("WebsiteUser")
         // After each task runs, sleep randomly from 5 to 15 seconds.
         .set_wait_time(Duration::from_secs(5), Duration::from_secs(15))?;
@@ -50,7 +51,8 @@ fn main() -> Result<(), GooseError> {
     GooseAttack::initialize()?
         // In this example, we only create a single taskset, named "WebsiteUser".
         .register_taskset(taskset)
-        .execute()?
+        .execute()
+        .await?
         .print();
 
     Ok(())

--- a/examples/simple_with_session.rs
+++ b/examples/simple_with_session.rs
@@ -32,7 +32,8 @@ struct AuthenticationResponse {
     jwt_token: String,
 }
 
-fn main() -> Result<(), GooseError> {
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
     GooseAttack::initialize()?
         // In this example, we only create a single taskset, named "WebsiteUser".
         .register_taskset(
@@ -44,7 +45,8 @@ fn main() -> Result<(), GooseError> {
                 // These next two tasks run repeatedly as long as the load test is running.
                 .register_task(task!(authenticated_index)),
         )
-        .execute()?
+        .execute()
+        .await?
         .print();
 
     Ok(())

--- a/examples/umami/main.rs
+++ b/examples/umami/main.rs
@@ -14,7 +14,8 @@ use crate::spanish::*;
 /// Defines the actual load test. Each task set simulates a type of user.
 ///  - Anonymous English user: loads the English version of all pages
 ///  - Anonymous Spanish user: loads the Spanish version of all pages
-fn main() -> Result<(), GooseError> {
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
     let _goose_metrics = GooseAttack::initialize()?
         .register_taskset(
             taskset!("Anonymous English user")
@@ -83,7 +84,8 @@ fn main() -> Result<(), GooseError> {
                 ),
         )
         .set_default(GooseDefault::Host, "https://drupal-9.ddev.site/")?
-        .execute()?
+        .execute()
+        .await?
         .print();
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -465,7 +465,8 @@ pub enum GooseDefault {
 /// ```rust
 /// use goose::prelude::*;
 ///
-/// fn main() -> Result<(), GooseError> {
+/// #[tokio::main]
+/// async fn main() -> Result<(), GooseError> {
 ///     GooseAttack::initialize()?
 ///         .set_default(GooseDefault::Host, "local.dev")?;
 ///
@@ -537,7 +538,8 @@ pub trait GooseDefaultType<T> {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     GooseAttack::initialize()?
     ///         // Do not reset the metrics after the load test finishes starting.
     ///         .set_default(GooseDefault::NoResetMetrics, true)?

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -29,7 +29,8 @@
 //! ```rust
 //! use goose::prelude::*;
 //!
-//! fn main() -> Result<(), GooseError> {
+//! #[tokio::main]
+//! async fn main() -> Result<(), GooseError> {
 //!     let mut foo_tasks = taskset!("FooTasks").set_weight(10)?;
 //!     let mut bar_tasks = taskset!("BarTasks").set_weight(5)?;
 //!
@@ -112,7 +113,8 @@
 //! ```rust
 //! use goose::prelude::*;
 //!
-//! fn main() -> Result<(), GooseError> {
+//! #[tokio::main]
+//! async fn main() -> Result<(), GooseError> {
 //!     let mut a_task = task!(a_task_function).set_weight(9)?;
 //!     let mut b_task = task!(b_task_function).set_weight(3)?;
 //!

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -551,7 +551,8 @@ impl GooseTaskSet {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     let mut example_tasks = taskset!("ExampleTasks").set_weight(3)?;
     ///
     ///     Ok(())
@@ -597,7 +598,8 @@ impl GooseTaskSet {
     /// use goose::prelude::*;
     /// use std::time::Duration;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     taskset!("ExampleTasks").set_wait_time(Duration::from_secs(0), Duration::from_secs(1))?;
     ///
     ///     Ok(())
@@ -2222,7 +2224,8 @@ impl GooseUser {
     /// use goose::prelude::*;
     /// use std::time::Duration;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     let _goose_metrics = GooseAttack::initialize()?
     ///         .register_taskset(taskset!("LoadtestTasks")
     ///             .set_host("http://foo.example.com/")
@@ -2232,7 +2235,8 @@ impl GooseUser {
     ///         )
     ///         // Set a default run time so this test runs to completion.
     ///         .set_default(GooseDefault::RunTime, 1)?
-    ///         .execute()?;
+    ///         .execute()
+    ///         .await?;
     ///
     ///     Ok(())
     /// }
@@ -2466,7 +2470,8 @@ impl GooseTask {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     task!(task_function).set_weight(3)?;
     ///
     ///     Ok(())
@@ -2539,7 +2544,8 @@ impl GooseTask {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     let runs_first = task!(first_task_function).set_sequence(1).set_weight(2)?;
     ///     let runs_second = task!(second_task_function_a).set_sequence(2);
     ///     let also_runs_second = task!(second_task_function_b).set_sequence(2).set_weight(2)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -877,7 +877,8 @@ impl GooseAttack {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     GooseAttack::initialize()?
     ///         .set_scheduler(GooseScheduler::Random)
     ///         .register_taskset(taskset!("A Tasks")
@@ -916,7 +917,8 @@ impl GooseAttack {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     GooseAttack::initialize()?
     ///         .register_taskset(taskset!("ExampleTasks")
     ///             .register_task(task!(example_task))
@@ -964,7 +966,8 @@ impl GooseAttack {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     GooseAttack::initialize()?
     ///         .test_start(task!(setup));
     ///
@@ -993,7 +996,8 @@ impl GooseAttack {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     GooseAttack::initialize()?
     ///         .test_stop(task!(teardown));
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,8 @@
 //! ```rust
 //! use goose::prelude::*;
 //!
-//! fn main() -> Result<(), GooseError> {
+//! #[tokio::main]
+//! async fn main() -> Result<(), GooseError> {
 //!     let _goose_metrics = GooseAttack::initialize()?
 //!         .register_taskset(taskset!("LoadtestTasks")
 //!             // Register the foo task, assigning it a weight of 10.
@@ -123,7 +124,8 @@
 //!         .set_default(GooseDefault::Host, "http://dev.local/")?
 //!         // We set a default run time so this test runs to completion.
 //!         .set_default(GooseDefault::RunTime, 1)?
-//!         .execute()?;
+//!         .execute()
+//!         .await?;
 //!
 //!     Ok(())
 //! }
@@ -469,7 +471,6 @@ use std::sync::{
 use std::time::Duration;
 use std::{fmt, io, time};
 use tokio::fs::File;
-use tokio::runtime::Runtime;
 
 use crate::config::{GooseConfiguration, GooseDefaults};
 use crate::controller::{GooseControllerProtocol, GooseControllerRequest};
@@ -1222,7 +1223,8 @@ impl GooseAttack {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     let _goose_metrics = GooseAttack::initialize()?
     ///         .register_taskset(taskset!("ExampleTasks")
     ///             .register_task(task!(example_task).set_weight(2)?)
@@ -1232,7 +1234,8 @@ impl GooseAttack {
     ///         )
     ///         // Exit after one second so test doesn't run forever.
     ///         .set_default(GooseDefault::RunTime, 1)?
-    ///         .execute()?;
+    ///         .execute()
+    ///         .await?;
     ///
     ///     Ok(())
     /// }
@@ -1249,7 +1252,7 @@ impl GooseAttack {
     ///     Ok(())
     /// }
     /// ```
-    pub fn execute(mut self) -> Result<GooseMetrics, GooseError> {
+    pub async fn execute(mut self) -> Result<GooseMetrics, GooseError> {
         // If version flag is set, display package name and version and exit.
         if self.configuration.version {
             println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
@@ -1316,8 +1319,7 @@ impl GooseAttack {
         if self.attack_mode == AttackMode::Manager {
             #[cfg(feature = "gaggle")]
             {
-                let rt = Runtime::new().unwrap();
-                self = rt.block_on(manager::manager_main(self));
+                self = manager::manager_main(self).await;
             }
 
             #[cfg(not(feature = "gaggle"))]
@@ -1331,8 +1333,7 @@ impl GooseAttack {
         else if self.attack_mode == AttackMode::Worker {
             #[cfg(feature = "gaggle")]
             {
-                let rt = Runtime::new().unwrap();
-                self = rt.block_on(worker::worker_main(&self));
+                self = worker::worker_main(self).await;
             }
 
             #[cfg(not(feature = "gaggle"))]
@@ -1345,8 +1346,7 @@ impl GooseAttack {
         }
         // Start goose in single-process mode.
         else {
-            let rt = Runtime::new().unwrap();
-            self = rt.block_on(self.start_attack(None))?;
+            self = self.start_attack(None).await?;
         }
 
         Ok(self.metrics)

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::io::BufWriter;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::{thread, time};
+use std::time;
 
 use crate::metrics::{
     self, GooseErrorMetricAggregate, GooseErrorMetrics, GooseRequestMetricAggregate,
@@ -577,7 +577,7 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                     }
                     if !load_test_finished {
                         // Sleep a tenth of a second then return to the loop.
-                        thread::sleep(time::Duration::from_millis(100));
+                        tokio::time::sleep(time::Duration::from_millis(100)).await;
                     }
                 } else {
                     panic!("error receiving user message: {}", e);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -731,7 +731,8 @@ impl GooseTaskMetricAggregate {
 /// ```rust
 /// use goose::prelude::*;
 ///
-/// fn main() -> Result<(), GooseError> {
+/// #[tokio::main]
+/// async fn main() -> Result<(), GooseError> {
 ///     let goose_metrics: GooseMetrics = GooseAttack::initialize()?
 ///         .register_taskset(taskset!("ExampleUsers")
 ///             .register_task(task!(example_task))
@@ -740,7 +741,8 @@ impl GooseTaskMetricAggregate {
 ///         .set_default(GooseDefault::Host, "http://localhost/")?
 ///         // Set a default run time so this test runs to completion.
 ///         .set_default(GooseDefault::RunTime, 1)?
-///         .execute()?;
+///         .execute()
+///         .await?;
 ///
 ///     // It is now possible to do something with the metrics collected by Goose.
 ///     // For now, we'll just pretty-print the entire object.
@@ -931,7 +933,8 @@ impl GooseMetrics {
     /// ```rust
     /// use goose::prelude::*;
     ///
-    /// fn main() -> Result<(), GooseError> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), GooseError> {
     ///     GooseAttack::initialize()?
     ///         .register_taskset(taskset!("ExampleUsers")
     ///             .register_task(task!(example_task))
@@ -940,7 +943,8 @@ impl GooseMetrics {
     ///         .set_default(GooseDefault::Host, "http://localhost/")?
     ///         // Set a default run time so this test runs to completion.
     ///         .set_default(GooseDefault::RunTime, 1)?
-    ///         .execute()?
+    ///         .execute()
+    ///         .await?
     ///         .print();
     ///
     ///     Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -535,10 +535,8 @@ mod tests {
         assert_eq!(truncate_string("abcde", 2), "..");
     }
 
-    #[test]
-    fn timer() {
-        use std::thread;
-
+    #[tokio::test]
+    async fn timer() {
         let started = time::Instant::now();
 
         // 60 second timer has not expired.
@@ -548,7 +546,7 @@ mod tests {
         assert!(!timer_expired(started, 0));
 
         let sleep_duration = time::Duration::from_secs(1);
-        thread::sleep(sleep_duration);
+        tokio::time::sleep(sleep_duration).await;
 
         // Timer is now expired.
         assert!(timer_expired(started, 1));

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3,7 +3,7 @@ use nng::*;
 use serde::{Deserialize, Serialize};
 use std::io::BufWriter;
 use std::sync::atomic::Ordering;
-use std::{thread, time};
+use std::time;
 use url::Url;
 
 const EMPTY_ARGS: Vec<&str> = vec![];
@@ -49,7 +49,7 @@ pub fn register_shutdown_pipe_handler(manager: &Socket) {
         .expect("failed to set up new pipe handler");
 }
 
-pub(crate) async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
+pub(crate) async fn worker_main(goose_attack: GooseAttack) -> GooseAttack {
     // Creates a TCP address.
     let address = format!(
         "tcp://{}:{}",
@@ -68,7 +68,7 @@ pub(crate) async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
         .expect("failed to set up pipe handler");
 
     // Pause 1/10 of a second in case we're blocking on a cargo lock.
-    thread::sleep(time::Duration::from_millis(100));
+    tokio::time::sleep(time::Duration::from_millis(100)).await;
     // Connect to manager.
     let mut retries = 0;
     loop {
@@ -84,7 +84,7 @@ pub(crate) async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
                     "sleeping {:?} milliseconds waiting for manager...",
                     sleep_duration
                 );
-                thread::sleep(sleep_duration);
+                tokio::time::sleep(sleep_duration).await;
                 retries += 1;
             }
         }
@@ -198,7 +198,7 @@ pub(crate) async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
                     get_worker_id(),
                     sleep_duration
                 );
-                thread::sleep(sleep_duration);
+                tokio::time::sleep(sleep_duration).await;
             }
         }
     }

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -287,7 +287,7 @@ async fn test_single_taskset_closure() {
     run_load_test(false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Spawn a gaggle of 1 manager and 2 workers each simulating one user. Run a load test,
 // with a single task set containing two weighted tasks setup via closure. Validate

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -216,7 +216,7 @@ fn validate_closer_test(
 
 // Helper to run the test, takes a flag for indicating if running in standalone
 // mode or Gaggle mode.
-fn run_load_test(is_gaggle: bool) {
+async fn run_load_test(is_gaggle: bool) {
     // Start mock server.
     let server = MockServer::start();
 
@@ -236,7 +236,8 @@ fn run_load_test(is_gaggle: bool) {
             let goose_metrics = common::run_load_test(
                 common::build_load_test(configuration.clone(), &build_taskset(), None, None),
                 None,
-            );
+            )
+            .await;
 
             (configuration, goose_metrics)
         }
@@ -267,7 +268,8 @@ fn run_load_test(is_gaggle: bool) {
                     None,
                 ),
                 Some(worker_handles),
-            );
+            )
+            .await;
 
             (manager_configuration, goose_metrics)
         }
@@ -277,20 +279,20 @@ fn run_load_test(is_gaggle: bool) {
     validate_closer_test(&mock_endpoints, &goose_metrics, &configuration);
 }
 
-#[test]
+#[tokio::test]
 // Load test with a single task set containing two weighted tasks setup via closure.
 // Validate weighting and statistics.
-fn test_single_taskset_closure() {
+async fn test_single_taskset_closure() {
     // Run load test with is_gaggle set to false.
-    run_load_test(false);
+    run_load_test(false).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Spawn a gaggle of 1 manager and 2 workers each simulating one user. Run a load test,
 // with a single task set containing two weighted tasks setup via closure. Validate
 // that weighting and metrics are correctly merged to the Manager.
-fn test_single_taskset_closure_gaggle() {
+async fn test_single_taskset_closure_gaggle() {
     // Run load test with is_gaggle set to true.
-    run_load_test(true);
+    run_load_test(true).await;
 }

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -685,13 +685,13 @@ fn make_request(test_state: &mut TestState, command: &str) {
 }
 
 // Test controlling a load test with Telnet.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_telnet_controller() {
     run_standalone_test(TestType::Telnet).await;
 }
 
 // Test controlling a load test with WebSocket controller.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_websocket_controller() {
     run_standalone_test(TestType::WebSocket).await;
 }

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -217,7 +217,7 @@ async fn test_defaults() {
     goose_metrics.print();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Configure load test with set_default, run as Gaggle.
@@ -409,7 +409,7 @@ async fn test_no_defaults() {
     goose_metrics.print();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Configure load test with run time options (not with defaults), run as Gaggle.

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -1,3 +1,4 @@
+use futures::future::join_all;
 use httpmock::{Method::GET, Mock, MockServer};
 use serial_test::serial;
 
@@ -136,9 +137,9 @@ fn validate_test(
     }
 }
 
-#[test]
+#[tokio::test]
 // Configure load test with set_default.
-fn test_defaults() {
+async fn test_defaults() {
     // Multiple tests run together, so set a unique name.
     let request_log = "defaults-".to_string() + REQUEST_LOG;
     let debug_log = "defaults-".to_string() + DEBUG_LOG;
@@ -202,6 +203,7 @@ fn test_defaults() {
         .set_default(GooseDefault::StickyFollow, true)
         .unwrap()
         .execute()
+        .await
         .unwrap();
 
     validate_test(
@@ -215,11 +217,11 @@ fn test_defaults() {
     goose_metrics.print();
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Configure load test with set_default, run as Gaggle.
-fn test_defaults_gaggle() {
+async fn test_defaults_gaggle() {
     // Multiple tests run together, so set a unique name.
     let request_log = "gaggle-defaults".to_string() + REQUEST_LOG;
     let debug_log = "gaggle-defaults".to_string() + DEBUG_LOG;
@@ -255,8 +257,8 @@ fn test_defaults_gaggle() {
         let worker_configuration = configuration.clone();
         let worker_request_log = request_log.clone() + &i.to_string();
         let worker_debug_log = debug_log.clone() + &i.to_string();
-        worker_handles.push(std::thread::spawn(move || {
-            let _ = crate::GooseAttack::initialize_with_config(worker_configuration)
+        worker_handles.push(tokio::spawn(
+            crate::GooseAttack::initialize_with_config(worker_configuration)
                 .unwrap()
                 .register_taskset(taskset!("Index").register_task(task!(get_index)))
                 .register_taskset(taskset!("About").register_task(task!(get_about)))
@@ -280,9 +282,8 @@ fn test_defaults_gaggle() {
                 .unwrap()
                 .set_default(GooseDefault::ManagerPort, PORT)
                 .unwrap()
-                .execute()
-                .unwrap();
-        }));
+                .execute(),
+        ));
     }
 
     // Start manager instance in current thread and run a distributed load test.
@@ -325,12 +326,11 @@ fn test_defaults_gaggle() {
         .set_default(GooseDefault::ManagerBindPort, PORT)
         .unwrap()
         .execute()
+        .await
         .unwrap();
 
     // Wait for both worker threads to finish and exit.
-    for worker_handle in worker_handles {
-        let _ = worker_handle.join();
-    }
+    join_all(worker_handles).await;
 
     let mut request_logs: Vec<String> = vec![];
     let mut debug_logs: Vec<String> = vec![];
@@ -346,9 +346,9 @@ fn test_defaults_gaggle() {
     goose_metrics.print();
 }
 
-#[test]
+#[tokio::test]
 // Configure load test with run time options (not with defaults).
-fn test_no_defaults() {
+async fn test_no_defaults() {
     // Multiple tests run together, so set a unique name.
     let requests_file = "nodefaults-".to_string() + REQUEST_LOG;
     let debug_file = "nodefaults-".to_string() + DEBUG_LOG;
@@ -395,6 +395,7 @@ fn test_no_defaults() {
         .register_taskset(taskset!("Index").register_task(task!(get_index)))
         .register_taskset(taskset!("About").register_task(task!(get_about)))
         .execute()
+        .await
         .unwrap();
 
     validate_test(
@@ -408,11 +409,11 @@ fn test_no_defaults() {
     goose_metrics.print();
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Configure load test with run time options (not with defaults), run as Gaggle.
-fn test_no_defaults_gaggle() {
+async fn test_no_defaults_gaggle() {
     let requests_file = "gaggle-nodefaults".to_string() + REQUEST_LOG;
     let debug_file = "gaggle-nodefaults".to_string() + DEBUG_LOG;
 
@@ -459,14 +460,13 @@ fn test_no_defaults_gaggle() {
             ],
         );
         println!("{:#?}", worker_configuration);
-        worker_handles.push(std::thread::spawn(move || {
-            let _ = crate::GooseAttack::initialize_with_config(worker_configuration)
+        worker_handles.push(tokio::spawn(
+            crate::GooseAttack::initialize_with_config(worker_configuration)
                 .unwrap()
                 .register_taskset(taskset!("Index").register_task(task!(get_index)))
                 .register_taskset(taskset!("About").register_task(task!(get_about)))
-                .execute()
-                .unwrap();
-        }));
+                .execute(),
+        ));
     }
 
     let manager_configuration = common::build_configuration(
@@ -499,12 +499,11 @@ fn test_no_defaults_gaggle() {
         .register_taskset(taskset!("Index").register_task(task!(get_index)))
         .register_taskset(taskset!("About").register_task(task!(get_about)))
         .execute()
+        .await
         .unwrap();
 
     // Wait for both worker threads to finish and exit.
-    for worker_handle in worker_handles {
-        let _ = worker_handle.join();
-    }
+    join_all(worker_handles).await;
 
     let mut requests_files: Vec<String> = vec![];
     let mut debug_files: Vec<String> = vec![];
@@ -525,9 +524,9 @@ fn test_no_defaults_gaggle() {
     goose_metrics.print();
 }
 
-#[test]
+#[tokio::test]
 // Configure load test with defaults, disable metrics.
-fn test_defaults_no_metrics() {
+async fn test_defaults_no_metrics() {
     let server = MockServer::start();
 
     // Setup the mock endpoints needed for this test.
@@ -554,6 +553,7 @@ fn test_defaults_no_metrics() {
         .set_default(GooseDefault::NoMetrics, true)
         .unwrap()
         .execute()
+        .await
         .unwrap();
 
     // Confirm that we loaded the mock endpoints.

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -231,7 +231,7 @@ async fn test_error_summary() {
     run_standalone_test(TestType::ErrorSummary).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Confirm that errors show up in the summary when enabled, in Gaggle mode.
@@ -245,7 +245,7 @@ async fn test_no_error_summary() {
     run_standalone_test(TestType::NoErrorSummary).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Confirm that errors do not show up in the summary when --no-error-summary is enabled,

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -150,7 +150,7 @@ fn get_tasks() -> GooseTaskSet {
 }
 
 // Helper to run all standalone tests.
-fn run_standalone_test(test_type: TestType) {
+async fn run_standalone_test(test_type: TestType) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -169,14 +169,15 @@ fn run_standalone_test(test_type: TestType) {
     let goose_metrics = common::run_load_test(
         common::build_load_test(configuration.clone(), &get_tasks(), None, None),
         None,
-    );
+    )
+    .await;
 
     // Confirm that the load test ran correctly.
     validate_error(&goose_metrics, &mock_endpoints, &configuration, test_type);
 }
 
 // Helper to run all standalone tests.
-fn run_gaggle_test(test_type: TestType) {
+async fn run_gaggle_test(test_type: TestType) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -213,7 +214,7 @@ fn run_gaggle_test(test_type: TestType) {
         common::build_load_test(manager_configuration.clone(), &get_tasks(), None, None);
 
     // Run the Goose Attack.
-    let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles));
+    let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
 
     // Confirm that the load test ran correctly.
     validate_error(
@@ -224,31 +225,31 @@ fn run_gaggle_test(test_type: TestType) {
     );
 }
 
-#[test]
+#[tokio::test]
 // Confirm that errors show up in the summary when enabled.
-fn test_error_summary() {
-    run_standalone_test(TestType::ErrorSummary);
+async fn test_error_summary() {
+    run_standalone_test(TestType::ErrorSummary).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Confirm that errors show up in the summary when enabled, in Gaggle mode.
-fn test_error_summary_gaggle() {
-    run_gaggle_test(TestType::ErrorSummary);
+async fn test_error_summary_gaggle() {
+    run_gaggle_test(TestType::ErrorSummary).await;
 }
 
-#[test]
+#[tokio::test]
 // Confirm that errors do not show up in the summary when --no-error-summary is enabled.
-fn test_no_error_summary() {
-    run_standalone_test(TestType::NoErrorSummary);
+async fn test_no_error_summary() {
+    run_standalone_test(TestType::NoErrorSummary).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Confirm that errors do not show up in the summary when --no-error-summary is enabled,
 // in Gaggle mode.
-fn test_no_error_summary_gaggle() {
-    run_gaggle_test(TestType::NoErrorSummary);
+async fn test_no_error_summary_gaggle() {
+    run_gaggle_test(TestType::NoErrorSummary).await;
 }

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -220,7 +220,7 @@ fn validate_test(
 }
 
 // Helper to run all standalone tests.
-fn run_standalone_test(test_type: TestType, format: &str) {
+async fn run_standalone_test(test_type: TestType, format: &str) {
     let request_log = test_type.to_string() + "-request-log." + format;
     let task_log = test_type.to_string() + "-task-log." + format;
     let debug_log = test_type.to_string() + "-debug-log." + format;
@@ -261,7 +261,8 @@ fn run_standalone_test(test_type: TestType, format: &str) {
     let goose_metrics = common::run_load_test(
         common::build_load_test(configuration, &get_tasks(), None, None),
         None,
-    );
+    )
+    .await;
 
     let log_files = LogFiles {
         request_logs: &[request_log.to_string()],
@@ -276,7 +277,7 @@ fn run_standalone_test(test_type: TestType, format: &str) {
 }
 
 // Helper to run all gaggle tests.
-fn run_gaggle_test(test_type: TestType, format: &str) {
+async fn run_gaggle_test(test_type: TestType, format: &str) {
     let requests_file = test_type.to_string() + "-gaggle-request-log." + format;
     let tasks_file = test_type.to_string() + "-gaggle-task-log." + format;
     let error_file = test_type.to_string() + "-gaggle-error-log." + format;
@@ -357,10 +358,10 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
         let worker_goose_attack =
             common::build_load_test(worker_configuration.clone(), &get_tasks(), None, None);
         // Start worker instance of the load test.
-        worker_handles.push(std::thread::spawn(move || {
-            // Run the load test as configured.
-            common::run_load_test(worker_goose_attack, None);
-        }));
+        worker_handles.push(tokio::spawn(common::run_load_test(
+            worker_goose_attack,
+            None,
+        )));
     }
 
     let manager_configuration = common::build_configuration(
@@ -383,7 +384,7 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
         common::build_load_test(manager_configuration, &get_tasks(), None, None);
 
     // Run the Goose Attack.
-    let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles));
+    let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
 
     let log_files = LogFiles {
         request_logs: &requests_files,
@@ -408,212 +409,212 @@ fn run_gaggle_test(test_type: TestType, format: &str) {
     }
 }
 
-#[test]
+#[tokio::test]
 // Enable json-formatted requests log.
-fn test_requests_logs_json() {
-    run_standalone_test(TestType::Requests, "json");
+async fn test_requests_logs_json() {
+    run_standalone_test(TestType::Requests, "json").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable json-formatted requests log, in Gaggle mode.
-fn test_requests_logs_json_gaggle() {
-    run_gaggle_test(TestType::Requests, "json");
+async fn test_requests_logs_json_gaggle() {
+    run_gaggle_test(TestType::Requests, "json").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable csv-formatted requests log.
-fn test_requests_logs_csv() {
-    run_standalone_test(TestType::Requests, "csv");
+async fn test_requests_logs_csv() {
+    run_standalone_test(TestType::Requests, "csv").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable csv-formatted requests log, in Gaggle mode.
-fn test_requests_logs_csv_gaggle() {
-    run_gaggle_test(TestType::Requests, "csv");
+async fn test_requests_logs_csv_gaggle() {
+    run_gaggle_test(TestType::Requests, "csv").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable raw-formatted requests log.
-fn test_requests_logs_raw() {
-    run_standalone_test(TestType::Requests, "raw");
+async fn test_requests_logs_raw() {
+    run_standalone_test(TestType::Requests, "raw").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted requests log, in Gaggle mode.
-fn test_requests_logs_raw_gaggle() {
-    run_gaggle_test(TestType::Requests, "raw");
+async fn test_requests_logs_raw_gaggle() {
+    run_gaggle_test(TestType::Requests, "raw").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable pretty-formatted requests log.
-fn test_requests_logs_pretty() {
-    run_standalone_test(TestType::Requests, "pretty");
+async fn test_requests_logs_pretty() {
+    run_standalone_test(TestType::Requests, "pretty").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable pretty-formatted requests log, in Gaggle mode.
-fn test_requests_logs_pretty_gaggle() {
-    run_gaggle_test(TestType::Requests, "pretty");
+async fn test_requests_logs_pretty_gaggle() {
+    run_gaggle_test(TestType::Requests, "pretty").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable json-formatted tasks log.
-fn test_tasks_logs_json() {
-    run_standalone_test(TestType::Tasks, "json");
+async fn test_tasks_logs_json() {
+    run_standalone_test(TestType::Tasks, "json").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable json-formatted tasks log, in Gaggle mode.
-fn test_tasks_logs_json_gaggle() {
-    run_gaggle_test(TestType::Tasks, "json");
+async fn test_tasks_logs_json_gaggle() {
+    run_gaggle_test(TestType::Tasks, "json").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable csv-formatted tasks log.
-fn test_tasks_logs_csv() {
-    run_standalone_test(TestType::Tasks, "csv");
+async fn test_tasks_logs_csv() {
+    run_standalone_test(TestType::Tasks, "csv").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable csv-formatted tasks log, in Gaggle mode.
-fn test_tasks_logs_csv_gaggle() {
-    run_gaggle_test(TestType::Tasks, "csv");
+async fn test_tasks_logs_csv_gaggle() {
+    run_gaggle_test(TestType::Tasks, "csv").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable raw-formatted tasks log.
-fn test_tasks_logs_raw() {
-    run_standalone_test(TestType::Tasks, "raw");
+async fn test_tasks_logs_raw() {
+    run_standalone_test(TestType::Tasks, "raw").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted tasks log, in Gaggle mode.
-fn test_tasks_logs_raw_gaggle() {
-    run_gaggle_test(TestType::Tasks, "raw");
+async fn test_tasks_logs_raw_gaggle() {
+    run_gaggle_test(TestType::Tasks, "raw").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable raw-formatted error log.
-fn test_error_logs_raw() {
-    run_standalone_test(TestType::Error, "raw");
+async fn test_error_logs_raw() {
+    run_standalone_test(TestType::Error, "raw").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted error log, in Gaggle mode.
-fn test_error_logs_raw_gaggle() {
-    run_gaggle_test(TestType::Error, "raw");
+async fn test_error_logs_raw_gaggle() {
+    run_gaggle_test(TestType::Error, "raw").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable json-formatted error log.
-fn test_error_logs_json() {
-    run_standalone_test(TestType::Error, "json");
+async fn test_error_logs_json() {
+    run_standalone_test(TestType::Error, "json").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable json-formatted error log, in Gaggle mode.
-fn test_error_logs_json_gaggle() {
-    run_gaggle_test(TestType::Error, "json");
+async fn test_error_logs_json_gaggle() {
+    run_gaggle_test(TestType::Error, "json").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable csv-formatted error log.
-fn test_error_logs_csv() {
-    run_standalone_test(TestType::Error, "csv");
+async fn test_error_logs_csv() {
+    run_standalone_test(TestType::Error, "csv").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable csv-formatted error log, in Gaggle mode.
-fn test_error_logs_csv_gaggle() {
-    run_gaggle_test(TestType::Error, "csv");
+async fn test_error_logs_csv_gaggle() {
+    run_gaggle_test(TestType::Error, "csv").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable raw-formatted debug log.
-fn test_debug_logs_raw() {
-    run_standalone_test(TestType::Debug, "raw");
+async fn test_debug_logs_raw() {
+    run_standalone_test(TestType::Debug, "raw").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted debug log, in Gaggle mode.
-fn test_debug_logs_raw_gaggle() {
-    run_gaggle_test(TestType::Debug, "raw");
+async fn test_debug_logs_raw_gaggle() {
+    run_gaggle_test(TestType::Debug, "raw").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable json-formatted debug log.
-fn test_debug_logs_json() {
-    run_standalone_test(TestType::Debug, "json");
+async fn test_debug_logs_json() {
+    run_standalone_test(TestType::Debug, "json").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable json-formatted debug log, in Gaggle mode.
-fn test_debug_logs_json_gaggle() {
-    run_gaggle_test(TestType::Debug, "json");
+async fn test_debug_logs_json_gaggle() {
+    run_gaggle_test(TestType::Debug, "json").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable csv-formatted debug log.
-fn test_debug_logs_csv() {
-    run_standalone_test(TestType::Debug, "csv");
+async fn test_debug_logs_csv() {
+    run_standalone_test(TestType::Debug, "csv").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable csv-formatted debug log, in Gaggle mode.
-fn test_debug_logs_csv_gaggle() {
-    run_gaggle_test(TestType::Debug, "csv");
+async fn test_debug_logs_csv_gaggle() {
+    run_gaggle_test(TestType::Debug, "csv").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable raw-formatted logs.
-fn test_all_logs_raw() {
-    run_standalone_test(TestType::All, "raw");
+async fn test_all_logs_raw() {
+    run_standalone_test(TestType::All, "raw").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted logs, in Gaggle mode.
-fn test_all_logs_raw_gaggle() {
-    run_gaggle_test(TestType::All, "raw");
+async fn test_all_logs_raw_gaggle() {
+    run_gaggle_test(TestType::All, "raw").await;
 }
 
-#[test]
+#[tokio::test]
 // Enable pretty-formatted logs.
-fn test_all_logs_pretty() {
-    run_standalone_test(TestType::All, "pretty");
+async fn test_all_logs_pretty() {
+    run_standalone_test(TestType::All, "pretty").await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable pretty-formatted logs, in Gaggle mode.
-fn test_all_logs_pretty_gaggle() {
-    run_gaggle_test(TestType::All, "pretty");
+async fn test_all_logs_pretty_gaggle() {
+    run_gaggle_test(TestType::All, "pretty").await;
 }

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -415,7 +415,7 @@ async fn test_requests_logs_json() {
     run_standalone_test(TestType::Requests, "json").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable json-formatted requests log, in Gaggle mode.
@@ -429,7 +429,7 @@ async fn test_requests_logs_csv() {
     run_standalone_test(TestType::Requests, "csv").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable csv-formatted requests log, in Gaggle mode.
@@ -443,7 +443,7 @@ async fn test_requests_logs_raw() {
     run_standalone_test(TestType::Requests, "raw").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted requests log, in Gaggle mode.
@@ -457,7 +457,7 @@ async fn test_requests_logs_pretty() {
     run_standalone_test(TestType::Requests, "pretty").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable pretty-formatted requests log, in Gaggle mode.
@@ -471,7 +471,7 @@ async fn test_tasks_logs_json() {
     run_standalone_test(TestType::Tasks, "json").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable json-formatted tasks log, in Gaggle mode.
@@ -485,7 +485,7 @@ async fn test_tasks_logs_csv() {
     run_standalone_test(TestType::Tasks, "csv").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable csv-formatted tasks log, in Gaggle mode.
@@ -499,7 +499,7 @@ async fn test_tasks_logs_raw() {
     run_standalone_test(TestType::Tasks, "raw").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted tasks log, in Gaggle mode.
@@ -513,7 +513,7 @@ async fn test_error_logs_raw() {
     run_standalone_test(TestType::Error, "raw").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted error log, in Gaggle mode.
@@ -527,7 +527,7 @@ async fn test_error_logs_json() {
     run_standalone_test(TestType::Error, "json").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable json-formatted error log, in Gaggle mode.
@@ -541,7 +541,7 @@ async fn test_error_logs_csv() {
     run_standalone_test(TestType::Error, "csv").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable csv-formatted error log, in Gaggle mode.
@@ -555,7 +555,7 @@ async fn test_debug_logs_raw() {
     run_standalone_test(TestType::Debug, "raw").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted debug log, in Gaggle mode.
@@ -569,7 +569,7 @@ async fn test_debug_logs_json() {
     run_standalone_test(TestType::Debug, "json").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable json-formatted debug log, in Gaggle mode.
@@ -583,7 +583,7 @@ async fn test_debug_logs_csv() {
     run_standalone_test(TestType::Debug, "csv").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable csv-formatted debug log, in Gaggle mode.
@@ -597,7 +597,7 @@ async fn test_all_logs_raw() {
     run_standalone_test(TestType::All, "raw").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable raw-formatted logs, in Gaggle mode.
@@ -611,7 +611,7 @@ async fn test_all_logs_pretty() {
     run_standalone_test(TestType::All, "pretty").await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable pretty-formatted logs, in Gaggle mode.

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -161,7 +161,7 @@ async fn test_no_normal_tasks() {
     run_load_test(false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Test taskset with only on_start() and on_stop() tasks, in Gaggle mode.
 async fn test_no_normal_tasks_gaggle() {

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -108,7 +108,7 @@ fn get_tasks() -> GooseTaskSet {
 
 // Helper to run the test, takes a flag for indicating if running in standalone
 // mode or Gaggle mode.
-fn run_load_test(is_gaggle: bool) {
+async fn run_load_test(is_gaggle: bool) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -125,7 +125,8 @@ fn run_load_test(is_gaggle: bool) {
             common::run_load_test(
                 common::build_load_test(configuration, &get_tasks(), None, None),
                 None,
-            );
+            )
+            .await;
         }
         true => {
             // Build common configuration.
@@ -144,7 +145,8 @@ fn run_load_test(is_gaggle: bool) {
             common::run_load_test(
                 common::build_load_test(manager_configuration, &get_tasks(), None, None),
                 Some(worker_handles),
-            );
+            )
+            .await;
         }
     }
 
@@ -152,17 +154,17 @@ fn run_load_test(is_gaggle: bool) {
     validate_test(&mock_endpoints);
 }
 
-#[test]
+#[tokio::test]
 // Test taskset with only on_start() and on_stop() tasks.
-fn test_no_normal_tasks() {
+async fn test_no_normal_tasks() {
     // Run load test with is_gaggle set to false.
-    run_load_test(false);
+    run_load_test(false).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Test taskset with only on_start() and on_stop() tasks, in Gaggle mode.
-fn test_no_normal_tasks_gaggle() {
+async fn test_no_normal_tasks_gaggle() {
     // Run load test with is_gaggle set to true.
-    run_load_test(true);
+    run_load_test(true).await;
 }

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -238,7 +238,7 @@ async fn test_one_taskset() {
     run_standalone_test(TestType::NoResetMetrics).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Test a single task set with multiple weighted tasks, in Gaggle mode.

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -157,7 +157,7 @@ fn get_tasks() -> GooseTaskSet {
 }
 
 // Helper to run all standalone tests.
-fn run_standalone_test(test_type: TestType) {
+async fn run_standalone_test(test_type: TestType) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -176,14 +176,15 @@ fn run_standalone_test(test_type: TestType) {
     let goose_metrics = common::run_load_test(
         common::build_load_test(configuration.clone(), &get_tasks(), None, None),
         None,
-    );
+    )
+    .await;
 
     // Confirm that the load test ran correctly.
     validate_one_taskset(&goose_metrics, &mock_endpoints, &configuration, test_type);
 }
 
 // Helper to run all standalone tests.
-fn run_gaggle_test(test_type: TestType) {
+async fn run_gaggle_test(test_type: TestType) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -220,7 +221,7 @@ fn run_gaggle_test(test_type: TestType) {
         common::build_load_test(manager_configuration.clone(), &get_tasks(), None, None);
 
     // Run the Goose Attack.
-    let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles));
+    let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
 
     // Confirm that the load test ran correctly.
     validate_one_taskset(
@@ -231,24 +232,24 @@ fn run_gaggle_test(test_type: TestType) {
     );
 }
 
-#[test]
+#[tokio::test]
 // Test a single task set with multiple weighted tasks.
-fn test_one_taskset() {
-    run_standalone_test(TestType::NoResetMetrics);
+async fn test_one_taskset() {
+    run_standalone_test(TestType::NoResetMetrics).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Test a single task set with multiple weighted tasks, in Gaggle mode.
-fn test_one_taskset_gaggle() {
-    run_gaggle_test(TestType::NoResetMetrics);
+async fn test_one_taskset_gaggle() {
+    run_gaggle_test(TestType::NoResetMetrics).await;
 }
 
-#[test]
+#[tokio::test]
 // Test a single task set with multiple weighted tasks, enable --no-reset-metrics.
-fn test_one_taskset_reset_metrics() {
-    run_standalone_test(TestType::ResetMetrics);
+async fn test_one_taskset_reset_metrics() {
+    run_standalone_test(TestType::ResetMetrics).await;
 }
 
 /* @TODO: @FIXME: Goose is not resetting metrics when running in Gaggle mode.

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -388,7 +388,7 @@ async fn test_redirect() {
     run_standalone_test(TestType::Chain).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Request a page that redirects multiple times with different redirect headers,
@@ -405,7 +405,7 @@ async fn test_domain_redirect() {
     run_standalone_test(TestType::Domain).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Request a page that redirects to another domain, in Gaggle mode.
@@ -423,7 +423,7 @@ async fn test_sticky_domain_redirect() {
     run_standalone_test(TestType::Sticky).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Request a page that redirects to another domain with --sticky-follow enabled, in

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -315,7 +315,7 @@ fn get_tasks(test_type: &TestType) -> GooseTaskSet {
 }
 
 // Helper to run all standalone tests.
-fn run_standalone_test(test_type: TestType) {
+async fn run_standalone_test(test_type: TestType) {
     // Start the mock servers.
     let server1 = MockServer::start();
     let server2 = MockServer::start();
@@ -334,14 +334,15 @@ fn run_standalone_test(test_type: TestType) {
     common::run_load_test(
         common::build_load_test(configuration, &get_tasks(&test_type), None, None),
         None,
-    );
+    )
+    .await;
 
     // Confirm that the load test was actually redirected.
     validate_redirect(&test_type, &mock_endpoints);
 }
 
 // Helper to run all standalone tests.
-fn run_gaggle_test(test_type: TestType) {
+async fn run_gaggle_test(test_type: TestType) {
     // Start the mock servers.
     let server1 = MockServer::start();
     let server2 = MockServer::start();
@@ -375,60 +376,60 @@ fn run_gaggle_test(test_type: TestType) {
         common::build_load_test(manager_configuration, &get_tasks(&test_type), None, None);
 
     // Run the Goose Attack.
-    common::run_load_test(manager_goose_attack, Some(worker_handles));
+    common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
 
     // Confirm that the load test was actually redirected.
     validate_redirect(&test_type, &mock_endpoints);
 }
 
-#[test]
+#[tokio::test]
 // Request a page that redirects multiple times with different redirect headers.
-fn test_redirect() {
-    run_standalone_test(TestType::Chain);
+async fn test_redirect() {
+    run_standalone_test(TestType::Chain).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Request a page that redirects multiple times with different redirect headers,
 // in Gaggle mode.
-fn test_redirect_gaggle() {
-    run_gaggle_test(TestType::Chain);
+async fn test_redirect_gaggle() {
+    run_gaggle_test(TestType::Chain).await;
 }
 
-#[test]
+#[tokio::test]
 // Request a page that redirects to another domain.
 // Different domains are simulated with multiple mock servers running on different
 // ports.
-fn test_domain_redirect() {
-    run_standalone_test(TestType::Domain);
+async fn test_domain_redirect() {
+    run_standalone_test(TestType::Domain).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Request a page that redirects to another domain, in Gaggle mode.
 // Different domains are simulated with multiple mock servers running on different
 // ports.
-fn test_domain_redirect_gaggle() {
-    run_gaggle_test(TestType::Domain);
+async fn test_domain_redirect_gaggle() {
+    run_gaggle_test(TestType::Domain).await;
 }
 
-#[test]
+#[tokio::test]
 // Request a page that redirects to another domain with --sticky-follow enabled.
 // Different domains are simulated with multiple mock servers running on different
 // ports.
-fn test_sticky_domain_redirect() {
-    run_standalone_test(TestType::Sticky);
+async fn test_sticky_domain_redirect() {
+    run_standalone_test(TestType::Sticky).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Request a page that redirects to another domain with --sticky-follow enabled, in
 // Gaggle mode.
 // Different domains are simulated with multiple mock servers running on different
 // ports.
-fn test_sticky_domain_redirect_gaggle() {
-    run_gaggle_test(TestType::Sticky);
+async fn test_sticky_domain_redirect_gaggle() {
+    run_gaggle_test(TestType::Sticky).await;
 }

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -252,7 +252,7 @@ fn get_tasks() -> (GooseTaskSet, GooseTask, GooseTask) {
 }
 
 // Helper to run all standalone tests.
-fn run_standalone_test(test_type: &TestType, scheduler: &GooseScheduler) {
+async fn run_standalone_test(test_type: &TestType, scheduler: &GooseScheduler) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -290,14 +290,14 @@ fn run_standalone_test(test_type: &TestType, scheduler: &GooseScheduler) {
     }
 
     // Run the Goose Attack.
-    common::run_load_test(goose_attack, None);
+    common::run_load_test(goose_attack, None).await;
 
     // Confirm the load test ran correctly.
     validate_test(test_type, scheduler, &mock_endpoints);
 }
 
 // Helper to run all gaggle tests.
-fn run_gaggle_test(test_type: &TestType, scheduler: &GooseScheduler) {
+async fn run_gaggle_test(test_type: &TestType, scheduler: &GooseScheduler) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -369,80 +369,80 @@ fn run_gaggle_test(test_type: &TestType, scheduler: &GooseScheduler) {
     }
 
     // Run the Goose Attack.
-    common::run_load_test(manager_goose_attack, Some(worker_handles));
+    common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
 
     // Confirm the load test ran correctly.
     validate_test(test_type, scheduler, &mock_endpoints);
 }
 
-#[test]
+#[tokio::test]
 // Load test with multiple tasks allocating GooseTaskSets in round robin order.
-fn test_round_robin_taskset() {
-    run_standalone_test(&TestType::TaskSets, &GooseScheduler::RoundRobin);
+async fn test_round_robin_taskset() {
+    run_standalone_test(&TestType::TaskSets, &GooseScheduler::RoundRobin).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks allocating GooseTaskSets in round robin order, in
 // Gaggle mode.
-fn test_round_robin_taskset_gaggle() {
-    run_gaggle_test(&TestType::TaskSets, &GooseScheduler::RoundRobin);
+async fn test_round_robin_taskset_gaggle() {
+    run_gaggle_test(&TestType::TaskSets, &GooseScheduler::RoundRobin).await;
 }
 
-#[test]
+#[tokio::test]
 // Load test with multiple GooseTasks allocated in round robin order.
-fn test_round_robin_task() {
-    run_standalone_test(&TestType::Tasks, &GooseScheduler::RoundRobin);
+async fn test_round_robin_task() {
+    run_standalone_test(&TestType::Tasks, &GooseScheduler::RoundRobin).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple GooseTasks allocated in round robin order, in
 // Gaggle mode.
-fn test_round_robin_task_gaggle() {
-    run_gaggle_test(&TestType::Tasks, &GooseScheduler::RoundRobin);
+async fn test_round_robin_task_gaggle() {
+    run_gaggle_test(&TestType::Tasks, &GooseScheduler::RoundRobin).await;
 }
 
-#[test]
+#[tokio::test]
 // Load test with multiple tasks allocating GooseTaskSets in serial order.
-fn test_serial_taskset() {
-    run_standalone_test(&TestType::TaskSets, &GooseScheduler::Serial);
+async fn test_serial_taskset() {
+    run_standalone_test(&TestType::TaskSets, &GooseScheduler::Serial).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks allocating GooseTaskSets in serial order, in
 // Gaggle mode.
-fn test_serial_taskset_gaggle() {
-    run_gaggle_test(&TestType::TaskSets, &GooseScheduler::Serial);
+async fn test_serial_taskset_gaggle() {
+    run_gaggle_test(&TestType::TaskSets, &GooseScheduler::Serial).await;
 }
 
-#[test]
+#[tokio::test]
 // Load test with multiple GooseTasks allocated in serial order.
-fn test_serial_tasks() {
-    run_standalone_test(&TestType::Tasks, &GooseScheduler::Serial);
+async fn test_serial_tasks() {
+    run_standalone_test(&TestType::Tasks, &GooseScheduler::Serial).await;
 }
 
-#[test]
+#[tokio::test]
 // Load test with multiple tasks allocating GooseTaskSets in random order.
-fn test_random_taskset() {
-    run_standalone_test(&TestType::TaskSets, &GooseScheduler::Random);
+async fn test_random_taskset() {
+    run_standalone_test(&TestType::TaskSets, &GooseScheduler::Random).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks allocating GooseTaskSets in random order, in
 // Gaggle mode.
-fn test_random_taskset_gaggle() {
-    run_gaggle_test(&TestType::TaskSets, &GooseScheduler::Random);
+async fn test_random_taskset_gaggle() {
+    run_gaggle_test(&TestType::TaskSets, &GooseScheduler::Random).await;
 }
 
-#[test]
+#[tokio::test]
 // Load test with multiple tasks allocating GooseTaskSets in random order.
-fn test_random_tasks() {
-    run_standalone_test(&TestType::Tasks, &GooseScheduler::Random);
+async fn test_random_tasks() {
+    run_standalone_test(&TestType::Tasks, &GooseScheduler::Random).await;
 }

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -381,7 +381,7 @@ async fn test_round_robin_taskset() {
     run_standalone_test(&TestType::TaskSets, &GooseScheduler::RoundRobin).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks allocating GooseTaskSets in round robin order, in
@@ -396,7 +396,7 @@ async fn test_round_robin_task() {
     run_standalone_test(&TestType::Tasks, &GooseScheduler::RoundRobin).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple GooseTasks allocated in round robin order, in
@@ -411,7 +411,7 @@ async fn test_serial_taskset() {
     run_standalone_test(&TestType::TaskSets, &GooseScheduler::Serial).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks allocating GooseTaskSets in serial order, in
@@ -432,7 +432,7 @@ async fn test_random_taskset() {
     run_standalone_test(&TestType::TaskSets, &GooseScheduler::Random).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks allocating GooseTaskSets in random order, in

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -348,7 +348,7 @@ async fn test_not_sequenced() {
     run_standalone_test(TestType::NotSequenced).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks and no sequences defined, in Gaggle mode.
@@ -370,7 +370,7 @@ async fn test_sequenced_sequential() {
     run_standalone_test(TestType::SequencedSerial).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks and sequences defined, using the
@@ -379,7 +379,7 @@ async fn test_sequenced_round_robin_gaggle() {
     run_gaggle_test(TestType::SequencedRoundRobin).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks and sequences defined, using the

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -227,7 +227,7 @@ fn get_tasks(test_type: &TestType) -> (GooseTaskSet, GooseTask, GooseTask) {
 }
 
 // Helper to run all standalone tests.
-fn run_standalone_test(test_type: TestType) {
+async fn run_standalone_test(test_type: TestType) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -263,14 +263,14 @@ fn run_standalone_test(test_type: TestType) {
     }
 
     // Run the Goose Attack.
-    common::run_load_test(goose_attack, None);
+    common::run_load_test(goose_attack, None).await;
 
     // Confirm the load test ran correctly.
     validate_test(&test_type, &mock_endpoints);
 }
 
 // Helper to run all gaggle tests.
-fn run_gaggle_test(test_type: TestType) {
+async fn run_gaggle_test(test_type: TestType) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -336,54 +336,54 @@ fn run_gaggle_test(test_type: TestType) {
     }
 
     // Run the Goose Attack.
-    common::run_load_test(manager_goose_attack, Some(worker_handles));
+    common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
 
     // Confirm the load test ran correctly.
     validate_test(&test_type, &mock_endpoints);
 }
 
-#[test]
+#[tokio::test]
 // Load test with multiple tasks and no sequences defined.
-fn test_not_sequenced() {
-    run_standalone_test(TestType::NotSequenced);
+async fn test_not_sequenced() {
+    run_standalone_test(TestType::NotSequenced).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks and no sequences defined, in Gaggle mode.
-fn test_not_sequenced_gaggle() {
-    run_gaggle_test(TestType::NotSequenced);
+async fn test_not_sequenced_gaggle() {
+    run_gaggle_test(TestType::NotSequenced).await;
 }
 
-#[test]
+#[tokio::test]
 // Load test with multiple tasks and sequences defined, using the
 // round robin scheduler.
-fn test_sequenced_round_robin() {
-    run_standalone_test(TestType::SequencedRoundRobin);
+async fn test_sequenced_round_robin() {
+    run_standalone_test(TestType::SequencedRoundRobin).await;
 }
 
-#[test]
+#[tokio::test]
 // Load test with multiple tasks and sequences defined, using the
 // sequential scheduler.
-fn test_sequenced_sequential() {
-    run_standalone_test(TestType::SequencedSerial);
+async fn test_sequenced_sequential() {
+    run_standalone_test(TestType::SequencedSerial).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks and sequences defined, using the
 // round robin scheduler, in Gaggle mode.
-fn test_sequenced_round_robin_gaggle() {
-    run_gaggle_test(TestType::SequencedRoundRobin);
+async fn test_sequenced_round_robin_gaggle() {
+    run_gaggle_test(TestType::SequencedRoundRobin).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Load test with multiple tasks and sequences defined, using the
 // sequential scheduler, in Gaggle mode.
-fn test_sequenced_sequential_gaggle() {
-    run_gaggle_test(TestType::SequencedSerial);
+async fn test_sequenced_sequential_gaggle() {
+    run_gaggle_test(TestType::SequencedSerial).await;
 }

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -201,7 +201,7 @@ async fn test_setup() {
     run_standalone_test(TestType::Start).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Test test_start(), in Gaggle mode.
@@ -215,7 +215,7 @@ async fn test_teardown() {
     run_standalone_test(TestType::Stop).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Test test_stop(), in Gaggle mode.
@@ -229,7 +229,7 @@ async fn test_setup_teardown() {
     run_standalone_test(TestType::StartAndStop).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 /// Test test_start and test_stop together, in Gaggle mode.

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -146,7 +146,7 @@ fn build_goose_attack(test_type: &TestType, configuration: GooseConfiguration) -
 }
 
 // Helper to run all standalone tests.
-fn run_standalone_test(test_type: TestType) {
+async fn run_standalone_test(test_type: TestType) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -160,14 +160,14 @@ fn run_standalone_test(test_type: TestType) {
     let goose_attack = build_goose_attack(&test_type, configuration);
 
     // Run the load test.
-    common::run_load_test(goose_attack, None);
+    common::run_load_test(goose_attack, None).await;
 
     // Confirm the load test ran correctly.
     validate_test(&test_type, &mock_endpoints);
 }
 
 // Helper to run all gaggle tests.
-fn run_gaggle_test(test_type: TestType) {
+async fn run_gaggle_test(test_type: TestType) {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -189,50 +189,50 @@ fn run_gaggle_test(test_type: TestType) {
     let goose_attack = build_goose_attack(&test_type, manager_configuration);
 
     // Run the load test.
-    common::run_load_test(goose_attack, Some(worker_handles));
+    common::run_load_test(goose_attack, Some(worker_handles)).await;
 
     // Confirm the load test ran correctly.
     validate_test(&test_type, &mock_endpoints);
 }
 
-#[test]
+#[tokio::test]
 // Test test_start().
-fn test_setup() {
-    run_standalone_test(TestType::Start);
+async fn test_setup() {
+    run_standalone_test(TestType::Start).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Test test_start(), in Gaggle mode.
-fn test_setup_gaggle() {
-    run_gaggle_test(TestType::Start);
+async fn test_setup_gaggle() {
+    run_gaggle_test(TestType::Start).await;
 }
 
-#[test]
+#[tokio::test]
 // Test test_stop().
-fn test_teardown() {
-    run_standalone_test(TestType::Stop);
+async fn test_teardown() {
+    run_standalone_test(TestType::Stop).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 // Test test_stop(), in Gaggle mode.
-fn test_teardown_gaggle() {
-    run_gaggle_test(TestType::Stop);
+async fn test_teardown_gaggle() {
+    run_gaggle_test(TestType::Stop).await;
 }
 
-#[test]
+#[tokio::test]
 /// Test test_start and test_stop together.
-fn test_setup_teardown() {
-    run_standalone_test(TestType::StartAndStop);
+async fn test_setup_teardown() {
+    run_standalone_test(TestType::StartAndStop).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 #[serial]
 /// Test test_start and test_stop together, in Gaggle mode.
-fn test_setup_teardown_gaggle() {
-    run_gaggle_test(TestType::StartAndStop);
+async fn test_setup_teardown_gaggle() {
+    run_gaggle_test(TestType::StartAndStop).await;
 }

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -222,7 +222,7 @@ async fn test_throttle() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable throttle to confirm it limits the number of request per second, in
 // Gaggle mode. Increase the throttle and confirm it increases the number of

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -154,11 +154,11 @@ fn get_tasks() -> GooseTaskSet {
         .register_task(task!(get_about))
 }
 
-#[test]
+#[tokio::test]
 // Enable throttle to confirm it limits the number of request per second.
 // Increase the throttle and confirm it increases the number of requests
 // per second.
-fn test_throttle() {
+async fn test_throttle() {
     // Start the mock server.
     let server = MockServer::start();
 
@@ -180,7 +180,8 @@ fn test_throttle() {
     common::run_load_test(
         common::build_load_test(configuration, &get_tasks(), None, None),
         None,
-    );
+    )
+    .await;
 
     // Confirm that the load test was actually throttled.
     let test1_lines = validate_test(
@@ -209,7 +210,8 @@ fn test_throttle() {
     common::run_load_test(
         common::build_load_test(configuration, &get_tasks(), None, None),
         None,
-    );
+    )
+    .await;
 
     // Confirm that the load test was actually throttled, at an increased rate.
     let _ = validate_test(
@@ -220,12 +222,12 @@ fn test_throttle() {
     );
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
 // Enable throttle to confirm it limits the number of request per second, in
 // Gaggle mode. Increase the throttle and confirm it increases the number of
 // requests per second, in Gaggle mode.
-fn test_throttle_gaggle() {
+async fn test_throttle_gaggle() {
     // Multiple tests run together, so set a unique name.
     let request_log = "gaggle-".to_string() + REQUEST_LOG;
 
@@ -250,10 +252,10 @@ fn test_throttle_gaggle() {
         let worker_goose_attack =
             common::build_load_test(worker_configuration.clone(), &get_tasks(), None, None);
         // Start worker instance of the load test.
-        worker_handles.push(std::thread::spawn(move || {
-            // Run the load test as configured.
-            common::run_load_test(worker_goose_attack, None);
-        }));
+        worker_handles.push(tokio::spawn(common::run_load_test(
+            worker_goose_attack,
+            None,
+        )));
     }
 
     // Start manager instance in current thread and run a distributed load test.
@@ -272,7 +274,7 @@ fn test_throttle_gaggle() {
         common::build_load_test(manager_configuration.clone(), &get_tasks(), None, None);
 
     // Run the Goose Attack.
-    common::run_load_test(manager_goose_attack, Some(worker_handles));
+    common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
 
     // Confirm that the load test was actually throttled.
     let test1_lines = validate_test(
@@ -302,10 +304,10 @@ fn test_throttle_gaggle() {
         let worker_goose_attack =
             common::build_load_test(worker_configuration.clone(), &get_tasks(), None, None);
         // Start worker instance of the load test.
-        worker_handles.push(std::thread::spawn(move || {
-            // Run the load test as configured.
-            common::run_load_test(worker_goose_attack, None);
-        }));
+        worker_handles.push(tokio::spawn(common::run_load_test(
+            worker_goose_attack,
+            None,
+        )));
     }
 
     // Build the load test for the Manager.
@@ -313,7 +315,7 @@ fn test_throttle_gaggle() {
         common::build_load_test(manager_configuration, &get_tasks(), None, None);
 
     // Run the Goose Attack.
-    common::run_load_test(manager_goose_attack, Some(worker_handles));
+    common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
 
     // Confirm that the load test was actually throttled, at an increased rate.
     let _ = validate_test(


### PR DESCRIPTION
In complex use case, a user may need to run some code alongside the GooseAttack which is currently complicated be Goose create a tokio Runtime which prevent user to use #[tokio::main] and run other futures.

This change remove the runtime initialization from Goose and make the function `execute` async. 