### PR TITLE
introduce GooseRequest and builder pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.14.2-dev
+## 0.15.0-dev
  - [#372](https://github.com/tag1consulting/goose/pull/372) de-deduplicate documentation, favoring [The Goose Book](https://book.goose.rs)
+ - @TODO: errors ...
 
 ## 0.14.1 October 13, 2021
  - [#364](https://github.com/tag1consulting/goose/pull/364) add link from the [Developer Documentation](https://docs.rs/goose) to [The Git Book](https://book.goose.rs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 0.15.0-dev
  - [#372](https://github.com/tag1consulting/goose/pull/372) de-deduplicate documentation, favoring [The Goose Book](https://book.goose.rs)
- - @TODO: errors ...
+ - [#373](https://github.com/tag1consulting/goose/pull/373) **API change**: introduce `GooseRequest` and `GooseRequestBuilder` for more flexibility when making requests
+    o remove `GooseUser::post_named`, `GooseUser::head_named`, `GooseUser::delete_named`, `GooseUser::goose_get`, `GooseUser::goose_put`, `GooseUser::goose_head`, `GooseUser::goose_put`, `GooseUser::goose_patch`, `GooseUser::goose_delete`, and `GooseUser::goose_send`
+    o adds or modifies helpers `GooseUser::get`, `GooseUser::get_named`, `GooseUser::post`, `GooseUser::post_form`, `GooseUser::post_json`, `GooseUser::head`, and `GooseUser::delete`
+    o replaces `GooseUser::goose_send` with `GooseUser::request` which accepts a `GooseRequest` object
+    o fixes [#370] (see `GooseRequestBuilder::expect_status_code`)
 
 ## 0.14.1 October 13, 2021
  - [#364](https://github.com/tag1consulting/goose/pull/364) add link from the [Developer Documentation](https://docs.rs/goose) to [The Git Book](https://book.goose.rs)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.14.2-dev"
+version = "0.15.0-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/examples/drupal_memcache.rs
+++ b/examples/drupal_memcache.rs
@@ -104,14 +104,7 @@ async fn drupal_memcache_front_page(user: &mut GooseUser) -> GooseTaskResult {
                         }
                     }
                     for asset in &urls {
-                        let _ = user
-                            .request(
-                                GooseRequest::builder()
-                                    .path(&*asset.to_string())
-                                    .name("static asset")
-                                    .build(),
-                            )
-                            .await;
+                        let _ = user.get_named(&*asset.to_string(), "static asset").await;
                     }
                 }
                 Err(e) => {

--- a/examples/drupal_memcache.rs
+++ b/examples/drupal_memcache.rs
@@ -104,7 +104,14 @@ async fn drupal_memcache_front_page(user: &mut GooseUser) -> GooseTaskResult {
                         }
                     }
                     for asset in &urls {
-                        let _ = user.get_named(asset, "static asset").await;
+                        let _ = user
+                            .request(
+                                GooseRequest::builder()
+                                    .path(&*asset.to_string())
+                                    .name("static asset")
+                                    .build(),
+                            )
+                            .await;
                     }
                 }
                 Err(e) => {
@@ -185,8 +192,7 @@ async fn drupal_memcache_login(user: &mut GooseUser) -> GooseTaskResult {
                         ("form_id", "user_login"),
                         ("op", "Log+in"),
                     ];
-                    let request_builder = user.goose_post("/user")?;
-                    let _goose = user.goose_send(request_builder.form(&params), None).await;
+                    let _goose = user.post_form("/user", &params).await?;
                     // @TODO: verify that we actually logged in.
                 }
                 Err(e) => {
@@ -302,8 +308,7 @@ async fn drupal_memcache_post_comment(user: &mut GooseUser) -> GooseTaskResult {
                     ];
 
                     // Post the comment.
-                    let request_builder = user.goose_post(&comment_path)?;
-                    let mut goose = user.goose_send(request_builder.form(&params), None).await?;
+                    let mut goose = user.post_form(&comment_path, &params).await?;
 
                     // Verify that the comment posted.
                     match goose.response {

--- a/examples/drupal_memcache.rs
+++ b/examples/drupal_memcache.rs
@@ -104,7 +104,7 @@ async fn drupal_memcache_front_page(user: &mut GooseUser) -> GooseTaskResult {
                         }
                     }
                     for asset in &urls {
-                        let _ = user.get_named(&*asset.to_string(), "static asset").await;
+                        let _ = user.get_named(asset, "static asset").await;
                     }
                 }
                 Err(e) => {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -45,10 +45,8 @@ async fn main() -> Result<(), GooseError> {
 /// on_start task when registering it above. This means it only runs one time
 /// per user, when the user thread first starts.
 async fn website_login(user: &mut GooseUser) -> GooseTaskResult {
-    let request_builder = user.goose_post("/login")?;
-    // https://docs.rs/reqwest/*/reqwest/blocking/struct.RequestBuilder.html#method.form
     let params = [("username", "test_user"), ("password", "")];
-    let _goose = user.goose_send(request_builder.form(&params), None).await?;
+    let _goose = user.post_form("/login", &params).await?;
 
     Ok(())
 }

--- a/examples/simple_with_session.rs
+++ b/examples/simple_with_session.rs
@@ -77,7 +77,7 @@ async fn authenticated_index(user: &mut GooseUser) -> GooseTaskResult {
     let session = user.get_session_data_unchecked::<Session>();
     let goose_request = GooseRequest::builder()
         .request_builder(
-            user.request_builder(&GooseMethod::Get, "/")?
+            user.get_request_builder(&GooseMethod::Get, "/")?
                 .bearer_auth(&session.jwt_token),
         )
         .build();

--- a/examples/simple_with_session.rs
+++ b/examples/simple_with_session.rs
@@ -75,10 +75,11 @@ async fn authenticated_index(user: &mut GooseUser) -> GooseTaskResult {
     // This will panic if the session is missing or if the session is not of the right type
     // use `get_session_data` to handle missing session
     let session = user.get_session_data_unchecked::<Session>();
-    let url = user.build_url("/")?;
-    let request_builder = user.client.get(url).bearer_auth(&session.jwt_token);
     let goose_request = GooseRequest::builder()
-        .request_builder(request_builder)
+        .request_builder(
+            user.request_builder(&GooseMethod::Get, "/")?
+                .bearer_auth(&session.jwt_token),
+        )
         .build();
 
     user.request(goose_request).await?;

--- a/examples/simple_with_session.rs
+++ b/examples/simple_with_session.rs
@@ -72,16 +72,22 @@ async fn website_signup(user: &mut GooseUser) -> GooseTaskResult {
 
 /// A very simple task that simply loads the front page.
 async fn authenticated_index(user: &mut GooseUser) -> GooseTaskResult {
-    // This will panic if the session is missing or if the session is not of the right type
-    // use `get_session_data` to handle missing session
+    // This will panic if the session is missing or if the session is not of the right type.
+    // Use `get_session_data` to handle a missing session.
     let session = user.get_session_data_unchecked::<Session>();
+
+    // Create a Reqwest RequestBuilder object and configure bearer authentication when making
+    // a GET request for the index.
+    let reqwest_request_builder = user
+        .get_request_builder(&GooseMethod::Get, "/")?
+        .bearer_auth(&session.jwt_token);
+
+    // Add the manually created RequestBuilder and build a GooseRequest object.
     let goose_request = GooseRequest::builder()
-        .request_builder(
-            user.get_request_builder(&GooseMethod::Get, "/")?
-                .bearer_auth(&session.jwt_token),
-        )
+        .set_request_builder(reqwest_request_builder)
         .build();
 
+    // Make the actual request.
     user.request(goose_request).await?;
 
     Ok(())

--- a/examples/umami/admin.rs
+++ b/examples/umami/admin.rs
@@ -66,8 +66,7 @@ pub async fn log_in(user: &mut GooseUser) -> GooseTaskResult {
                         ("form_id", &"user_login_form".to_string()),
                         ("op", &"Log+in".to_string()),
                     ];
-                    let request_builder = user.goose_post("/en/user/login")?;
-                    logged_in_user = user.goose_send(request_builder.form(&params), None).await?;
+                    logged_in_user = user.post_form("/en/user/login", &params).await?;
 
                     // A successful log in is redirected.
                     if !logged_in_user.request.redirected {
@@ -169,9 +168,9 @@ pub async fn edit_article(user: &mut GooseUser) -> GooseTaskResult {
                         ("form_id", &"node_article_edit_form".to_string()),
                         ("op", &"Save (this translation)".to_string()),
                     ];
-                    let request_builder =
-                        user.goose_post(&format!("/en/node/{}/edit", article.unwrap().nid))?;
-                    saved_article = user.goose_send(request_builder.form(&params), None).await?;
+                    saved_article = user
+                        .post_form(&format!("/en/node/{}/edit", article.unwrap().nid), &params)
+                        .await?;
 
                     // A successful node save is redirected.
                     if !saved_article.request.redirected {

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -443,14 +443,7 @@ pub async fn load_static_elements(user: &mut GooseUser, html: &str) {
 
     // Load all the static assets found on the page.
     for asset in &urls {
-        let _ = user
-            .request(
-                GooseRequest::builder()
-                    .path(&*asset.to_string())
-                    .name("static asset")
-                    .build(),
-            )
-            .await;
+        let _ = user.get_named(&*asset.to_string(), "static asset").await;
     }
 }
 

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -443,7 +443,7 @@ pub async fn load_static_elements(user: &mut GooseUser, html: &str) {
 
     // Load all the static assets found on the page.
     for asset in &urls {
-        let _ = user.get_named(&*asset.to_string(), "static asset").await;
+        let _ = user.get_named(asset, "static asset").await;
     }
 }
 

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -443,7 +443,14 @@ pub async fn load_static_elements(user: &mut GooseUser, html: &str) {
 
     // Load all the static assets found on the page.
     for asset in &urls {
-        let _ = user.get_named(asset, "static asset").await;
+        let _ = user
+            .request(
+                GooseRequest::builder()
+                    .path(&*asset.to_string())
+                    .name("static asset")
+                    .build(),
+            )
+            .await;
     }
 }
 
@@ -565,8 +572,7 @@ pub async fn anonymous_contact_form(user: &mut GooseUser, english: bool) -> Goos
                         ("form_id", "contact_message_feedback_form"),
                         ("op", "Send+message"),
                     ];
-                    let request_builder = user.goose_post(contact_form_url)?;
-                    contact_form = user.goose_send(request_builder.form(&params), None).await?;
+                    contact_form = user.post_form(contact_form_url, &params).await?;
                 }
                 Err(e) => {
                     return user.set_failure(
@@ -694,8 +700,7 @@ pub async fn search(user: &mut GooseUser, english: bool) -> GooseTaskResult {
                         ("form_id", "search_form"),
                         ("op", "Search"),
                     ];
-                    let request_builder = user.goose_post(search_form_url)?;
-                    search_form = user.goose_send(request_builder.form(&params), None).await?;
+                    search_form = user.post_form(search_form_url, &params).await?;
 
                     // A successful search is redirected.
                     if !search_form.request.redirected {

--- a/src/docs/goose-book/src/config/rustls.md
+++ b/src/docs/goose-book/src/config/rustls.md
@@ -4,5 +4,5 @@ By default Reqwest (and therefore Goose) uses the system-native transport layer 
 
 ```toml
 [dependencies]
-goose = { version = "^0.14", default-features = false, features = ["rustls-tls"] }
+goose = { version = "^0.15", default-features = false, features = ["rustls-tls"] }
 ```

--- a/src/docs/goose-book/src/controller/telnet.md
+++ b/src/docs/goose-book/src/controller/telnet.md
@@ -11,7 +11,7 @@ Trying 127.0.0.1...
 Connected to localhost.
 Escape character is '^]'.
 goose> ?
-goose 0.14.1 controller commands:
+goose 0.15.0 controller commands:
  help (?)           this help
  exit (quit)        exit controller
  start              start an idle load test

--- a/src/docs/goose-book/src/getting-started/creating.md
+++ b/src/docs/goose-book/src/getting-started/creating.md
@@ -12,7 +12,7 @@ This creates a new directory named `loadtest/` containing `loadtest/Cargo.toml` 
 
 ```toml
 [dependencies]
-goose = "^0.14"
+goose = "^0.15"
 tokio = "^1.12"
 ```
 
@@ -21,9 +21,9 @@ At this point it's possible to compile all dependencies, though the resulting bi
 ```bash
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.14.1
+  Downloaded goose v0.15.0
       ...
-   Compiling goose v0.14.1
+   Compiling goose v0.15.0
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`
@@ -41,7 +41,8 @@ use goose::prelude::*;
 > ```rust
 > use crate::config::{GooseDefault, GooseDefaultType};
 > use crate::goose::{
->     GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet, GooseUser,
+>     GooseMethod, GooseRequest, GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult,
+>     GooseTaskSet, GooseUser,
 > };
 > use crate::metrics::{GooseCoordinatedOmissionMitigation, GooseMetrics};
 > use crate::{task, taskset, GooseAttack, GooseError, GooseScheduler};

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1238,6 +1238,22 @@ impl GooseUser {
         Ok(self.request(GooseRequest::delete(path)).await?)
     }
 
+    pub fn request_builder(
+        &self,
+        method: &GooseMethod,
+        path: &str,
+    ) -> Result<RequestBuilder, GooseTaskError> {
+        let url = self.build_url(path)?;
+        Ok(match method {
+            GooseMethod::Delete => self.client.delete(&url),
+            GooseMethod::Get => self.client.get(&url),
+            GooseMethod::Head => self.client.head(&url),
+            GooseMethod::Patch => self.client.patch(&url),
+            GooseMethod::Post => self.client.post(&url),
+            GooseMethod::Put => self.client.put(&url),
+        })
+    }
+
     /// Builds the provided
     /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
     /// object and then executes the response. If metrics are being displayed, it
@@ -1280,15 +1296,7 @@ impl GooseUser {
         let request_builder = if request.request_builder.is_some() {
             request.request_builder.take().unwrap()
         } else {
-            let url = self.build_url(request.path)?;
-            match request.method {
-                GooseMethod::Delete => self.client.delete(&url),
-                GooseMethod::Get => self.client.get(&url),
-                GooseMethod::Head => self.client.head(&url),
-                GooseMethod::Patch => self.client.patch(&url),
-                GooseMethod::Post => self.client.post(&url),
-                GooseMethod::Put => self.client.put(&url),
-            }
+            self.request_builder(&request.method, request.path)?
         };
 
         // Determine the name for this request.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -2,10 +2,10 @@
 //!
 //! Goose manages load tests with a series of objects:
 //!
-//! - [`GooseTaskSet`](./struct.GooseTaskSet.html) each user is assigned a task set, which is a collection of tasks.
-//! - [`GooseTask`](./struct.GooseTask.html) tasks define one or more web requests and are assigned to task sets.
-//! - [`GooseUser`](./struct.GooseUser.html) a user state responsible for repeatedly running all tasks in the assigned task set.
-//! - [`GooseRequest`](./struct.GooseRequest.html) optional metrics collected for each URL/method pair.
+//! - [`GooseTaskSet`] each user is assigned a task set, which is a collection of tasks.
+//! - [`GooseTask`] tasks define one or more web requests and are assigned to task sets.
+//! - [`GooseUser`] a user state responsible for repeatedly running all tasks in the assigned task set.
+//! - [`GooseRequestMetric`] optional metrics collected for each URL/method pair.
 //!
 //! ## Creating Task Sets
 //!
@@ -686,7 +686,7 @@ pub fn goose_method_from_method(method: Method) -> Result<GooseMethod, GooseTask
     })
 }
 
-/// The response to a GooseRequest
+/// The response to a [`GooseRequestMetric`].
 #[derive(Debug)]
 pub struct GooseResponse {
     /// The request that this is a response to.
@@ -1093,17 +1093,13 @@ impl GooseUser {
     /// A helper to make a `GET` request of a path and collect relevant metrics.
     /// Automatically prepends the correct host.
     ///
-    /// (If you need to set headers, change timeouts, or otherwise make use of the
-    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
-    /// object, you can instead call [`goose_get`](./struct.GooseUser.html#method.goose_get)
-    /// which returns a
-    /// [`RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html),
-    /// then call
-    /// [`goose_send`](./struct.GooseUser.html#method.goose_send) to invoke the request.)
-    ///
     /// Calls to `get()` return a [`GooseResponse`](./struct.GooseResponse.html) object which
     /// contains a copy of the request you made ([`GooseRequestMetric`](./struct.GooseRequestMetric.html)),
     /// and the response ([`reqwest::Response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    ///
+    /// If you need to set headers, change timeouts, or otherwise make use of the
+    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
+    /// object, refer to [`GooseUser::get_request_builder`].
     ///
     /// # Example
     /// ```rust
@@ -1125,15 +1121,13 @@ impl GooseUser {
     /// A helper to make a `POST` request of a path and collect relevant metrics.
     /// Automatically prepends the correct host.
     ///
-    /// (If you need to set headers, change timeouts, or otherwise make use of the
-    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
-    /// object, you can instead call `goose_post` which returns a
-    /// [`RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html),
-    /// then call `goose_send` to invoke the request.)
-    ///
     /// Calls to `post()` return a [`GooseResponse`](./struct.GooseResponse.html) object which
     /// contains a copy of the request you made ([`GooseRequestMetric`](./struct.GooseRequestMetric.html)),
     /// and the response ([`reqwest::Response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    ///
+    /// If you need to set headers, change timeouts, or otherwise make use of the
+    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
+    /// object, refer to [`GooseUser::get_request_builder`].
     ///
     /// # Example
     /// ```rust
@@ -1163,6 +1157,31 @@ impl GooseUser {
         Ok(self.request(goose_request).await?)
     }
 
+    /// A helper to make a `POST` request of a form on a path and collect relevant metrics.
+    /// Automatically prepends the correct host.
+    ///
+    /// Calls to `post_form()` return a [`GooseResponse`](./struct.GooseResponse.html) object which
+    /// contains a copy of the request you made ([`GooseRequestMetric`](./struct.GooseRequestMetric.html)),
+    /// and the response ([`reqwest::Response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    ///
+    /// If you need to set headers, change timeouts, or otherwise make use of the
+    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
+    /// object, refer to [`GooseUser::get_request_builder`].
+    ///
+    /// # Example
+    /// ```rust
+    /// use goose::prelude::*;
+    ///
+    /// let mut task = task!(post_function);
+    ///
+    /// /// A very simple task that POSTs form parameters.
+    /// async fn post_function(user: &mut GooseUser) -> GooseTaskResult {
+    ///     let params = [("foo", "bar"), ("foo2", "bar2")];
+    ///     let _goose = user.post_form("path/to/foo/", &params).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn post_form<T: Serialize + ?Sized>(
         &mut self,
         path: &str,
@@ -1181,15 +1200,13 @@ impl GooseUser {
     /// A helper to make a `HEAD` request of a path and collect relevant metrics.
     /// Automatically prepends the correct host.
     ///
-    /// (If you need to set headers, change timeouts, or otherwise make use of the
-    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
-    /// object, you can instead call `goose_head` which returns a
-    /// [`RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html),
-    /// then call `goose_send` to invoke the request.)
-    ///
     /// Calls to `head()` return a [`GooseResponse`](./struct.GooseResponse.html) object which
     /// contains a copy of the request you made ([`GooseRequestMetric`](./struct.GooseRequestMetric.html)),
     /// and the response ([`reqwest::Response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    ///
+    /// If you need to set headers, change timeouts, or otherwise make use of the
+    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
+    /// object, refer to [`GooseUser::get_request_builder`].
     ///
     /// # Example
     /// ```rust
@@ -1211,15 +1228,13 @@ impl GooseUser {
     /// A helper to make a `DELETE` request of a path and collect relevant metrics.
     /// Automatically prepends the correct host.
     ///
-    /// (If you need to set headers, change timeouts, or otherwise make use of the
-    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
-    /// object, you can instead call `goose_delete` which returns a
-    /// [`RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html),
-    /// then call `goose_send` to invoke the request.)
-    ///
     /// Calls to `delete()` return a [`GooseResponse`](./struct.GooseResponse.html) object which
     /// contains a copy of the request you made ([`GooseRequestMetric`](./struct.GooseRequestMetric.html)),
     /// and the response ([`reqwest::Response`](https://docs.rs/reqwest/*/reqwest/struct.Response.html)).
+    ///
+    /// If you need to set headers, change timeouts, or otherwise make use of the
+    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
+    /// object, refer to [`GooseUser::get_request_builder`].
     ///
     /// # Example
     /// ```rust
@@ -1238,12 +1253,54 @@ impl GooseUser {
         Ok(self.request(GooseRequest::delete(path)).await?)
     }
 
-    pub fn request_builder(
+    /// Used to get a [`reqwest::RequestBuilder`] object. If no [`reqwest::RequestBuilder`] is
+    /// already defined in the [`GooseRequest`] passed to [`GooseUser::request`] it will automatically
+    /// invoke this function.
+    ///
+    /// The HTTP request method must be defined as a [`GooseMethod`], and the path that will be requested
+    /// must be defined as a [`&str`].
+    ///
+    /// It is possible to use this function to directly interact with the [`reqwest::RequestBuilder`]
+    /// object and the [`GooseRequest`] object during load tests. In the following example, we set a
+    /// timeout on the Request, and tell Goose to expect a 404 HTTP response status code.
+    ///
+    /// # Example
+    /// ```rust
+    /// use goose::prelude::*;
+    ///
+    /// let mut task = task!(test_404);
+    ///
+    /// async fn test_404(user: &mut GooseUser) -> GooseTaskResult {
+    ///     use std::time::Duration;
+    ///
+    ///     // Manually interact with the Reqwest RequestBuilder object.
+    ///     let request_builder = user.get_request_builder(&GooseMethod::Get, "no/such/path")?
+    ///         // Configure the request to timeout if it takes longer than 500 milliseconds.
+    ///         .timeout(Duration::from_millis(500));
+    ///
+    ///     // Manually build a GooseRequest.
+    ///     let goose_request = GooseRequest::builder()
+    ///         // Manually add our custom RequestBuilder object.
+    ///         .request_builder(request_builder)
+    ///         // Tell Goose to expect a 404 status code.
+    ///         .expect_status_code(404)
+    ///         // Turn the GooseRequestBuilder object into a GooseRequest.
+    ///         .build();
+    ///
+    ///     // Finaly make the actual request with our custom GooseRequest object.
+    ///     let _goose = user.request(goose_request).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn get_request_builder(
         &self,
         method: &GooseMethod,
         path: &str,
     ) -> Result<RequestBuilder, GooseTaskError> {
+        // Prepend the `base_url` to all relative paths.
         let url = self.build_url(path)?;
+        // Invoke Reqwest function appropriate to the request method.
         Ok(match method {
             GooseMethod::Delete => self.client.delete(&url),
             GooseMethod::Get => self.client.get(&url),
@@ -1254,18 +1311,10 @@ impl GooseUser {
         })
     }
 
-    /// Builds the provided
-    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
-    /// object and then executes the response. If metrics are being displayed, it
-    /// also captures request metrics.
+    /// Makes a request for the provided [`GooseRequest`] object, and if metrics are enabled
+    /// captures relevant metrics.
     ///
-    /// It is possible to build and execute a
-    /// [`reqwest::RequestBuilder`](https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html)
-    /// object directly with [`reqwest`](https://docs.rs/reqwest/) without using this helper
-    /// function, but then Goose is unable to capture metrics.
-    ///
-    /// Calls to `goose_send()` returns a `Result` containing a
-    /// [`GooseResponse`](./struct.GooseResponse.html) on success, and a
+    /// Calls to `request()` return a [`Result`] containing a [`GooseResponse`] on success, and a
     /// [`flume::SendError`](https://docs.rs/flume/*/flume/struct.SendError.html)`<bool>`,
     /// on failure. Failure only happens when `--throttle-requests` is enabled and the load test
     /// completes. The [`GooseResponse`](./struct.GooseResponse.html) object contains a copy of
@@ -1278,11 +1327,16 @@ impl GooseUser {
     ///
     /// let mut task = task!(get_function);
     ///
-    /// /// A simple task that makes a GET request, exposing the Reqwest
-    /// /// request builder.
-    /// /// @TODO
+    /// /// A simple task that makes a GET request.
     /// async fn get_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let goose = user.get("/path/to/foo").await?;
+    ///     let goose_request = GooseRequest::builder()
+    ///       // Goose will prepend a host name to this path.
+    ///       .path("path/to/loadtest")
+    ///       // GET is the default method, this is not necessary.
+    ///       .method(GooseMethod::Get)
+    ///       // Assemble the `GooseRequestBuilder` into a `GooseRequest.
+    ///       .build();
+    ///     let goose = user.request(goose_request).await?;
     ///
     ///     // Do stuff with goose.request and/or goose.response here.
     ///
@@ -1293,10 +1347,12 @@ impl GooseUser {
         &mut self,
         mut request: GooseRequest<'_>,
     ) -> Result<GooseResponse, GooseTaskError> {
+        // If the RequestBuilder is already defined in the GooseRequest use it.
         let request_builder = if request.request_builder.is_some() {
             request.request_builder.take().unwrap()
+        // Otherwise get a new RequestBuilder.
         } else {
-            self.request_builder(&request.method, request.path)?
+            self.get_request_builder(&request.method, request.path)?
         };
 
         // Determine the name for this request.
@@ -1310,12 +1366,13 @@ impl GooseUser {
             self.throttle.clone().unwrap().send_async(true).await?;
         };
 
-        // The request is officially started
+        // Once past the throttle, the request is officially started.
         let started = Instant::now();
 
+        // Create a Reqwest Request object from the RequestBuilder.
         let built_request = request_builder.build()?;
 
-        // String version of request path.
+        // Get a string version of request path for logging.
         let path = match Url::parse(&built_request.url().to_string()) {
             Ok(u) => u.path().to_string(),
             Err(e) => {
@@ -1365,23 +1422,28 @@ impl GooseUser {
         let response = self.client.execute(built_request).await;
         request_metric.set_response_time(started.elapsed().as_millis());
 
+        // Determine if the request suceeded or failed.
         match &response {
             Ok(r) => {
                 let status_code = r.status();
                 debug!("{:?}: status_code {}", &path, status_code);
 
+                // Update the request_metric object.
+                request_metric.set_status_code(Some(status_code));
+                request_metric.set_final_url(r.url().as_str());
+
+                // Check if we were expecting a specific status code.
                 if let Some(expect_status_code) = request.expect_status_code {
+                    // Record a failure if the expected status code was not returned.
                     if status_code != expect_status_code {
                         request_metric.success = false;
                         request_metric.error = format!("{}: {}", status_code, request_name);
                     }
+                // Otherwise record a failure if the returned status code was not a success.
                 } else if !status_code.is_success() {
                     request_metric.success = false;
                     request_metric.error = format!("{}: {}", status_code, request_name);
                 }
-
-                request_metric.set_status_code(Some(status_code));
-                request_metric.set_final_url(r.url().as_str());
 
                 // Load test user was redirected.
                 if self.config.sticky_follow && request_metric.raw.url != request_metric.final_url {

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -80,7 +80,7 @@
 //!
 //! /// A very simple task that loads the front page.
 //! async fn task_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/").await?;
+//!     let _goose = user.get("").await?;
 //!
 //!     Ok(())
 //! }
@@ -98,7 +98,7 @@
 //!
 //! /// A very simple task that loads the front page.
 //! async fn task_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/").await?;
+//!     let _goose = user.get("").await?;
 //!
 //!     Ok(())
 //! }
@@ -123,14 +123,14 @@
 //!
 //! /// A very simple task that loads the "a" page.
 //! async fn a_task_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/a/").await?;
+//!     let _goose = user.get("a/").await?;
 //!
 //!     Ok(())
 //! }
 //!
 //! /// Another very simple task that loads the "b" page.
 //! async fn b_task_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/b/").await?;
+//!     let _goose = user.get("b/").await?;
 //!
 //!     Ok(())
 //! }
@@ -155,21 +155,21 @@
 //!
 //! /// A very simple task that loads the "a" page.
 //! async fn a_task_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/a/").await?;
+//!     let _goose = user.get("a/").await?;
 //!
 //!     Ok(())
 //! }
 //!
 //! /// Another very simple task that loads the "b" page.
 //! async fn b_task_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/b/").await?;
+//!     let _goose = user.get("b/").await?;
 //!
 //!     Ok(())
 //! }
 //!
 //! /// Another very simple task that loads the "c" page.
 //! async fn c_task_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/c/").await?;
+//!     let _goose = user.get("c/").await?;
 //!
 //!     Ok(())
 //! }
@@ -190,7 +190,7 @@
 //!
 //! /// A very simple task that loads the "a" page.
 //! async fn a_task_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/a/").await?;
+//!     let _goose = user.get("a/").await?;
 //!
 //!     Ok(())
 //! }
@@ -211,7 +211,7 @@
 //!
 //! /// Another very simple task that loads the "b" page.
 //! async fn b_task_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/b/").await?;
+//!     let _goose = user.get("b/").await?;
 //!
 //!     Ok(())
 //! }
@@ -242,7 +242,7 @@
 //!
 //! /// A very simple task that makes a GET request.
 //! async fn get_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.get("/path/to/foo/").await?;
+//!     let _goose = user.get("path/to/foo/").await?;
 //!
 //!     Ok(())
 //! }
@@ -265,7 +265,7 @@
 //!
 //! /// A very simple task that makes a POST request.
 //! async fn post_function(user: &mut GooseUser) -> GooseTaskResult {
-//!     let _goose = user.post("/path/to/foo/", "string value to post").await?;
+//!     let _goose = user.post("path/to/foo/", "string value to post").await?;
 //!
 //!     Ok(())
 //! }
@@ -533,7 +533,7 @@ impl GooseTaskSet {
     ///
     /// /// A very simple task that loads the "a" page.
     /// async fn a_task_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/a/").await?;
+    ///     let _goose = user.get("a/").await?;
     ///
     ///     Ok(())
     /// }
@@ -1109,7 +1109,7 @@ impl GooseUser {
     ///
     /// /// A very simple task that makes a GET request.
     /// async fn get_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/path/to/foo/").await?;
+    ///     let _goose = user.get("path/to/foo/").await?;
     ///
     ///     Ok(())
     /// }
@@ -1144,7 +1144,7 @@ impl GooseUser {
     ///
     /// /// A very simple task that makes a POST request.
     /// async fn post_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.post("/path/to/foo/", "BODY BEING POSTED").await?;
+    ///     let _goose = user.post("path/to/foo/", "BODY BEING POSTED").await?;
     ///
     ///     Ok(())
     /// }
@@ -1223,7 +1223,7 @@ impl GooseUser {
     ///
     /// /// A very simple task that makes a HEAD request.
     /// async fn head_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.head("/path/to/foo/").await?;
+    ///     let _goose = user.head("path/to/foo/").await?;
     ///
     ///     Ok(())
     /// }
@@ -1258,7 +1258,7 @@ impl GooseUser {
     ///
     /// /// A very simple task that makes a DELETE request.
     /// async fn delete_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.delete("/path/to/foo/").await?;
+    ///     let _goose = user.delete("path/to/foo/").await?;
     ///
     ///     Ok(())
     /// }
@@ -1704,7 +1704,7 @@ impl GooseUser {
     ///
     /// /// A simple task that makes a GET request.
     /// async fn get_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let mut goose = user.get("/404").await?;
+    ///     let mut goose = user.get("404").await?;
     ///
     ///     if let Ok(response) = &goose.response {
     ///         // We expect a 404 here.
@@ -1758,7 +1758,7 @@ impl GooseUser {
     /// let mut task = task!(loadtest_index_page);
     ///
     /// async fn loadtest_index_page(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let mut goose = user.get("/").await?;
+    ///     let mut goose = user.get("").await?;
     ///
     ///     if let Ok(response) = goose.response {
     ///         // We only need to check pages that returned a success status code.
@@ -1837,7 +1837,7 @@ impl GooseUser {
     /// let mut task = task!(loadtest_index_page);
     ///
     /// async fn loadtest_index_page(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let mut goose = user.get("/").await?;
+    ///     let mut goose = user.get("").await?;
     ///
     ///     match goose.response {
     ///         Ok(response) => {
@@ -2107,7 +2107,7 @@ impl GooseUser {
     /// }
     ///
     /// async fn task_foo(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/").await?;
+    ///     let _goose = user.get("").await?;
     ///
     ///     Ok(())
     /// }
@@ -2117,7 +2117,7 @@ impl GooseUser {
     ///     // http://foo.example.com, after this task runs all subsequent
     ///     // requests are made against http://bar.example.com/.
     ///     user.set_base_url("http://bar.example.com/");
-    ///     let _goose = user.get("/").await?;
+    ///     let _goose = user.get("").await?;
     ///
     ///     Ok(())
     /// }
@@ -2128,7 +2128,9 @@ impl GooseUser {
     }
 }
 
-/// A GooseRequest ...
+/// Every HTTP request that Goose must be first defined as a GooseRequest. To create a
+/// GooseRequest, use [`GooseRequest::builder`] which returns a [`GooseRequestBuilder`]
+/// object.
 pub struct GooseRequest<'a> {
     // Defaults to ""
     path: &'a str,
@@ -2151,6 +2153,28 @@ impl<'a> GooseRequest<'a> {
 /// Used to build a [`GooseRequest`] object, necessary to make a request with Goose.
 ///
 /// # Example
+/// ```rust
+/// use goose::prelude::*;
+///
+/// let mut a_task = task!(task_function);
+///
+/// // A simple task that loads a relative path.
+/// async fn task_function(user: &mut GooseUser) -> GooseTaskResult {
+///     // Manually create a GooseRequestBuilder object.
+///     let goose_request = GooseRequest::builder()
+///         // Set a relative path to request.
+///         .path("about")
+///         // Name the request in the metircs.
+///         .name("About page")
+///         // Build the GooseRequest object.
+///         .build();
+///
+///     // Make the configured request.
+///     let _goose = user.request(goose_request).await?;
+///
+///     Ok(())
+/// }
+/// ```
 pub struct GooseRequestBuilder<'a> {
     path: &'a str,
     method: GooseMethod,
@@ -2170,31 +2194,184 @@ impl<'a> GooseRequestBuilder<'a> {
         }
     }
 
+    /// Set the path to request.
+    ///
+    /// Typically is a relative path allowing Goose to append a configurable base_url.
+    ///
+    /// Defaults to "" (the main index).
+    ///
+    /// # Example
+    /// This can be implemented in a simpler way using the [`GooseUser::get`] helper function.
+    /// ```rust
+    /// use goose::prelude::*;
+    ///
+    /// let mut a_task = task!(task_function);
+    ///
+    /// // A simple task that loads a relative path.
+    /// async fn task_function(user: &mut GooseUser) -> GooseTaskResult {
+    ///     // Manually create a GooseRequestBuilder object.
+    ///     let goose_request = GooseRequest::builder()
+    ///         // Set a relative path to request.
+    ///         .path("a/relative/path")
+    ///         // Build the GooseRequest object.
+    ///         .build();
+    ///
+    ///     // Make the configured request.
+    ///     let _goose = user.request(goose_request).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn path(mut self, path: impl Into<&'a str>) -> Self {
         self.path = path.into();
         self
     }
 
+    /// Set the method of the request.
+    ///
+    /// Must be set to a [`GooseMethod`].
+    ///
+    /// Defaults to [`GooseMethod::Get`].
+    ///
+    /// # Example
+    /// ```rust
+    /// use goose::prelude::*;
+    ///
+    /// let mut a_task = task!(task_function);
+    ///
+    /// // Make a DELETE request.
+    /// async fn task_function(user: &mut GooseUser) -> GooseTaskResult {
+    ///     // Manually create a GooseRequestBuilder object.
+    ///     let goose_request = GooseRequest::builder()
+    ///         // Set a relative path to request.
+    ///         .path("path/to/delete")
+    ///         // Set the method to DELETE.
+    ///         .method(GooseMethod::Delete)
+    ///         // Build the GooseRequest object.
+    ///         .build();
+    ///
+    ///     // Make the configured DELETE request.
+    ///     let _goose = user.request(goose_request).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn method(mut self, method: GooseMethod) -> Self {
         self.method = method;
         self
     }
 
+    /// Set a name for the request, affecting how it shows up in metrics.
+    ///
+    /// Must be set to a [`GooseMethod`].
+    ///
+    /// Defaults to [`GooseMethod::Get`].
+    ///
+    /// # Example
+    /// ```rust
+    /// use goose::prelude::*;
+    ///
+    /// let mut a_task = task!(task_function);
+    ///
+    /// // Make a named request.
+    /// async fn task_function(user: &mut GooseUser) -> GooseTaskResult {
+    ///     // Manually create a GooseRequestBuilder object.
+    ///     let goose_request = GooseRequest::builder()
+    ///         // Set a relative path to request.
+    ///         .path("path/to/request")
+    ///         // Name the request in the metrics.
+    ///         .name("custom name")
+    ///         // Build the GooseRequest object.
+    ///         .build();
+    ///
+    ///     // Make the configured request.
+    ///     let _goose = user.request(goose_request).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn name(mut self, name: impl Into<&'a str>) -> Self {
         self.name = Some(name.into());
         self
     }
 
+    /// Manually configure the expected HTTP response status code.
+    ///
+    /// Defaults to [`reqwest::StatusCode::is_success`].
+    ///
+    /// # Example
+    /// Intentionally request a 404 page, and do not trigger an error.
+    /// ```rust
+    /// use goose::prelude::*;
+    ///
+    /// let mut a_task = task!(task_function);
+    ///
+    /// // Make a named request.
+    /// async fn task_function(user: &mut GooseUser) -> GooseTaskResult {
+    ///     // Manually create a GooseRequestBuilder object.
+    ///     let goose_request = GooseRequest::builder()
+    ///         // Set a relative path to request.
+    ///         .path("no/such/path")
+    ///         // Tell Goose to expect a 404 HTTP response status code.
+    ///         .expect_status_code(404)
+    ///         // Build the GooseRequest object.
+    ///         .build();
+    ///
+    ///     // Make the configured request.
+    ///     let _goose = user.request(goose_request).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn expect_status_code(mut self, status_code: u16) -> Self {
         self.expect_status_code = Some(status_code);
         self
     }
 
+    /// Manually create the [`reqwest::RequestBuilder`] used to make a request.
+    ///
+    /// # Example
+    /// Manually create a `RequestBuilder` in order to set a timeout.
+    /// ```rust
+    /// use goose::prelude::*;
+    ///
+    /// let mut a_task = task!(task_function);
+    ///
+    /// async fn task_function(user: &mut GooseUser) -> GooseTaskResult {
+    ///     use std::time::Duration;
+    ///
+    ///     // Manually interact with the Reqwest RequestBuilder object.
+    ///     let request_builder = user.get_request_builder(&GooseMethod::Get, "no/such/path")?
+    ///         // Configure the request to timeout if it takes longer than 500 milliseconds.
+    ///         .timeout(Duration::from_millis(500));
+    ///
+    ///     // Manually build a GooseRequest in order to set our custom RequestBuilder.
+    ///     let goose_request = GooseRequest::builder()
+    ///         // Manually add our custom RequestBuilder object.
+    ///         .set_request_builder(request_builder)
+    ///         // Turn the GooseRequestBuilder object into a GooseRequest.
+    ///         .build();
+    ///
+    ///     // Finaly make the actual request with our custom GooseRequest object.
+    ///     let _goose = user.request(goose_request).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_request_builder(mut self, request_builder: RequestBuilder) -> Self {
         self.request_builder = Some(request_builder);
         self
     }
 
+    /// Build the [`GooseRequest`] object which is then passed to [`GooseUser::request`].
+    ///
+    /// # Example
+    /// ```rust
+    /// use goose::prelude::*;
+    ///
+    /// // Build the default "GET /".
+    /// let goose_request = GooseRequest::builder().build();
+    /// ```
     pub fn build(self) -> GooseRequest<'a> {
         let Self {
             path,
@@ -2345,7 +2522,7 @@ impl GooseTask {
     /// task!(my_task_function).set_name("foo");
     ///
     /// async fn my_task_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/").await?;
+    ///     let _goose = user.get("").await?;
     ///
     ///     Ok(())
     /// }
@@ -2373,7 +2550,7 @@ impl GooseTask {
     /// task!(my_on_start_function).set_on_start();
     ///
     /// async fn my_on_start_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/").await?;
+    ///     let _goose = user.get("").await?;
     ///
     ///     Ok(())
     /// }
@@ -2401,7 +2578,7 @@ impl GooseTask {
     /// task!(my_on_stop_function).set_on_stop();
     ///
     /// async fn my_on_stop_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/").await?;
+    ///     let _goose = user.get("").await?;
     ///
     ///     Ok(())
     /// }
@@ -2428,7 +2605,7 @@ impl GooseTask {
     /// }
     ///
     /// async fn task_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/").await?;
+    ///     let _goose = user.get("").await?;
     ///
     ///     Ok(())
     /// }
@@ -2469,19 +2646,19 @@ impl GooseTask {
     /// let runs_last = task!(third_task_function);
     ///
     /// async fn first_task_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/1").await?;
+    ///     let _goose = user.get("1").await?;
     ///
     ///     Ok(())
     /// }
     ///
     /// async fn second_task_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/2").await?;
+    ///     let _goose = user.get("2").await?;
     ///
     ///     Ok(())
     /// }
     ///
     /// async fn third_task_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/3").await?;
+    ///     let _goose = user.get("3").await?;
     ///
     ///     Ok(())
     /// }
@@ -2504,19 +2681,19 @@ impl GooseTask {
     /// }
     ///
     /// async fn first_task_function(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/1").await?;
+    ///     let _goose = user.get("1").await?;
     ///
     ///     Ok(())
     /// }
     ///
     /// async fn second_task_function_a(user: &mut GooseUser) -> GooseTaskResult {
-    ///     let _goose = user.get("/2a").await?;
+    ///     let _goose = user.get("2a").await?;
     ///
     ///     Ok(())
     /// }
     ///
     ///     async fn second_task_function_b(user: &mut GooseUser) -> GooseTaskResult {
-    ///       let _goose = user.get("/2b").await?;
+    ///       let _goose = user.get("2b").await?;
     ///
     ///       Ok(())
     ///     }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1115,7 +1115,14 @@ impl GooseUser {
     /// }
     /// ```
     pub async fn get(&mut self, path: &str) -> Result<GooseResponse, GooseTaskError> {
-        Ok(self.request(GooseRequest::get(path)).await?)
+        Ok(self
+            .request(
+                GooseRequest::builder()
+                    .method(GooseMethod::Get)
+                    .path(path)
+                    .build(),
+            )
+            .await?)
     }
 
     /// A helper to make a `POST` request of a path and collect relevant metrics.
@@ -1151,7 +1158,7 @@ impl GooseUser {
         let request_builder = self.client.post(url);
         let goose_request = GooseRequest::builder()
             .method(GooseMethod::Post)
-            .request_builder(request_builder.body(body))
+            .set_request_builder(request_builder.body(body))
             .build();
 
         Ok(self.request(goose_request).await?)
@@ -1191,7 +1198,7 @@ impl GooseUser {
         let request_builder = self.client.post(url);
         let goose_request = GooseRequest::builder()
             .method(GooseMethod::Post)
-            .request_builder(request_builder.form(&form))
+            .set_request_builder(request_builder.form(&form))
             .build();
 
         Ok(self.request(goose_request).await?)
@@ -1222,7 +1229,14 @@ impl GooseUser {
     /// }
     /// ```
     pub async fn head(&mut self, path: &str) -> Result<GooseResponse, GooseTaskError> {
-        Ok(self.request(GooseRequest::head(path)).await?)
+        Ok(self
+            .request(
+                GooseRequest::builder()
+                    .method(GooseMethod::Head)
+                    .path(path)
+                    .build(),
+            )
+            .await?)
     }
 
     /// A helper to make a `DELETE` request of a path and collect relevant metrics.
@@ -1250,7 +1264,14 @@ impl GooseUser {
     /// }
     /// ```
     pub async fn delete(&mut self, path: &str) -> Result<GooseResponse, GooseTaskError> {
-        Ok(self.request(GooseRequest::delete(path)).await?)
+        Ok(self
+            .request(
+                GooseRequest::builder()
+                    .method(GooseMethod::Delete)
+                    .path(path)
+                    .build(),
+            )
+            .await?)
     }
 
     /// Used to get a [`reqwest::RequestBuilder`] object. If no [`reqwest::RequestBuilder`] is
@@ -1281,7 +1302,7 @@ impl GooseUser {
     ///     // Manually build a GooseRequest.
     ///     let goose_request = GooseRequest::builder()
     ///         // Manually add our custom RequestBuilder object.
-    ///         .request_builder(request_builder)
+    ///         .set_request_builder(request_builder)
     ///         // Tell Goose to expect a 404 status code.
     ///         .expect_status_code(404)
     ///         // Turn the GooseRequestBuilder object into a GooseRequest.
@@ -2125,33 +2146,11 @@ impl<'a> GooseRequest<'a> {
     pub fn builder() -> GooseRequestBuilder<'a> {
         GooseRequestBuilder::new()
     }
-
-    pub fn get(path: &str) -> GooseRequest {
-        GooseRequest::builder().path(path).build()
-    }
-
-    pub fn post(path: &str) -> GooseRequest {
-        GooseRequest::builder()
-            .path(path)
-            .method(GooseMethod::Post)
-            .build()
-    }
-
-    pub fn head(path: &str) -> GooseRequest {
-        GooseRequest::builder()
-            .path(path)
-            .method(GooseMethod::Head)
-            .build()
-    }
-
-    pub fn delete(path: &str) -> GooseRequest {
-        GooseRequest::builder()
-            .path(path)
-            .method(GooseMethod::Delete)
-            .build()
-    }
 }
 
+/// Used to build a [`GooseRequest`] object, necessary to make a request with Goose.
+///
+/// # Example
 pub struct GooseRequestBuilder<'a> {
     path: &'a str,
     method: GooseMethod,
@@ -2160,6 +2159,7 @@ pub struct GooseRequestBuilder<'a> {
     request_builder: Option<RequestBuilder>,
 }
 impl<'a> GooseRequestBuilder<'a> {
+    // Internal helper to build a [`GooseRequest`] from a [`GooseRequestBuilder`].
     fn new() -> Self {
         Self {
             path: "",
@@ -2190,7 +2190,7 @@ impl<'a> GooseRequestBuilder<'a> {
         self
     }
 
-    pub fn request_builder(mut self, request_builder: RequestBuilder) -> Self {
+    pub fn set_request_builder(mut self, request_builder: RequestBuilder) -> Self {
         self.request_builder = Some(request_builder);
         self
     }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1116,14 +1116,14 @@ impl GooseUser {
     /// }
     /// ```
     pub async fn get(&mut self, path: &str) -> Result<GooseResponse, GooseTaskError> {
-        Ok(self
-            .request(
-                GooseRequest::builder()
-                    .method(GooseMethod::Get)
-                    .path(path)
-                    .build(),
-            )
-            .await?)
+        // GET path.
+        let goose_request = GooseRequest::builder()
+            .method(GooseMethod::Get)
+            .path(path)
+            .build();
+
+        // Make the request and return the GooseResponse.
+        Ok(self.request(goose_request).await?)
     }
 
     /// A helper to make a named `GET` request of a path and collect relevant metrics.
@@ -1156,15 +1156,15 @@ impl GooseUser {
         path: &str,
         name: &str,
     ) -> Result<GooseResponse, GooseTaskError> {
-        Ok(self
-            .request(
-                GooseRequest::builder()
-                    .method(GooseMethod::Get)
-                    .path(path)
-                    .name(name)
-                    .build(),
-            )
-            .await?)
+        // GET path named.
+        let goose_request = GooseRequest::builder()
+            .method(GooseMethod::Get)
+            .path(path)
+            .name(name)
+            .build();
+
+        // Make the request and return the GooseResponse.
+        Ok(self.request(goose_request).await?)
     }
 
     /// A helper to make a `POST` request of a path and collect relevant metrics.
@@ -1197,13 +1197,17 @@ impl GooseUser {
         path: &str,
         body: T,
     ) -> Result<GooseResponse, GooseTaskError> {
+        // Build a Reqwest RequestBuilder object.
         let url = self.build_url(path)?;
-        let request_builder = self.client.post(url);
+        let reqwest_request_builder = self.client.post(url);
+
+        // POST request.
         let goose_request = GooseRequest::builder()
             .method(GooseMethod::Post)
-            .set_request_builder(request_builder.body(body))
+            .set_request_builder(reqwest_request_builder.body(body))
             .build();
 
+        // Make the request and return the GooseResponse.
         Ok(self.request(goose_request).await?)
     }
 
@@ -1238,13 +1242,17 @@ impl GooseUser {
         path: &str,
         form: &T,
     ) -> Result<GooseResponse, GooseTaskError> {
+        // Build a Reqwest RequestBuilder object.
         let url = self.build_url(path)?;
-        let request_builder = self.client.post(url);
+        let reqwest_request_builder = self.client.post(url);
+
+        // POST form request.
         let goose_request = GooseRequest::builder()
             .method(GooseMethod::Post)
-            .set_request_builder(request_builder.form(&form))
+            .set_request_builder(reqwest_request_builder.form(&form))
             .build();
 
+        // Make the request and return the GooseResponse.
         Ok(self.request(goose_request).await?)
     }
 
@@ -1282,13 +1290,17 @@ impl GooseUser {
         path: &str,
         json: &T,
     ) -> Result<GooseResponse, GooseTaskError> {
+        // Build a Reqwest RequestBuilder object.
         let url = self.build_url(path)?;
-        let request_builder = self.client.post(url);
+        let reqwest_request_builder = self.client.post(url);
+
+        // POST json request.
         let goose_request = GooseRequest::builder()
             .method(GooseMethod::Post)
-            .set_request_builder(request_builder.json(&json))
+            .set_request_builder(reqwest_request_builder.json(&json))
             .build();
 
+        // Make the request and return the GooseResponse.
         Ok(self.request(goose_request).await?)
     }
 
@@ -1318,14 +1330,14 @@ impl GooseUser {
     /// }
     /// ```
     pub async fn head(&mut self, path: &str) -> Result<GooseResponse, GooseTaskError> {
-        Ok(self
-            .request(
-                GooseRequest::builder()
-                    .method(GooseMethod::Head)
-                    .path(path)
-                    .build(),
-            )
-            .await?)
+        // HEAD request.
+        let goose_request = GooseRequest::builder()
+            .method(GooseMethod::Head)
+            .path(path)
+            .build();
+
+        // Make the request and return the GooseResponse.
+        Ok(self.request(goose_request).await?)
     }
 
     /// A helper to make a `DELETE` request of a path and collect relevant metrics.
@@ -1354,14 +1366,14 @@ impl GooseUser {
     /// }
     /// ```
     pub async fn delete(&mut self, path: &str) -> Result<GooseResponse, GooseTaskError> {
-        Ok(self
-            .request(
-                GooseRequest::builder()
-                    .method(GooseMethod::Delete)
-                    .path(path)
-                    .build(),
-            )
-            .await?)
+        // DELETE request.
+        let goose_request = GooseRequest::builder()
+            .method(GooseMethod::Delete)
+            .path(path)
+            .build();
+
+        // Make the request and return the GooseResponse.
+        Ok(self.request(goose_request).await?)
     }
 
     /// Used to get a [`reqwest::RequestBuilder`] object. If no [`reqwest::RequestBuilder`] is
@@ -1399,7 +1411,7 @@ impl GooseUser {
     ///         // Turn the GooseRequestBuilder object into a GooseRequest.
     ///         .build();
     ///
-    ///     // Finaly make the actual request with our custom GooseRequest object.
+    ///     // Finally make the actual request with our custom GooseRequest object.
     ///     let _goose = user.request(goose_request).await?;
     ///
     ///     Ok(())
@@ -1412,7 +1424,9 @@ impl GooseUser {
     ) -> Result<RequestBuilder, GooseTaskError> {
         // Prepend the `base_url` to all relative paths.
         let url = self.build_url(path)?;
-        // Invoke Reqwest function appropriate to the request method.
+
+        // Invoke appropriate Reqwest convenience function to generate an
+        // appropriate RequestBuilder.
         Ok(match method {
             GooseMethod::Delete => self.client.delete(&url),
             GooseMethod::Get => self.client.get(&url),
@@ -2231,6 +2245,7 @@ impl GooseUser {
 /// [`GooseUser::delete`] helpers.
 ///
 /// For complete instructions review [`GooseRequestBuilder`].
+#[derive(Debug)]
 pub struct GooseRequest<'a> {
     // Defaults to `""`.
     path: &'a str,
@@ -2287,7 +2302,7 @@ pub struct GooseRequestBuilder<'a> {
     request_builder: Option<RequestBuilder>,
 }
 impl<'a> GooseRequestBuilder<'a> {
-    // Internal helper to build a [`GooseRequest`] from a [`GooseRequestBuilder`].
+    // Internal method to build a [`GooseRequest`] from a [`GooseRequestBuilder`].
     fn new() -> Self {
         Self {
             path: "",
@@ -2456,7 +2471,7 @@ impl<'a> GooseRequestBuilder<'a> {
     ///         // Turn the GooseRequestBuilder object into a GooseRequest.
     ///         .build();
     ///
-    ///     // Finaly make the actual request with our custom GooseRequest object.
+    ///     // Finally make the actual request with our custom GooseRequest object.
     ///     let _goose = user.request(goose_request).await?;
     ///
     ///     Ok(())

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -84,8 +84,7 @@
 //!         None,
 //!     )?;
 //!
-//!     let request_builder = user.goose_post(path)?;
-//!     let goose = user.goose_send(request_builder.form(&params), None).await?;
+//!     let goose = user.post_form(path, &params).await?;
 //!
 //!     // Log the form parameters that were posted together with details about the entire
 //!     // request that was sent to the server.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,7 +9,8 @@
 
 pub use crate::config::{GooseDefault, GooseDefaultType};
 pub use crate::goose::{
-    GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult, GooseTaskSet, GooseUser,
+    GooseMethod, GooseRequest, GooseTask, GooseTaskError, GooseTaskFunction, GooseTaskResult,
+    GooseTaskSet, GooseUser,
 };
 pub use crate::metrics::{GooseCoordinatedOmissionMitigation, GooseMetrics};
 pub use crate::{task, taskset, GooseAttack, GooseError, GooseScheduler};

--- a/src/user.rs
+++ b/src/user.rs
@@ -62,8 +62,8 @@ pub(crate) async fn user_main(
                 // Determine which task we're going to run next.
                 let function = &thread_task_set.tasks[*thread_task_index].function;
                 debug!(
-                    "launching on_start {} task from {}",
-                    thread_task_name, thread_task_set.name
+                    "[user {}]: launching {} task from {}",
+                    thread_number, thread_task_name, thread_task_set.name
                 );
                 // Invoke the task function.
                 let _todo = invoke_task_function(

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -24,9 +24,8 @@ const RUN_TIME: usize = 2;
 
 // Test task.
 pub async fn login(user: &mut GooseUser) -> GooseTaskResult {
-    let request_builder = user.goose_post(LOGIN_PATH)?;
     let params = [("username", "me"), ("password", "s3crET!")];
-    let _goose = user.goose_send(request_builder.form(&params), None).await?;
+    let _goose = user.post_form(LOGIN_PATH, &params).await?;
     Ok(())
 }
 


### PR DESCRIPTION
 - **API change**: introduce `GooseRequest` and `GooseRequestBuilder` for more flexibility when making requests
    o remove `GooseUser::post_named`, `GooseUser::head_named`, `GooseUser::delete_named`, `GooseUser::goose_get`, `GooseUser::goose_put`, `GooseUser::goose_head`, `GooseUser::goose_put`, `GooseUser::goose_patch`, `GooseUser::goose_delete`, and `GooseUser::goose_send`
    o adds or modifies helpers `GooseUser::get`, `GooseUser::get_named`, `GooseUser::post`, `GooseUser::post_form`, `GooseUser::post_json`, `GooseUser::head`, and `GooseUser::delete`
    o replaces `GooseUser::goose_send` with `GooseUser::request` which accepts a `GooseRequest` object
    o fixes [#370] (see `GooseRequestBuilder::expect_status_code`)