### PR TITLE
Add additional graphs to the HTML report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.15.2-dev
  - [#391](https://github.com/tag1consulting/goose/pull/391) properly sleep for configured `set_wait_time()` walking regularly to exit quickly if the load test ends
+ - [#394](https://github.com/tag1consulting/goose/pull/394) add additional graphs to the HTML report: errors per second,
+ average response time, active users, active tasks
 
 ## 0.15.1 November 19, 2021
  - [#374](https://github.com/tag1consulting/goose/pull/374) renamed `simple-with-session.rs` to `session.rs` and `simple-closure.rs` to `closure.rs` to avoid confusion with the `simple.rs` example as they all do different things

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 0.15.2-dev
  - [#391](https://github.com/tag1consulting/goose/pull/391) properly sleep for configured `set_wait_time()` walking regularly to exit quickly if the load test ends
- - [#394](https://github.com/tag1consulting/goose/pull/394) add additional graphs to the HTML report: errors per second,
- average response time, active users, active tasks
+ - [#394](https://github.com/tag1consulting/goose/pull/394) add additional graphs to the HTML report: errors per second, average response time, active users, active tasks
 
 ## 0.15.1 November 19, 2021
  - [#374](https://github.com/tag1consulting/goose/pull/374) renamed `simple-with-session.rs` to `session.rs` and `simple-closure.rs` to `closure.rs` to avoid confusion with the `simple.rs` example as they all do different things

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -287,6 +287,7 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
+use chrono::Utc;
 use downcast_rs::{impl_downcast, Downcast};
 use http::method::Method;
 use reqwest::{header, Client, ClientBuilder, RequestBuilder, Response};
@@ -1510,6 +1511,7 @@ impl GooseUser {
 
         // Once past the throttle, the request is officially started.
         let started = Instant::now();
+        let request_time = Utc::now();
 
         // Create a Reqwest Request object from the RequestBuilder.
         let built_request = request_builder.build()?;
@@ -1558,6 +1560,7 @@ impl GooseUser {
             request_name,
             self.started.elapsed().as_millis(),
             self.weighted_users_index,
+            request_time,
         );
 
         // Make the actual request.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -287,7 +287,6 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
-use chrono::Utc;
 use downcast_rs::{impl_downcast, Downcast};
 use http::method::Method;
 use reqwest::{header, Client, ClientBuilder, RequestBuilder, Response};

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1511,7 +1511,6 @@ impl GooseUser {
 
         // Once past the throttle, the request is officially started.
         let started = Instant::now();
-        let request_time = Utc::now();
 
         // Create a Reqwest Request object from the RequestBuilder.
         let built_request = request_builder.build()?;
@@ -1560,7 +1559,6 @@ impl GooseUser {
             request_name,
             self.started.elapsed().as_millis(),
             self.weighted_users_index,
-            request_time,
         );
 
         // Make the actual request.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -511,7 +511,7 @@ impl GooseRequestMetricAggregate {
 /// better to do it as we go to save memory.
 fn expand_per_second_metric_array<T: Clone>(data: &mut Vec<T>, second: usize, initial: T) {
     // Each element in per second metric vectors (self.requests_per_second,
-    // self.errors_per_second, ...) is count for a given second since the start
+    // self.errors_per_second, ...) is counted for a given second since the start
     // of the test. Since we don't know how long the test will at the beginning
     // we need to push new elements (second counters) as the test is running.
     if data.len() <= second {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2579,7 +2579,7 @@ impl GooseAttack {
             match message.unwrap() {
                 GooseMetric::Request(request_metric) => {
                     // If there was an error, store it.
-                    if !request_metric.success && !request_metric.error.is_empty() {
+                    if !request_metric.error.is_empty() {
                         self.record_error(&request_metric, goose_attack_run_state);
                     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -529,7 +529,7 @@ fn expand_per_second_metric_array<T: Clone>(data: &mut Vec<T>, second: usize, in
 /// `Eq` trait has no functions on it - it is there only to inform the compiler
 /// that this is an equivalence rather than a partial equivalence.
 ///
-/// See https://doc.rust-lang.org/std/cmp/trait.Eq.html for more information.
+/// See <https://doc.rust-lang.org/std/cmp/trait.Eq.html> for more information.
 impl Eq for GooseRequestMetricAggregate {}
 
 /// Implement ordering for GooseRequestMetricAggregate.
@@ -3291,6 +3291,11 @@ impl GooseAttack {
         Ok(())
     }
 
+    /// Adds timestamps to the graph data series to ensure correct time display on x axis.
+    ///
+    /// Will take a vector of (generally numerical) values and convert them into tuples where
+    /// the second element will be the data point and the first element will be formatted time
+    /// it belongs to.
     fn add_timestamp_to_html_graph_data<T: Copy>(
         &self,
         data: Vec<T>,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2892,6 +2892,19 @@ impl GooseAttack {
                 graph_stopped,
             );
 
+            // Generate active users graph.
+            let graph_users_per_second = report::graph_users_per_second_template(
+                &self.add_timestamp_to_html_graph_data(
+                    self.metrics.users_per_second.clone(),
+                    &starting,
+                    &started,
+                ),
+                graph_starting,
+                graph_started,
+                graph_stopping,
+                graph_stopped,
+            );
+
             // Prepare aggregate per-request metrics.
             let (raw_aggregate_requests_per_second, raw_aggregate_failures_per_second) =
                 per_second_calculations(
@@ -3135,19 +3148,6 @@ impl GooseAttack {
                     tasks_rows.push(report::task_metrics_row(metric));
                 }
 
-                // Generate active users graph.
-                let graph_users_per_second = report::graph_users_per_second_template(
-                    &self.add_timestamp_to_html_graph_data(
-                        self.metrics.users_per_second.clone(),
-                        &starting,
-                        &started,
-                    ),
-                    graph_starting,
-                    graph_started,
-                    graph_stopping,
-                    graph_stopped,
-                );
-
                 // Generate active tasks graph.
                 let graph_tasks_per_second = report::graph_tasks_per_second_template(
                     &self.add_timestamp_to_html_graph_data(
@@ -3161,11 +3161,8 @@ impl GooseAttack {
                     graph_stopped,
                 );
 
-                tasks_template = report::task_metrics_template(
-                    &tasks_rows.join("\n"),
-                    &graph_tasks_per_second,
-                    &graph_users_per_second,
-                );
+                tasks_template =
+                    report::task_metrics_template(&tasks_rows.join("\n"), &graph_tasks_per_second);
             } else {
                 tasks_template = "".to_string();
             }
@@ -3268,6 +3265,7 @@ impl GooseAttack {
                     errors_template: &errors_template,
                     graph_rps_template: &graph_rps_template,
                     graph_average_response_time_template: &graph_average_response_time_template,
+                    graph_users_per_second: &graph_users_per_second,
                 },
             );
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2395,6 +2395,15 @@ impl GooseAttack {
                 }
             }
 
+            // Record current users and tasks for users/tasks per second graph in HTML report.
+            if self.attack_mode != AttackMode::Worker {
+                let mut tasks = 0;
+                for set in self.task_sets.iter() {
+                    tasks += set.tasks.len();
+                }
+                self.metrics.record_users_tasks_per_second(tasks as u32);
+            }
+
             // Load messages from user threads until the receiver queue is empty.
             let received_message = self.receive_metrics(goose_attack_run_state, flush).await?;
 
@@ -2562,12 +2571,6 @@ impl GooseAttack {
     ) -> Result<bool, GooseError> {
         let mut received_message = false;
         let mut message = goose_attack_run_state.metrics_rx.try_recv();
-
-        let mut tasks = 0;
-        for set in self.task_sets.iter() {
-            tasks += set.tasks.len();
-        }
-        self.metrics.record_users_tasks_per_second(tasks as u32);
 
         // Main loop wakes up every 500ms, so don't spend more than 400ms receiving metrics.
         let receive_timeout = 400;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -917,7 +917,7 @@ pub struct GooseMetrics {
     pub users: usize,
     /// Number of users at the end of each second of the test. Each element of the vector
     /// represents one second.
-    pub users_per_second: Vec<u32>,
+    pub users_per_second: Vec<usize>,
     /// Tracks details about each request made during the load test.
     ///
     /// Can be disabled with the `--no-metrics` run-time option, or with
@@ -2219,7 +2219,7 @@ impl GooseMetrics {
             let second = (Utc::now().timestamp() - starting.timestamp()) as usize;
 
             expand_per_second_metric_array(&mut self.users_per_second, second, 0);
-            self.users_per_second[second] = self.users as u32;
+            self.users_per_second[second] = self.users;
 
             expand_per_second_metric_array(&mut self.tasks_per_second, second, 0);
             self.tasks_per_second[second] = tasks;
@@ -3284,12 +3284,12 @@ impl GooseAttack {
         Ok(())
     }
 
-    fn add_timestamp_to_html_graph_data(
+    fn add_timestamp_to_html_graph_data<T: Copy>(
         &self,
-        data: Vec<u32>,
+        data: Vec<T>,
         starting: &DateTime<Local>,
         started: &DateTime<Local>,
-    ) -> Vec<(String, u32)> {
+    ) -> Vec<(String, T)> {
         data.iter()
             .enumerate()
             .filter(|(second, _)| {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2229,18 +2229,10 @@ impl GooseMetrics {
     /// This is called from [`GooseAttack::receive_metrics()`] and the data
     /// collected is used to display users and tasks graphs on the HTML report.
     pub(crate) fn record_users_tasks_per_second(&mut self, tasks: usize, second: usize) {
-        let last_user_count = match self.users_per_second.last() {
-            Some(last) => *last,
-            None => 0,
-        };
-        expand_per_second_metric_array(&mut self.users_per_second, second, last_user_count);
+        expand_per_second_metric_array(&mut self.users_per_second, second, 0);
         self.users_per_second[second] = self.users;
 
-        let last_task_count = match self.tasks_per_second.last() {
-            Some(last) => *last,
-            None => 0,
-        };
-        expand_per_second_metric_array(&mut self.tasks_per_second, second, last_task_count);
+        expand_per_second_metric_array(&mut self.tasks_per_second, second, 0);
         self.tasks_per_second[second] = tasks;
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2578,7 +2578,7 @@ impl GooseAttack {
             match message.unwrap() {
                 GooseMetric::Request(request_metric) => {
                     // If there was an error, store it.
-                    if !request_metric.error.is_empty() {
+                    if !request_metric.success && !request_metric.error.is_empty() {
                         self.record_error(&request_metric, goose_attack_run_state);
                     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -942,7 +942,7 @@ pub struct GooseMetrics {
     pub tasks: GooseTaskMetrics,
     /// Number of tasks at the end of each second of the test. Each element of the vector
     /// represents one second.
-    pub tasks_per_second: Vec<u32>,
+    pub tasks_per_second: Vec<usize>,
     /// Tracks and counts each time an error is detected during the load test.
     ///
     /// Can be disabled with either the `--no-error-summary` or `--no-metrics` run-time options,
@@ -2228,7 +2228,7 @@ impl GooseMetrics {
     ///
     /// This is called from [`GooseAttack::receive_metrics()`] and the data
     /// collected is used to display users and tasks graphs on the HTML report.
-    pub(crate) fn record_users_tasks_per_second(&mut self, tasks: u32) {
+    pub(crate) fn record_users_tasks_per_second(&mut self, tasks: usize) {
         if let Some(starting) = self.starting {
             let second = (Utc::now().timestamp() - starting.timestamp()) as usize;
 
@@ -2394,7 +2394,7 @@ impl GooseAttack {
                 for set in self.task_sets.iter() {
                     tasks += set.tasks.len();
                 }
-                self.metrics.record_users_tasks_per_second(tasks as u32);
+                self.metrics.record_users_tasks_per_second(tasks);
             }
 
             // Load messages from user threads until the receiver queue is empty.

--- a/src/report.rs
+++ b/src/report.rs
@@ -478,7 +478,7 @@ pub fn graph_average_response_time_template(
 }
 
 pub fn graph_users_per_second_template(
-    users: &[(String, u32)],
+    users: &[(String, usize)],
     starting: Option<DateTime<Local>>,
     started: Option<DateTime<Local>>,
     stopping: Option<DateTime<Local>>,
@@ -514,10 +514,10 @@ pub fn graph_tasks_per_second_template(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn graph_template(
+fn graph_template<T: Serialize>(
     html_id: &str,
     y_axis_label: &str,
-    data: &[(String, u32)],
+    data: &[(String, T)],
     starting: Option<DateTime<Local>>,
     started: Option<DateTime<Local>>,
     stopping: Option<DateTime<Local>>,

--- a/src/report.rs
+++ b/src/report.rs
@@ -495,8 +495,8 @@ pub fn graph_users_per_second_template(
     )
 }
 
-pub fn graph_tasks_per_second_template(
-    tasks: &[(String, u32)],
+pub fn graph_tasks_per_second_template<T: Serialize>(
+    tasks: &[(String, T)],
     starting: Option<DateTime<Local>>,
     started: Option<DateTime<Local>>,
     stopping: Option<DateTime<Local>>,

--- a/src/report.rs
+++ b/src/report.rs
@@ -502,8 +502,8 @@ pub fn graph_tasks_per_second_template<T: Serialize>(
     stopped: Option<DateTime<Local>>,
 ) -> String {
     graph_template(
-        "graph-active-tasks",
-        "Active tasks #",
+        "graph-tps",
+        "Tasks #",
         tasks,
         starting,
         started,
@@ -1410,7 +1410,7 @@ mod test {
 
     #[test]
     fn test_graph_tasks_per_second_template() {
-        let expected_prefix = expected_graph_html_prefix("graph-active-tasks", "Active tasks #");
+        let expected_prefix = expected_graph_html_prefix("graph-tps", "Tasks #");
 
         let data = vec![
             ("2021-11-21 21:20:32".to_string(), 123),

--- a/src/report.rs
+++ b/src/report.rs
@@ -23,6 +23,7 @@ pub struct GooseReportTemplates<'a> {
     pub graph_eps_template: &'a str,
     pub graph_average_response_time_template: &'a str,
     pub graph_users_per_second_template: &'a str,
+    pub graph_tasks_per_second_template: &'a str,
 }
 
 /// Defines the metrics reported about requests.
@@ -486,6 +487,25 @@ pub fn graph_users_per_second_template(
     )
 }
 
+pub fn graph_tasks_per_second_template(
+    tasks: &[(String, u32)],
+    starting: Option<DateTime<Local>>,
+    started: Option<DateTime<Local>>,
+    stopping: Option<DateTime<Local>>,
+    stopped: Option<DateTime<Local>>,
+) -> String {
+    graph_template(
+        "Active tasks",
+        "graph-active-tasks",
+        "Active tasks #",
+        tasks,
+        starting,
+        started,
+        stopping,
+        stopped,
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 fn graph_template(
     title: &str,
@@ -627,6 +647,7 @@ pub fn build_report(
         || !templates.graph_eps_template.is_empty()
         || !templates.graph_average_response_time_template.is_empty()
         || !templates.graph_users_per_second_template.is_empty()
+        || !templates.graph_tasks_per_second_template.is_empty()
     {
         echarts_include = "<script src=\"https://cdn.jsdelivr.net/npm/echarts@5.2.2/dist/echarts.min.js\"></script>".to_string();
     } else {
@@ -768,6 +789,8 @@ pub fn build_report(
 
         {graph_users_per_second_template}
 
+        {graph_tasks_per_second_template}
+
     </div>
 </body>
 </html>"#,
@@ -788,6 +811,7 @@ pub fn build_report(
         graph_eps_template = templates.graph_eps_template,
         graph_average_response_time_template = templates.graph_average_response_time_template,
         graph_users_per_second_template = templates.graph_users_per_second_template,
+        graph_tasks_per_second_template = templates.graph_tasks_per_second_template,
     )
 }
 
@@ -1387,6 +1411,141 @@ mod test {
         );
         assert_eq!(
             graph_users_per_second_template(
+                &data,
+                Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 32)),
+                Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 34)),
+                Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 36)),
+                Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 38))
+            ),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_graph_tasks_per_second_template() {
+        let expected_prefix =
+            expected_graph_html_prefix("Active tasks", "graph-active-tasks", "Active tasks #");
+
+        let data = vec![
+            ("2021-11-21 21:20:32".to_string(), 123),
+            ("2021-11-21 21:20:33".to_string(), 111),
+            ("2021-11-21 21:20:34".to_string(), 99),
+            ("2021-11-21 21:20:35".to_string(), 134),
+        ];
+
+        let mut expected = expected_prefix.to_owned();
+        expected.push_str(r#"                                data: [
+                                    
+                                    
+                                ]
+                            },
+                            data: [["2021-11-21 21:20:32",123],["2021-11-21 21:20:33",111],["2021-11-21 21:20:34",99],["2021-11-21 21:20:35",134]],
+                        }
+                    ]
+                });
+            </script>
+        </div>"#
+        );
+        assert_eq!(
+            graph_tasks_per_second_template(&data, None, None, None, None),
+            expected
+        );
+
+        let mut expected = expected_prefix.to_owned();
+        expected.push_str(r#"                                data: [
+                                    [
+                {
+                    name: 'Starting',
+                    xAxis: '2021-11-21 21:20:32'
+                },
+                {
+                    xAxis: '2021-11-21 21:20:34'
+                }
+            ],
+                                    
+                                ]
+                            },
+                            data: [["2021-11-21 21:20:32",123],["2021-11-21 21:20:33",111],["2021-11-21 21:20:34",99],["2021-11-21 21:20:35",134]],
+                        }
+                    ]
+                });
+            </script>
+        </div>"#
+        );
+        assert_eq!(
+            graph_tasks_per_second_template(
+                &data,
+                Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 32)),
+                Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 34)),
+                None,
+                None
+            ),
+            expected
+        );
+
+        let mut expected = expected_prefix.to_owned();
+        expected.push_str(r#"                                data: [
+                                    
+                                    [
+                {
+                    name: 'Stopping',
+                    xAxis: '2021-11-21 21:20:32'
+                },
+                {
+                    xAxis: '2021-11-21 21:20:34'
+                }
+            ],
+                                ]
+                            },
+                            data: [["2021-11-21 21:20:32",123],["2021-11-21 21:20:33",111],["2021-11-21 21:20:34",99],["2021-11-21 21:20:35",134]],
+                        }
+                    ]
+                });
+            </script>
+        </div>"#
+        );
+        assert_eq!(
+            graph_tasks_per_second_template(
+                &data,
+                None,
+                None,
+                Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 32)),
+                Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 34))
+            ),
+            expected
+        );
+
+        let mut expected = expected_prefix;
+        expected.push_str(r#"                                data: [
+                                    [
+                {
+                    name: 'Starting',
+                    xAxis: '2021-11-21 21:20:32'
+                },
+                {
+                    xAxis: '2021-11-21 21:20:34'
+                }
+            ],
+                                    [
+                {
+                    name: 'Stopping',
+                    xAxis: '2021-11-21 21:20:36'
+                },
+                {
+                    xAxis: '2021-11-21 21:20:38'
+                }
+            ],
+                                ]
+                            },
+                            data: [["2021-11-21 21:20:32",123],["2021-11-21 21:20:33",111],["2021-11-21 21:20:34",99],["2021-11-21 21:20:35",134]],
+                        }
+                    ]
+                });
+            </script>
+        </div>"#
+        );
+        assert_eq!(
+            graph_tasks_per_second_template(
                 &data,
                 Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 32)),
                 Some(Local.ymd(2021, 11, 21).and_hms(21, 20, 34)),

--- a/src/report.rs
+++ b/src/report.rs
@@ -21,6 +21,7 @@ pub struct GooseReportTemplates<'a> {
     pub errors_template: &'a str,
     pub graph_rps_template: &'a str,
     pub graph_average_response_time_template: &'a str,
+    pub graph_users_per_second: &'a str,
 }
 
 /// Defines the metrics reported about requests.
@@ -315,18 +316,12 @@ pub fn status_code_metrics_row(metric: StatusCodeMetric) -> String {
 }
 
 /// If task metrics are enabled, add a task metrics table to the html report.
-pub fn task_metrics_template(
-    task_rows: &str,
-    graph_tasks_per_second: &str,
-    graph_users_per_second: &str,
-) -> String {
+pub fn task_metrics_template(task_rows: &str, graph_tasks_per_second: &str) -> String {
     format!(
         r#"<div class="tasks">
         <h2>Task Metrics</h2>
 
         {graph_tasks_per_second}
-
-        {graph_users_per_second}
 
         <table>
             <thead>
@@ -347,7 +342,6 @@ pub fn task_metrics_template(
         </table>
     </div>"#,
         task_rows = task_rows,
-        graph_users_per_second = graph_users_per_second,
         graph_tasks_per_second = graph_tasks_per_second,
     )
 }
@@ -788,6 +782,11 @@ pub fn build_report(
 
         {tasks_template}
 
+        <div class="users">
+        <h2>User Metrics</h2>
+            {graph_users_per_second}
+        </div>
+
         {errors_template}
 
     </div>
@@ -807,6 +806,7 @@ pub fn build_report(
         errors_template = templates.errors_template,
         graph_rps_template = templates.graph_rps_template,
         graph_average_response_time_template = templates.graph_average_response_time_template,
+        graph_users_per_second = templates.graph_users_per_second,
     )
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -423,6 +423,7 @@ pub fn error_row(error: &metrics::GooseErrorMetricAggregate) -> String {
     )
 }
 
+/// Build a requests per second graph.
 pub fn graph_rps_template(
     rps: &[(String, u32)],
     starting: Option<DateTime<Local>>,
@@ -441,6 +442,7 @@ pub fn graph_rps_template(
     )
 }
 
+/// Build an errors per second graph.
 pub fn graph_eps_template(
     eps: &[(String, u32)],
     starting: Option<DateTime<Local>>,
@@ -459,6 +461,7 @@ pub fn graph_eps_template(
     )
 }
 
+/// Build an average response time graph.
 pub fn graph_average_response_time_template(
     response_times: &[(String, u32)],
     starting: Option<DateTime<Local>>,
@@ -477,6 +480,7 @@ pub fn graph_average_response_time_template(
     )
 }
 
+/// Build a users per second graph.
 pub fn graph_users_per_second_template(
     users: &[(String, usize)],
     starting: Option<DateTime<Local>>,
@@ -495,6 +499,7 @@ pub fn graph_users_per_second_template(
     )
 }
 
+/// Build a tasks per second graph.
 pub fn graph_tasks_per_second_template<T: Serialize>(
     tasks: &[(String, T)],
     starting: Option<DateTime<Local>>,
@@ -513,6 +518,8 @@ pub fn graph_tasks_per_second_template<T: Serialize>(
     )
 }
 
+/// Helper function to build HTML charts powered by the
+/// [ECharts](https://echarts.apache.org) library.
 #[allow(clippy::too_many_arguments)]
 fn graph_template<T: Serialize>(
     html_id: &str,

--- a/src/util.rs
+++ b/src/util.rs
@@ -474,6 +474,7 @@ impl MovingAverage {
 }
 
 impl Default for MovingAverage {
+    /// Creates an empty moving average.
     fn default() -> MovingAverage {
         MovingAverage::new()
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 //! Utility functions used by Goose, and available when writing load tests.
 
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
 use std::str::FromStr;
@@ -444,6 +445,40 @@ pub(crate) fn setup_ctrlc_handler(canceled: &Arc<AtomicBool>) {
     }
 }
 
+/// Data structure to maintain moving averages.
+///
+/// It will maintain the current average and the number of data items that
+/// were used to compute it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MovingAverage {
+    /// Number of data items that were used to compute the current average.
+    count: u32,
+    /// Current average.
+    pub average: f32,
+}
+
+impl MovingAverage {
+    /// Create a new MovingAverage object.
+    pub fn new() -> Self {
+        MovingAverage {
+            count: 0,
+            average: 0.,
+        }
+    }
+
+    /// Adds a new data item and calculates the new average.
+    pub fn add_item(&mut self, item: f32) {
+        self.count += 1;
+        self.average += (item as f32 - self.average) / self.count as f32;
+    }
+}
+
+impl Default for MovingAverage {
+    fn default() -> MovingAverage {
+        MovingAverage::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -610,5 +645,53 @@ mod tests {
         assert!(is_valid_host("http://foo").is_ok());
         assert!(is_valid_host("http:///example.com").is_ok());
         assert!(!is_valid_host("http:// example.com").is_ok());
+    }
+
+    #[test]
+    fn moving_average() {
+        let mut moving_average = MovingAverage::new();
+        assert_eq!(
+            moving_average,
+            MovingAverage {
+                count: 0,
+                average: 0.
+            }
+        );
+
+        moving_average.add_item(1.23);
+        assert_eq!(
+            moving_average,
+            MovingAverage {
+                count: 1,
+                average: 1.23
+            }
+        );
+
+        moving_average.add_item(2.34);
+        assert_eq!(
+            moving_average,
+            MovingAverage {
+                count: 2,
+                average: 1.785
+            }
+        );
+
+        moving_average.add_item(89.23);
+        assert_eq!(
+            moving_average,
+            MovingAverage {
+                count: 3,
+                average: 30.933332
+            }
+        );
+
+        moving_average.add_item(12.34);
+        assert_eq!(
+            moving_average,
+            MovingAverage {
+                count: 4,
+                average: 26.285
+            }
+        );
     }
 }


### PR DESCRIPTION
Closes #246.

## Graphs

- Errors per second
- Average response time per second
- Active users per second
- Active tasks per second

## Screenshots

### Errors

![Screenshot 2021-11-24 at 16-07-12 Goose Attack Report](https://user-images.githubusercontent.com/376889/143273822-0bd6c449-1dcd-4674-9343-97f6e8d48a46.png)

### Response time

<img width="1048" alt="Screenshot 2021-11-24 at 19 01 35" src="https://user-images.githubusercontent.com/376889/143298706-6ae23bf3-f37c-4a2f-a4e1-5cbd985ad601.png">

### Active users

<img width="1043" alt="Screenshot 2021-11-24 at 19 25 52" src="https://user-images.githubusercontent.com/376889/143301496-988d7e08-4c4d-4b92-b7f8-61be9abcfdc5.png">


