### PR TITLE
add link from dev docs to the goose book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.14.1-dev
+ - [#364](https://github.com/tag1consulting/goose/pull/364) add link from the [Developer Documentation](https://docs.rs/goose) to [The Git Book](https://book.goose.rs)
 
 ## 0.14.0 September 15, 2021
  - [#361](https://github.com/tag1consulting/goose/pull/361) convert `README.md` (and enhance) into [`The Goose Book`](https://book.goose.rs/)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Documentation
 //!
-//! - [README](https://github.com/tag1consulting/goose/blob/main/README.md)
+//! - [The Goose Book](https://book.goose.rs)
 //! - [Developer documentation](https://docs.rs/goose/)
 //! - [Blogs and more](https://tag1.com/goose/)
 //!   - [Goose vs Locust and jMeter](https://www.tag1consulting.com/blog/jmeter-vs-locust-vs-goose)


### PR DESCRIPTION
 - [#364](https://github.com/tag1consulting/goose/pull/364) add link from the [Developer Documentation](https://docs.rs/goose) to [The Git Book](https://book.goose.rs)