### PR TITLE
Allow shared reqwest client configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
  - update `GooseTaskSet::set_wait_time()` to accept `std::time::Duration` instead of `usize` allowing more granularity (API change)
  - use request name when displaying errors to avoid having a large volume of distinct error for the same endpoint when using path parameters
  - updated `tungstenite` dependency to [`0.15`](https://github.com/snapview/tungstenite-rs/blob/master/CHANGELOG.md)
-
+ - Use a shared reqwest client among all `GooseUser` 
 ## 0.13.3 August 25, 2021
  - document GooseConfiguration fields that were only documented as gumpdrop parameters (in order to generate new lines in the help output) so now they're also documented in the code
  - fix panic when `--no-task-metrics` is enabled and metrics are printed; add tests to prevent further regressions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,7 +459,7 @@ use lazy_static::lazy_static;
 use nng::Socket;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
-use reqwest::Client;
+use reqwest::{Client, ClientBuilder};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
@@ -822,7 +822,7 @@ impl GooseAttack {
     ) -> Result<GooseAttack, GooseError> {
         let client = Client::builder()
             .user_agent(APP_USER_AGENT)
-            .cookie_store(true)
+            .cookie_store(false)
             // Enable gzip unless `--no-gzip` flag is enabled.
             .gzip(!configuration.no_gzip)
             .build()?;
@@ -855,19 +855,18 @@ impl GooseAttack {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), GooseError> {
-    ///     let client = Client::builder()
-    ///         .build()?;
+    ///     let client_builder = Client::builder();
     ///
     ///     GooseAttack::initialize()?
     ///         .set_scheduler(GooseScheduler::Random)
-    ///         .set_client(client);
+    ///         .set_client(client_builder)?;
     ///
     ///     Ok(())
     /// }
     /// ```
-    pub fn set_client(mut self, client: Client) -> Self {
-        self.client = client;
-        self
+    pub fn set_client(mut self, client_builder: ClientBuilder) -> Result<Self, GooseError> {
+        self.client = client_builder.cookie_store(false).build()?;
+        Ok(self)
     }
 
     /// Define the order [`GooseTaskSet`](./goose/struct.GooseTaskSet.html)s are

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -845,26 +845,47 @@ impl GooseAttack {
         })
     }
 
-    /// Define a reqwest::Client shared among all the
+    /// Define a reqwest::ClientBuilder used to build a reqwest Client shared among all the
     /// [`GooseUser`](./goose/struct.GooseUser.html)s running.
+    ///
+    /// # Alternative Compression Algorithms
+    /// Reqwest also supports
+    /// [`brotli`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.brotli) and
+    /// [`deflate`](https://docs.rs/reqwest/*/reqwest/struct.ClientBuilder.html#method.deflate) compression.
+    ///
+    /// To enable either, you must enable the features in your load test's `Cargo.toml`, for example:
+    /// ```text
+    /// reqwest = { version = "^0.11.4",  default-features = false, features = [
+    ///     "brotli",
+    ///     "cookies",
+    ///     "deflate",
+    ///     "gzip",
+    ///     "json",
+    /// ] }
+    /// ```
+    ///
+    /// Once enabled, you can add `.brotli(true)` and/or `.deflate(true)` to your custom
+    /// [`reqwest::Client::builder()`], following the documentation above.
     ///
     /// # Example
     /// ```rust
     /// use goose::prelude::*;
     /// use reqwest::Client;
+    /// static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), GooseError> {
-    ///     let client_builder = Client::builder();
+    ///     let client_builder = Client::builder()
+    ///         .user_agent(APP_USER_AGENT);
     ///
     ///     GooseAttack::initialize()?
     ///         .set_scheduler(GooseScheduler::Random)
-    ///         .set_client(client_builder)?;
+    ///         .set_client_builder(client_builder)?;
     ///
     ///     Ok(())
     /// }
     /// ```
-    pub fn set_client(mut self, client_builder: ClientBuilder) -> Result<Self, GooseError> {
+    pub fn set_client_builder(mut self, client_builder: ClientBuilder) -> Result<Self, GooseError> {
         self.client = client_builder.cookie_store(false).build()?;
         Ok(self)
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,5 +1,6 @@
 use gumdrop::Options;
 use nng::*;
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::io::BufWriter;
 use std::sync::atomic::Ordering;
@@ -136,7 +137,9 @@ pub(crate) async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
         if worker_id == 0 {
             worker_id = initializer.worker_id;
         }
+        let client = Client::builder().build().unwrap();
         let user = GooseUser::new(
+            client,
             initializer.task_sets_index,
             Url::parse(&initializer.base_url).unwrap(),
             &initializer.config,


### PR DESCRIPTION
From Reqwest official documentation:

> The Client holds a connection pool internally, so it is advised that you create one and reuse it.
    You do not have to wrap the Client it in an Rc or Arc to reuse it, because it already uses an Arc internally.

This PR, use a shared reqwest client among all GooseUser and allow the user the configure the global client.