### PR TITLE
wake regularly during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.15.2-dev
  - [#391](https://github.com/tag1consulting/goose/pull/391) properly sleep for configured `set_wait_time()` walking regularly to exit quickly if the load test ends
  - [#394](https://github.com/tag1consulting/goose/pull/394) add additional graphs to the HTML report: errors per second, average response time, active users, active tasks
+ - [#403](https://github.com/tag1consulting/goose/pull/403) wake up a couple times a second to handle message and allow for a quick shutdown if the load test is canceled during startup
 
 ## 0.15.1 November 19, 2021
  - [#374](https://github.com/tag1consulting/goose/pull/374) renamed `simple-with-session.rs` to `session.rs` and `simple-closure.rs` to `closure.rs` to avoid confusion with the `simple.rs` example as they all do different things

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1396,17 +1396,10 @@ impl GooseAttack {
                 }
             }
         } else {
-            // If displaying running metrics, be sure we wake up often enough to
-            // display them at the configured rate.
-            let running_metrics = self.configuration.running_metrics.unwrap_or(0);
-
-            // Otherwise, sleep until the next time something needs to happen.
-            let sleep_duration = if running_metrics > 0
-                && running_metrics * 1_000 < goose_attack_run_state.spawn_user_in_ms
-            {
-                let sleep_delay = self.configuration.running_metrics.unwrap() * 1_000;
-                goose_attack_run_state.spawn_user_in_ms -= sleep_delay;
-                Duration::from_millis(sleep_delay as u64)
+            // Wake up twice a second to handle messages and allow for a quick shutdown if the
+            // load test is canceled during startup.
+            let sleep_duration = if goose_attack_run_state.spawn_user_in_ms > 500 {
+                Duration::from_millis(500)
             } else {
                 Duration::from_millis(goose_attack_run_state.spawn_user_in_ms as u64)
             };


### PR DESCRIPTION
 - wake up a couple times a second to handle message and allow for a quick shutdown if the load test is canceled during startup
 - fix #401 