### PR TITLE
fix example links

### DIFF
--- a/src/docs/goose-book/src/SUMMARY.md
+++ b/src/docs/goose-book/src/SUMMARY.md
@@ -39,7 +39,7 @@
 
 - [Examples](example/overview.md)
     - [Simple](example/simple.md)
-    - [Simple Closure](example/simple-closure.md)
-    - [Simple Session](example/simple-session.md)
+    - [Closure](example/closure.md)
+    - [Session](example/session.md)
     - [Drupal Memcache](example/drupal-memcache.md)
     - [Umami](example/umami.md)

--- a/src/docs/goose-book/src/example/overview.md
+++ b/src/docs/goose-book/src/example/overview.md
@@ -1,8 +1,8 @@
 # Examples
 
 Goose includes several examples to demonstrate load test functionality, including:
- - [Simple](https://github.com/tag1consulting/goose/blob/main/examples/simple.rs)
- - [Closure](https://github.com/tag1consulting/goose/blob/main/examples/closure.rs)
- - [Session](https://github.com/tag1consulting/goose/blob/main/examples/session.rs)
- - [Drupal Memcache](https://github.com/tag1consulting/goose/blob/main/examples/drupal_memcache.rs)
- - [Umami](https://github.com/tag1consulting/goose/tree/main/examples/umami)
+ - [Simple](simple.md) *([examples/simple.rs](https://github.com/tag1consulting/goose/blob/main/examples/simple.rs))*
+ - [Closure](closure.md) *([examples/closure.rs](https://github.com/tag1consulting/goose/blob/main/examples/closure.rs))*
+ - [Session](session.md) *([examples/session.rs](https://github.com/tag1consulting/goose/blob/main/examples/session.rs))*
+ - [Drupal Memcache](drupal-memcache.md) *([examples/drupal_memcache.rs](https://github.com/tag1consulting/goose/blob/main/examples/drupal_memcache.rs))*
+ - [Umami](umami.md) *([examples/umami/](https://github.com/tag1consulting/goose/tree/main/examples/umami))*


### PR DESCRIPTION
 - properly link to Example pages after renaming examples
 - make it more clear where links go, avoid accidentally steering people aware from the book