### PR TITLE
properly configure `--running-metrics VALUE` when set manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.15.1-dev
  - [#374](https://github.com/tag1consulting/goose/pull/374) renamed `simple-with-session.rs` to `session.rs` and `simple-closure.rs` to `closure.rs` to avoid confusion with the `simple.rs` example as they all do different things
+ - [#385](https://github.com/tag1consulting/goose/pull/385) properly configure `--running-metrics VALUE` when set manually
 
 ## 0.15.0 November 2, 2021
  - [#372](https://github.com/tag1consulting/goose/pull/372) de-deduplicate documentation, favoring [The Goose Book](https://book.goose.rs)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1357,7 +1357,7 @@ impl GooseConfiguration {
             // Use --running-metrics if set.
             GooseValue {
                 value: self.running_metrics,
-                filter: self.running_metrics.is_some(),
+                filter: self.running_metrics.is_none(),
                 message: "running_metrics",
             },
             // Otherwise use GooseDefault if set.


### PR DESCRIPTION
 - [#385](https://github.com/tag1consulting/goose/pull/385) properly configure `--running-metrics VALUE` when set manually

The configuration logic was reversed, so setting `--running-metrics VALUE` was never working, though using `GooseDefault::RunningMetrics` was (and still is) working.