### PR TITLE
Allow to set duration instead of seconds for task wait configuration

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -17,6 +17,8 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
+use std::time::Duration;
+
 use goose::prelude::*;
 
 fn main() -> Result<(), GooseError> {
@@ -25,7 +27,7 @@ fn main() -> Result<(), GooseError> {
         .register_taskset(
             taskset!("WebsiteUser")
                 // After each task runs, sleep randomly from 5 to 15 seconds.
-                .set_wait_time(5, 15)?
+                .set_wait_time(Duration::from_secs(5), Duration::from_secs(15))?
                 // This task only runs one time when the user first starts.
                 .register_task(task!(website_login).set_on_start())
                 // These next two tasks run repeatedly as long as the load test is running.

--- a/examples/simple_closure.rs
+++ b/examples/simple_closure.rs
@@ -20,11 +20,12 @@ use goose::prelude::*;
 
 use std::boxed::Box;
 use std::sync::Arc;
+use std::time::Duration;
 
 fn main() -> Result<(), GooseError> {
     let mut taskset = taskset!("WebsiteUser")
         // After each task runs, sleep randomly from 5 to 15 seconds.
-        .set_wait_time(5, 15)?;
+        .set_wait_time(Duration::from_secs(5), Duration::from_secs(15))?;
 
     let paths = vec!["/", "/about", "/our-team"];
     for request_path in paths {

--- a/examples/simple_with_session.rs
+++ b/examples/simple_with_session.rs
@@ -17,6 +17,8 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
+use std::time::Duration;
+
 use goose::prelude::*;
 use serde::Deserialize;
 
@@ -36,7 +38,7 @@ fn main() -> Result<(), GooseError> {
         .register_taskset(
             taskset!("WebsiteUser")
                 // After each task runs, sleep randomly from 5 to 15 seconds.
-                .set_wait_time(5, 15)?
+                .set_wait_time(Duration::from_secs(5), Duration::from_secs(15))?
                 // This task only runs one time when the user first starts.
                 .register_task(task!(website_signup).set_on_start())
                 // These next two tasks run repeatedly as long as the load test is running.

--- a/examples/umami/main.rs
+++ b/examples/umami/main.rs
@@ -3,6 +3,8 @@ mod common;
 mod english;
 mod spanish;
 
+use std::time::Duration;
+
 use goose::prelude::*;
 
 use crate::admin::*;
@@ -17,7 +19,7 @@ fn main() -> Result<(), GooseError> {
         .register_taskset(
             taskset!("Anonymous English user")
                 .set_weight(40)?
-                .set_wait_time(0, 3)?
+                .set_wait_time(Duration::from_secs(0), Duration::from_secs(3))?
                 .register_task(task!(front_page_en).set_name("anon /").set_weight(2)?)
                 .register_task(task!(basic_page_en).set_name("anon /en/basicpage"))
                 .register_task(task!(article_listing_en).set_name("anon /en/articles/"))
@@ -44,7 +46,7 @@ fn main() -> Result<(), GooseError> {
         .register_taskset(
             taskset!("Anonymous Spanish user")
                 .set_weight(9)?
-                .set_wait_time(0, 3)?
+                .set_wait_time(Duration::from_secs(0), Duration::from_secs(3))?
                 .register_task(task!(front_page_es).set_name("anon /es/").set_weight(2)?)
                 .register_task(task!(basic_page_es).set_name("anon /es/basicpage"))
                 .register_task(task!(article_listing_es).set_name("anon /es/articles/"))
@@ -70,7 +72,7 @@ fn main() -> Result<(), GooseError> {
         .register_taskset(
             taskset!("Admin user")
                 .set_weight(1)?
-                .set_wait_time(3, 10)?
+                .set_wait_time(Duration::from_secs(0), Duration::from_secs(3))?
                 .register_task(task!(log_in).set_on_start().set_name("auth /en/user/login"))
                 .register_task(task!(front_page_en).set_name("auth /").set_weight(2)?)
                 .register_task(task!(article_listing_en).set_name("auth /en/articles/"))

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -54,17 +54,18 @@
 //!
 //! ### Task Set Wait Time
 //!
-//! Wait time is specified as a low-high integer range. Each time a task completes in
-//! the task set, the user will pause for a random number of seconds inclusively between
+//! Wait time is specified as a low-high duration range. Each time a task completes in
+//! the task set, the user will pause for a random number of milliseconds inclusively between
 //! the low and high wait times. In the following example, users loading `foo` tasks will
 //! sleep 0 to 3 seconds after each task completes, and users loading `bar` tasks will
 //! sleep 5 to 10 seconds after each task completes.
 //!
 //! ```rust
 //! use goose::prelude::*;
+//! use std::time::Duration;
 //!
-//! let mut foo_tasks = taskset!("FooTasks").set_wait_time(0, 3).unwrap();
-//! let mut bar_tasks = taskset!("BarTasks").set_wait_time(5, 10).unwrap();
+//! let mut foo_tasks = taskset!("FooTasks").set_wait_time(Duration::from_secs(0), Duration::from_secs(3)).unwrap();
+//! let mut bar_tasks = taskset!("BarTasks").set_wait_time(Duration::from_secs(5), Duration::from_secs(10)).unwrap();
 //! ```
 //! ## Creating Tasks
 //!
@@ -290,6 +291,7 @@ use reqwest::{header, Client, ClientBuilder, RequestBuilder, Response};
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use std::time::Duration;
 use std::{fmt, str};
 use std::{future::Future, pin::Pin, time::Instant};
 use tokio::sync::RwLock;
@@ -468,10 +470,8 @@ pub struct GooseTaskSet {
     pub task_sets_index: usize,
     /// An integer value that controls the frequency that this task set will be assigned to a user.
     pub weight: usize,
-    /// An integer value indicating the minimum number of seconds a user will sleep after running a task.
-    pub min_wait: usize,
-    /// An integer value indicating the maximum number of seconds a user will sleep after running a task.
-    pub max_wait: usize,
+    /// An range of duration indicating the interval a user will sleep after running a task.
+    pub task_wait: Option<(Duration, Duration)>,
     /// A vector containing one copy of each [`GooseTask`](./struct.GooseTask.html) that will
     /// run by users running this task set.
     pub tasks: Vec<GooseTask>,
@@ -507,8 +507,7 @@ impl GooseTaskSet {
             name: name.to_string(),
             task_sets_index: usize::max_value(),
             weight: 1,
-            min_wait: 0,
-            max_wait: 0,
+            task_wait: None,
             tasks: Vec::new(),
             weighted_tasks: Vec::new(),
             weighted_on_start_tasks: Vec::new(),
@@ -589,26 +588,31 @@ impl GooseTaskSet {
         self
     }
 
-    /// Configure a task_set to to pause after running each task. The length of the pause will be randomly
-    /// selected from `min_weight` to `max_wait` inclusively.  For example, if `min_wait` is `0` and
-    /// `max_weight` is `2`, the user will randomly sleep for 0, 1 or 2 seconds after each task completes.
+    /// Configure a duration per task_set to pause after running each task. The length of the pause will be randomly
+    /// selected from `min_wait` to `max_wait` inclusively.  For example, if `min_wait` is `Duration::from_secs(0)` and
+    /// `max_wait` is `Duration::from_secs(2)`, the user will randomly sleep between 0 and 2_000 milliseconds after each task completes.
     ///
     /// # Example
     /// ```rust
     /// use goose::prelude::*;
+    /// use std::time::Duration;
     ///
     /// fn main() -> Result<(), GooseError> {
-    ///     taskset!("ExampleTasks").set_wait_time(0, 1)?;
+    ///     taskset!("ExampleTasks").set_wait_time(Duration::from_secs(0), Duration::from_secs(1))?;
     ///
     ///     Ok(())
     /// }
     /// ```
-    pub fn set_wait_time(mut self, min_wait: usize, max_wait: usize) -> Result<Self, GooseError> {
+    pub fn set_wait_time(
+        mut self,
+        min_wait: Duration,
+        max_wait: Duration,
+    ) -> Result<Self, GooseError> {
         trace!(
-            "{} set_wait time: min: {} max: {}",
+            "{} set_wait time: min: {}ms max: {}ms",
             self.name,
-            min_wait,
-            max_wait
+            min_wait.as_millis(),
+            max_wait.as_millis()
         );
         if min_wait > max_wait {
             return Err(GooseError::InvalidWaitTime {
@@ -619,8 +623,7 @@ impl GooseTaskSet {
                         .to_string(),
             });
         }
-        self.min_wait = min_wait;
-        self.max_wait = max_wait;
+        self.task_wait.replace((min_wait, max_wait));
 
         Ok(self)
     }
@@ -734,10 +737,6 @@ pub struct GaggleUser {
     pub task_sets_index: usize,
     /// The base URL to prepend to all relative paths.
     pub base_url: Arc<RwLock<Url>>,
-    /// Minimum amount of time to sleep after running a task.
-    pub min_wait: usize,
-    /// Maximum amount of time to sleep after running a task.
-    pub max_wait: usize,
     /// A local copy of the global GooseConfiguration.
     pub config: GooseConfiguration,
     /// Load test hash.
@@ -748,8 +747,6 @@ impl GaggleUser {
     pub fn new(
         task_sets_index: usize,
         base_url: Url,
-        min_wait: usize,
-        max_wait: usize,
         configuration: &GooseConfiguration,
         load_test_hash: u64,
     ) -> Self {
@@ -757,8 +754,6 @@ impl GaggleUser {
         GaggleUser {
             task_sets_index,
             base_url: Arc::new(RwLock::new(base_url)),
-            min_wait,
-            max_wait,
             config: configuration.clone(),
             load_test_hash,
         }
@@ -832,10 +827,6 @@ pub struct GooseUser {
     pub client: Client,
     /// The base URL to prepend to all relative paths.
     pub base_url: Url,
-    /// Minimum amount of time to sleep after running a task.
-    pub min_wait: usize,
-    /// Maximum amount of time to sleep after running a task.
-    pub max_wait: usize,
     /// A local copy of the global [`GooseConfiguration`](../struct.GooseConfiguration.html).
     pub config: GooseConfiguration,
     /// Channel to logger.
@@ -868,8 +859,6 @@ impl GooseUser {
     pub fn new(
         task_sets_index: usize,
         base_url: Url,
-        min_wait: usize,
-        max_wait: usize,
         configuration: &GooseConfiguration,
         load_test_hash: u64,
     ) -> Result<Self, GooseError> {
@@ -886,8 +875,6 @@ impl GooseUser {
             task_sets_index,
             client,
             base_url,
-            min_wait,
-            max_wait,
             config: configuration.clone(),
             logger: None,
             throttle: None,
@@ -905,7 +892,7 @@ impl GooseUser {
 
     /// Create a new single-use user.
     pub fn single(base_url: Url, configuration: &GooseConfiguration) -> Result<Self, GooseError> {
-        let mut single_user = GooseUser::new(0, base_url, 0, 0, configuration, 0)?;
+        let mut single_user = GooseUser::new(0, base_url, configuration, 0)?;
         // Only one user, so index is 0.
         single_user.weighted_users_index = 0;
         // Do not throttle [`test_start`](../struct.GooseAttack.html#method.test_start) (setup) and
@@ -2233,12 +2220,13 @@ impl GooseUser {
     /// # Example
     /// ```rust
     /// use goose::prelude::*;
+    /// use std::time::Duration;
     ///
     /// fn main() -> Result<(), GooseError> {
     ///     let _goose_metrics = GooseAttack::initialize()?
     ///         .register_taskset(taskset!("LoadtestTasks")
     ///             .set_host("http://foo.example.com/")
-    ///             .set_wait_time(0, 3)?
+    ///             .set_wait_time(Duration::from_secs(0), Duration::from_secs(3))?
     ///             .register_task(task!(task_foo).set_weight(10)?)
     ///             .register_task(task!(task_bar))
     ///         )
@@ -2619,8 +2607,7 @@ mod tests {
         assert_eq!(task_set.name, "foo");
         assert_eq!(task_set.task_sets_index, usize::max_value());
         assert_eq!(task_set.weight, 1);
-        assert_eq!(task_set.min_wait, 0);
-        assert_eq!(task_set.max_wait, 0);
+        assert_eq!(task_set.task_wait, None);
         assert!(task_set.host.is_none());
         assert_eq!(task_set.tasks.len(), 0);
         assert_eq!(task_set.weighted_tasks.len(), 0);
@@ -2633,8 +2620,7 @@ mod tests {
         assert_eq!(task_set.weighted_tasks.len(), 0);
         assert_eq!(task_set.task_sets_index, usize::max_value());
         assert_eq!(task_set.weight, 1);
-        assert_eq!(task_set.min_wait, 0);
-        assert_eq!(task_set.max_wait, 0);
+        assert_eq!(task_set.task_wait, None);
         assert!(task_set.host.is_none());
 
         // Different task can be registered.
@@ -2643,8 +2629,7 @@ mod tests {
         assert_eq!(task_set.weighted_tasks.len(), 0);
         assert_eq!(task_set.task_sets_index, usize::max_value());
         assert_eq!(task_set.weight, 1);
-        assert_eq!(task_set.min_wait, 0);
-        assert_eq!(task_set.max_wait, 0);
+        assert_eq!(task_set.task_wait, None);
         assert!(task_set.host.is_none());
 
         // Same task can be registered again.
@@ -2653,8 +2638,7 @@ mod tests {
         assert_eq!(task_set.weighted_tasks.len(), 0);
         assert_eq!(task_set.task_sets_index, usize::max_value());
         assert_eq!(task_set.weight, 1);
-        assert_eq!(task_set.min_wait, 0);
-        assert_eq!(task_set.max_wait, 0);
+        assert_eq!(task_set.task_wait, None);
         assert!(task_set.host.is_none());
 
         // Setting weight only affects weight field.
@@ -2663,8 +2647,7 @@ mod tests {
         assert_eq!(task_set.tasks.len(), 3);
         assert_eq!(task_set.weighted_tasks.len(), 0);
         assert_eq!(task_set.task_sets_index, usize::max_value());
-        assert_eq!(task_set.min_wait, 0);
-        assert_eq!(task_set.max_wait, 0);
+        assert_eq!(task_set.task_wait, None);
         assert!(task_set.host.is_none());
 
         // Weight can be changed.
@@ -2678,17 +2661,19 @@ mod tests {
         assert_eq!(task_set.tasks.len(), 3);
         assert_eq!(task_set.weighted_tasks.len(), 0);
         assert_eq!(task_set.task_sets_index, usize::max_value());
-        assert_eq!(task_set.min_wait, 0);
-        assert_eq!(task_set.max_wait, 0);
 
         // Host field can be changed.
         task_set = task_set.set_host("https://bar.example.com/");
         assert_eq!(task_set.host, Some("https://bar.example.com/".to_string()));
 
         // Wait time only affects wait time fields.
-        task_set = task_set.set_wait_time(1, 10).unwrap();
-        assert_eq!(task_set.min_wait, 1);
-        assert_eq!(task_set.max_wait, 10);
+        task_set = task_set
+            .set_wait_time(Duration::from_secs(1), Duration::from_secs(10))
+            .unwrap();
+        assert_eq!(
+            task_set.task_wait,
+            Some((Duration::from_secs(1), Duration::from_secs(10)))
+        );
         assert_eq!(task_set.host, Some("https://bar.example.com/".to_string()));
         assert_eq!(task_set.weight, 5);
         assert_eq!(task_set.tasks.len(), 3);
@@ -2696,9 +2681,13 @@ mod tests {
         assert_eq!(task_set.task_sets_index, usize::max_value());
 
         // Wait time can be changed.
-        task_set = task_set.set_wait_time(3, 9).unwrap();
-        assert_eq!(task_set.min_wait, 3);
-        assert_eq!(task_set.max_wait, 9);
+        task_set = task_set
+            .set_wait_time(Duration::from_secs(3), Duration::from_secs(9))
+            .unwrap();
+        assert_eq!(
+            task_set.task_wait,
+            Some((Duration::from_secs(3), Duration::from_secs(9)))
+        );
     }
 
     #[test]
@@ -2786,10 +2775,8 @@ mod tests {
         const HOST: &str = "http://example.com/";
         let configuration = GooseConfiguration::parse_args_default(&EMPTY_ARGS).unwrap();
         let base_url = get_base_url(Some(HOST.to_string()), None, None).unwrap();
-        let user = GooseUser::new(0, base_url, 0, 0, &configuration, 0).unwrap();
+        let user = GooseUser::new(0, base_url, &configuration, 0).unwrap();
         assert_eq!(user.task_sets_index, 0);
-        assert_eq!(user.min_wait, 0);
-        assert_eq!(user.max_wait, 0);
         assert_eq!(user.weighted_users_index, usize::max_value());
 
         // Confirm the URLs are correctly built using the default_host.
@@ -2815,9 +2802,7 @@ mod tests {
             Some("http://www.example.com/".to_string()),
         )
         .unwrap();
-        let user2 = GooseUser::new(0, base_url, 1, 3, &configuration, 0).unwrap();
-        assert_eq!(user2.min_wait, 1);
-        assert_eq!(user2.max_wait, 3);
+        let user2 = GooseUser::new(0, base_url, &configuration, 0).unwrap();
 
         // Confirm the URLs are correctly built using the task_set_host.
         let url = user2.build_url("/foo").unwrap();
@@ -2876,7 +2861,7 @@ mod tests {
         // Confirm Goose can build a base_url that includes a path.
         const HOST_WITH_PATH: &str = "http://example.com/with/path/";
         let base_url = get_base_url(Some(HOST_WITH_PATH.to_string()), None, None).unwrap();
-        let user = GooseUser::new(0, base_url, 0, 0, &configuration, 0).unwrap();
+        let user = GooseUser::new(0, base_url, &configuration, 0).unwrap();
 
         // Confirm the URLs are correctly built using the default_host that includes a path.
         let url = user.build_url("foo").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,6 +466,7 @@ use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
     Arc,
 };
+use std::time::Duration;
 use std::{fmt, io, time};
 use tokio::fs::File;
 use tokio::runtime::Runtime;
@@ -549,9 +550,9 @@ pub enum GooseError {
     /// Invalid wait time specified.
     InvalidWaitTime {
         // The specified minimum wait time.
-        min_wait: usize,
+        min_wait: Duration,
         // The specified maximum wait time.
-        max_wait: usize,
+        max_wait: Duration,
         /// An optional explanation of the error.
         detail: String,
     },
@@ -1132,8 +1133,6 @@ impl GooseAttack {
                 weighted_users.push(GooseUser::new(
                     self.task_sets[*task_sets_index].task_sets_index,
                     base_url,
-                    self.task_sets[*task_sets_index].min_wait,
-                    self.task_sets[*task_sets_index].max_wait,
                     &self.configuration,
                     self.metrics.hash,
                 )?);
@@ -1167,8 +1166,6 @@ impl GooseAttack {
                 weighted_users.push(GaggleUser::new(
                     self.task_sets[*task_sets_index].task_sets_index,
                     base_url,
-                    self.task_sets[*task_sets_index].min_wait,
-                    self.task_sets[*task_sets_index].max_wait,
                     &self.configuration,
                     self.metrics.hash,
                 ));

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -25,10 +25,6 @@ pub struct GooseUserInitializer {
     pub task_sets_index: usize,
     /// The base_url for this user thread.
     pub base_url: String,
-    /// Minimum amount of time to sleep after running a task.
-    pub min_wait: usize,
-    /// Maximum amount of time to sleep after running a task.
-    pub max_wait: usize,
     /// A local copy of the global GooseConfiguration.
     pub config: GooseConfiguration,
     /// How long the load test should run, in seconds.
@@ -474,8 +470,6 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                             users.push(GooseUserInitializer {
                                 task_sets_index: user.task_sets_index,
                                 base_url: user.base_url.read().await.to_string(),
-                                min_wait: user.min_wait,
-                                max_wait: user.max_wait,
                                 config: user.config.clone(),
                                 run_time: goose_attack.run_time,
                                 worker_id: workers.len(),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -139,8 +139,6 @@ pub(crate) async fn worker_main(goose_attack: &GooseAttack) -> GooseAttack {
         let user = GooseUser::new(
             initializer.task_sets_index,
             Url::parse(&initializer.base_url).unwrap(),
-            initializer.min_wait,
-            initializer.max_wait,
             &initializer.config,
             goose_attack.metrics.hash,
         )


### PR DESCRIPTION
I some cases, you want to have a high number of request from a small amount of users which is not possible with second as the time units. This allow you to set a waiting time in Duration.
 