### PR TITLE
Add requests per second graph to the HTML report.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -68,8 +68,6 @@ const DEFAULT_PORT: &str = "5115";
 /// --debug-format FORMAT      Sets debug log format (csv, json, raw, pretty)
 /// --no-debug-body            Do not include the response body in the debug log
 /// --status-codes             Tracks additional status code metrics
-/// --requests-per-second      Tracks additional requests per second metrics
-/// --rps-bucket               Size (in seconds) of the time-based requests per second bucket (default: 10)
 ///
 /// Advanced:
 /// --no-telnet                Doesn't enable telnet Controller
@@ -190,18 +188,8 @@ pub struct GooseConfiguration {
     #[options(no_short)]
     pub no_debug_body: bool,
     /// Tracks additional status code metrics
-    #[options(no_short, help = "Tracks additional status code metrics")]
+    #[options(no_short, help = "Tracks additional status code metrics\n\nAdvanced:")]
     pub status_codes: bool,
-    /// Tracks additional request per second metrics
-    #[options(no_short, help = "Tracks additional request per second metrics")]
-    pub requests_per_second: bool,
-    // Size (in seconds) of the time-based requests per second bucket (default: 10)
-    // Add a blank line and then an Advanced: header after this option
-    #[options(
-        no_short,
-        help = "Size of the time bucket in time-based requests per second calculations\n\nAdvanced:"
-    )]
-    pub rps_bucket: usize,
     /// Doesn't enable telnet Controller
     #[options(no_short)]
     pub no_telnet: bool,
@@ -335,10 +323,6 @@ pub(crate) struct GooseDefaults {
     pub co_mitigation: Option<GooseCoordinatedOmissionMitigation>,
     /// An optional default to track additional status code metrics.
     pub status_codes: Option<bool>,
-    /// An optional default to track requests per second metrics.
-    pub requests_per_second: Option<bool>,
-    // An optional default size of the requests per second bucket size.
-    pub rps_bucket: Option<usize>,
     /// An optional default maximum requests per second.
     pub throttle_requests: Option<usize>,
     /// An optional default to follows base_url redirect with subsequent request.
@@ -1539,42 +1523,6 @@ impl GooseConfiguration {
                 },
             ])
             .unwrap_or(false);
-
-        // Configure `requests_per_second`.
-        self.requests_per_second = self
-            .get_value(vec![
-                // Use --requests-per-second if set.
-                GooseValue {
-                    value: Some(self.requests_per_second),
-                    filter: !self.requests_per_second,
-                    message: "requests_per_second",
-                },
-                // Otherwise use GooseDefault if set.
-                GooseValue {
-                    value: defaults.requests_per_second,
-                    filter: defaults.requests_per_second.is_none() || self.worker,
-                    message: "requests_per_second",
-                },
-            ])
-            .unwrap_or(false);
-
-        // Configure `rps_bucket`.
-        self.rps_bucket = self
-            .get_value(vec![
-                // Use --requests-per-second-bucket if set.
-                GooseValue {
-                    value: Some(self.rps_bucket),
-                    filter: self.rps_bucket == 0,
-                    message: "rps_bucket",
-                },
-                // Otherwise use GooseDefault if set.
-                GooseValue {
-                    value: defaults.rps_bucket,
-                    filter: defaults.rps_bucket.is_none() || self.worker,
-                    message: "rps_bucket",
-                },
-            ])
-            .unwrap_or(10);
 
         // Configure `no_telnet`.
         self.no_telnet = self

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,8 +188,10 @@ pub struct GooseConfiguration {
     #[options(no_short)]
     pub no_debug_body: bool,
     /// Tracks additional status code metrics
+    // Add a blank line and then an Advanced: header after this option
     #[options(no_short, help = "Tracks additional status code metrics\n\nAdvanced:")]
     pub status_codes: bool,
+
     /// Doesn't enable telnet Controller
     #[options(no_short)]
     pub no_telnet: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,8 @@ const DEFAULT_PORT: &str = "5115";
 /// --debug-format FORMAT      Sets debug log format (csv, json, raw, pretty)
 /// --no-debug-body            Do not include the response body in the debug log
 /// --status-codes             Tracks additional status code metrics
+/// --requests-per-second      Tracks additional requests per second metrics
+/// --rps-bucket               Size (in seconds) of the time-based requests per second bucket (default: 10)
 ///
 /// Advanced:
 /// --no-telnet                Doesn't enable telnet Controller
@@ -188,10 +190,18 @@ pub struct GooseConfiguration {
     #[options(no_short)]
     pub no_debug_body: bool,
     /// Tracks additional status code metrics
-    // Add a blank line and then an Advanced: header after this option
-    #[options(no_short, help = "Tracks additional status code metrics\n\nAdvanced:")]
+    #[options(no_short, help = "Tracks additional status code metrics")]
     pub status_codes: bool,
-
+    /// Tracks additional request per second metrics
+    #[options(no_short, help = "Tracks additional request per second metrics")]
+    pub requests_per_second: bool,
+    // Size (in seconds) of the time-based requests per second bucket (default: 10)
+    // Add a blank line and then an Advanced: header after this option
+    #[options(
+        no_short,
+        help = "Size of the time bucket in time-based requests per second calculations\n\nAdvanced:"
+    )]
+    pub rps_bucket: usize,
     /// Doesn't enable telnet Controller
     #[options(no_short)]
     pub no_telnet: bool,
@@ -325,6 +335,10 @@ pub(crate) struct GooseDefaults {
     pub co_mitigation: Option<GooseCoordinatedOmissionMitigation>,
     /// An optional default to track additional status code metrics.
     pub status_codes: Option<bool>,
+    /// An optional default to track requests per second metrics.
+    pub requests_per_second: Option<bool>,
+    // An optional default size of the requests per second bucket size.
+    pub rps_bucket: Option<usize>,
     /// An optional default maximum requests per second.
     pub throttle_requests: Option<usize>,
     /// An optional default to follows base_url redirect with subsequent request.
@@ -1525,6 +1539,42 @@ impl GooseConfiguration {
                 },
             ])
             .unwrap_or(false);
+
+        // Configure `requests_per_second`.
+        self.requests_per_second = self
+            .get_value(vec![
+                // Use --requests-per-second if set.
+                GooseValue {
+                    value: Some(self.requests_per_second),
+                    filter: !self.requests_per_second,
+                    message: "requests_per_second",
+                },
+                // Otherwise use GooseDefault if set.
+                GooseValue {
+                    value: defaults.requests_per_second,
+                    filter: defaults.requests_per_second.is_none() || self.worker,
+                    message: "requests_per_second",
+                },
+            ])
+            .unwrap_or(false);
+
+        // Configure `rps_bucket`.
+        self.rps_bucket = self
+            .get_value(vec![
+                // Use --requests-per-second-bucket if set.
+                GooseValue {
+                    value: Some(self.rps_bucket),
+                    filter: self.rps_bucket == 0,
+                    message: "rps_bucket",
+                },
+                // Otherwise use GooseDefault if set.
+                GooseValue {
+                    value: defaults.rps_bucket,
+                    filter: defaults.rps_bucket.is_none() || self.worker,
+                    message: "rps_bucket",
+                },
+            ])
+            .unwrap_or(10);
 
         // Configure `no_telnet`.
         self.no_telnet = self

--- a/src/docs/goose-book/src/getting-started/common.md
+++ b/src/docs/goose-book/src/getting-started/common.md
@@ -78,6 +78,8 @@ cargo run --release -- -t 30m
 
 By default, Goose displays [text-formatted metrics](metrics.md) when a load test finishes. It can also optionally write an HTML-formatted report if you enable the `--report-file <NAME>` run-time option, where `<NAME>` is an absolute or relative path to the report file to generate. Any file that already exists at the specified path will be overwritten.
 
+HTML report includes some graphs that rely on [eCharts JavaScript library](https://echarts.apache.org). HTML report loads the library via CDN, which means that the graphs won't be loaded correctly if the CDN is not accessible.
+
 ### Example
 _Write an HTML-formatted report to `report.html` when the load test finishes._
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -457,6 +457,10 @@ impl GooseRequestMetricAggregate {
 
     /// Record request in requests per second metric.
     pub(crate) fn record_requests_per_second(&mut self, second: usize) {
+        // Each element in self.requests_per_second vector is count for a given
+        // second since the start of the test. Since we don't know how long the
+        // test will at the beginning we need to push new elements (second
+        // counters) as the test is running.
         if self.requests_per_second.len() <= second {
             for _ in 0..=(second - self.requests_per_second.len() + 1) {
                 self.requests_per_second.push(0);
@@ -3037,12 +3041,12 @@ impl GooseAttack {
                 && Some(stopped) == self.metrics.stopped
             {
                 let mut count = 0;
-                for (_path, path_metric) in self.metrics.requests.iter() {
+                for path_metric in self.metrics.requests.values() {
                     count = max(count, path_metric.requests_per_second.len());
                 }
 
                 let mut rps = vec![0; count];
-                for (_path, path_metric) in self.metrics.requests.iter() {
+                for path_metric in self.metrics.requests.values() {
                     for (second, count) in path_metric.requests_per_second.iter().enumerate() {
                         rps[second] += count;
                     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -9,7 +9,6 @@
 //! [`GooseErrorMetrics`] are displayed in tables.
 
 use chrono::prelude::*;
-use chrono::Utc;
 use http::StatusCode;
 use itertools::Itertools;
 use num_format::{Locale, ToFormattedString};

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3063,7 +3063,7 @@ impl GooseAttack {
             );
 
             // Write the report to file.
-            if let Err(e) = report_file.write(report.as_ref()).await {
+            if let Err(e) = report_file.write_all(report.as_ref()).await {
                 return Err(GooseError::InvalidOption {
                     option: "--report-file".to_string(),
                     value: self.get_report_file_path().unwrap(),

--- a/src/report.rs
+++ b/src/report.rs
@@ -406,16 +406,7 @@ pub fn error_row(error: &metrics::GooseErrorMetricAggregate) -> String {
     )
 }
 
-pub fn graph_rps_template(rps: Vec<f32>, bucket_size: usize) -> String {
-    let values = json!(rps);
-    let buckets = json!((0..rps.len())
-        .map(|bucket| format!(
-            "{}s - {}s",
-            (bucket * bucket_size),
-            ((bucket + 1) * bucket_size)
-        ))
-        .collect::<Vec<_>>());
-
+pub fn graph_rps_template(rps: Vec<u32>) -> String {
     format!(
         r#"<div class="graph-rps">
         <h2>Requests per second</h2>
@@ -428,23 +419,29 @@ pub fn graph_rps_template(rps: Vec<f32>, bucket_size: usize) -> String {
 
                 myChart.setOption({{
                     xAxis: {{
-                        type: 'category',
-                        data: {buckets}
+                        name: 'Time [s]',
+                        nameLocation: 'center',
+                        nameGap: 25,
+                        type: 'value',
                     }},
                     yAxis: {{
+                        name: 'Requests per second',
+                        nameLocation: 'center',
+                        nameRotate: 90,
+                        nameGap: 45,
                         type: 'value'
                     }},
                     series: [
                         {{
                             data: {values},
-                            type: 'line'
+                            type: 'line',
+                            symbol: 'none'
                         }}
                     ]
                 }});
             </script>
         </div>"#,
-        values = values,
-        buckets = buckets,
+        values = json!(rps.iter().enumerate().collect::<Vec<_>>()),
     )
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -409,11 +409,49 @@ pub fn error_row(error: &metrics::GooseErrorMetricAggregate) -> String {
 
 pub fn graph_rps_template(
     rps: Vec<(String, u32)>,
-    starting: DateTime<Local>,
-    started: DateTime<Local>,
-    stopping: DateTime<Local>,
-    stopped: DateTime<Local>,
+    starting: Option<DateTime<Local>>,
+    started: Option<DateTime<Local>>,
+    stopping: Option<DateTime<Local>>,
+    stopped: Option<DateTime<Local>>,
 ) -> String {
+    let datetime_format = "%Y-%m-%d %H:%M:%S";
+
+    let starting_area = if starting.is_some() && started.is_some() {
+        format!(
+            r#"[
+                {{
+                    name: 'Starting',
+                    xAxis: '{starting}'
+                }},
+                {{
+                    xAxis: '{started}'
+                }}
+            ],"#,
+            starting = starting.unwrap().format(datetime_format),
+            started = started.unwrap().format(datetime_format),
+        )
+    } else {
+        "".to_string()
+    };
+
+    let stopping_area = if stopping.is_some() && stopped.is_some() {
+        format!(
+            r#"[
+                {{
+                    name: 'Stopping',
+                    xAxis: '{stopping}'
+                }},
+                {{
+                    xAxis: '{stopped}'
+                }}
+            ],"#,
+            stopping = stopping.unwrap().format(datetime_format),
+            stopped = stopped.unwrap().format(datetime_format),
+        )
+    } else {
+        "".to_string()
+    };
+
     format!(
         r#"<div class="graph-rps">
         <h2>Requests per second</h2>
@@ -444,7 +482,16 @@ pub fn graph_rps_template(
                                 lineStyle: {{ color: '#2c664f' }},
                                 areaStyle: {{ color: '#378063' }}
                             }}
-                        }}
+                        }},
+                        {{
+                            start: 0,
+                            end: 100,
+                            fillerColor: 'rgba(34, 80, 61, 0.25)',
+                            selectedDataBackground: {{
+                                lineStyle: {{ color: '#2c664f' }},
+                                areaStyle: {{ color: '#378063' }}
+                            }}
+                        }},
                     ],
                     xAxis: {{ type: 'time' }},
                     yAxis: {{
@@ -464,24 +511,8 @@ pub fn graph_rps_template(
                             markArea: {{
                                 itemStyle: {{ color: 'rgba(6, 6, 6, 0.10)' }},
                                 data: [
-                                    [
-                                        {{
-                                            name: 'Starting',
-                                            xAxis: '{starting}'
-                                        }},
-                                        {{
-                                            xAxis: '{started}'
-                                        }}
-                                    ],
-                                    [
-                                        {{
-                                            name: 'Stopping',
-                                            xAxis: '{stopping}'
-                                        }},
-                                        {{
-                                            xAxis: '{stopped}'
-                                        }}
-                                    ]
+                                    {starting_area}
+                                    {stopping_area}
                                 ]
                             }},
                             data: {values},
@@ -491,10 +522,8 @@ pub fn graph_rps_template(
             </script>
         </div>"#,
         values = json!(rps),
-        starting = starting.format("%Y-%m-%d %H:%M:%S"),
-        started = started.format("%Y-%m-%d %H:%M:%S"),
-        stopping = stopping.format("%Y-%m-%d %H:%M:%S"),
-        stopped = stopped.format("%Y-%m-%d %H:%M:%S"),
+        starting_area = starting_area,
+        stopping_area = stopping_area
     )
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -410,11 +410,11 @@ pub fn graph_rps_template(rps: Vec<u32>) -> String {
     format!(
         r#"<div class="graph-rps">
         <h2>Requests per second</h2>
-            <div id="main" style="width: 1000px; height:660px; background: white;"></div>
+            <div id="graph-rps" style="width: 1000px; height:660px; background: white;"></div>
 
             <script src="https://cdn.jsdelivr.net/npm/echarts@5.2.2/dist/echarts.min.js"></script>
             <script type="text/javascript">
-                var chartDom = document.getElementById('main');
+                var chartDom = document.getElementById('graph-rps');
                 var myChart = echarts.init(chartDom);
 
                 myChart.setOption({{
@@ -441,7 +441,7 @@ pub fn graph_rps_template(rps: Vec<u32>) -> String {
                 }});
             </script>
         </div>"#,
-        values = json!(rps.iter().enumerate().collect::<Vec<_>>()),
+        values = json!(rps.iter().enumerate().collect::<Vec<_>>())
     )
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -455,7 +455,7 @@ pub fn graph_rps_template(
     format!(
         r#"<div class="graph-rps">
         <h2>Requests per second</h2>
-            <div id="graph-rps" style="width: 1000px; height:660px; background: white;"></div>
+            <div id="graph-rps" style="width: 1000px; height:500px; background: white;"></div>
 
             <script src="https://cdn.jsdelivr.net/npm/echarts@5.2.2/dist/echarts.min.js"></script>
             <script type="text/javascript">

--- a/src/report.rs
+++ b/src/report.rs
@@ -425,14 +425,11 @@ pub fn graph_rps_template(
                 var myChart = echarts.init(chartDom);
 
                 myChart.setOption({{
-                    tooltip: {{
-                        trigger: 'axis',
-                    }},
+                    color: ['#2c664f'],
+                    tooltip: {{ trigger: 'axis' }},
                     toolbox: {{
                         feature: {{
-                            dataZoom: {{
-                                yAxisIndex: 'none'
-                            }},
+                            dataZoom: {{ yAxisIndex: 'none' }},
                             restore: {{}},
                             saveAsImage: {{}}
                         }}
@@ -441,16 +438,15 @@ pub fn graph_rps_template(
                         {{
                             type: 'inside',
                             start: 0,
-                            end: 100
-                        }},
-                        {{
-                            start: 0,
-                            end: 100
+                            end: 100,
+                            fillerColor: 'rgba(34, 80, 61, 0.25)',
+                            selectedDataBackground: {{
+                                lineStyle: {{ color: '#2c664f' }},
+                                areaStyle: {{ color: '#378063' }}
+                            }}
                         }}
                     ],
-                    xAxis: {{
-                        type: 'time',
-                    }},
+                    xAxis: {{ type: 'time' }},
                     yAxis: {{
                         name: 'Requests per second',
                         nameLocation: 'center',
@@ -463,11 +459,10 @@ pub fn graph_rps_template(
                             type: 'line',
                             symbol: 'none',
                             sampling: 'lttb',
-                            areaStyle: {{}},
+                            lineStyle: {{ color: '#2c664f' }},
+                            areaStyle: {{ color: '#378063' }},
                             markArea: {{
-                                itemStyle: {{
-                                    color: 'rgba(255, 173, 177, 0.4)'
-                                }},
+                                itemStyle: {{ color: 'rgba(6, 6, 6, 0.10)' }},
                                 data: [
                                     [
                                         {{


### PR DESCRIPTION
Closes #246.

## TODO

- ~Graph color scheme~
- ~Only display starting/stopping phase when `--no-reset-metrics` is used~
- Investigate spike on transition between starting and started phase
- Confirm that metrics are correct (when throttling is enabled RPS numbers do not match exactly)
- Automated tests
- Add additional graphs. 

## Screenshots

### With `--no-reset-metrics`
<img width="1041" alt="Screenshot 2021-11-18 at 20 53 10" src="https://user-images.githubusercontent.com/376889/142495119-2002196c-8cf3-44eb-ab7e-92f8f74242b9.png">


### Without `--no-reset-metrics`
<img width="1066" alt="Screenshot 2021-11-18 at 20 49 50" src="https://user-images.githubusercontent.com/376889/142495134-ed00e11c-1241-4620-854c-1308761ffc52.png">

