### PR TITLE
underscore unread variable

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -220,7 +220,7 @@ pub(crate) struct GooseControllerRequest {
 #[derive(Debug)]
 pub(crate) struct GooseControllerResponse {
     /// An integer identifying which controller the parent is responding to.
-    pub client_id: u32,
+    pub _client_id: u32,
     /// The actual response message.
     pub response: GooseControllerResponseMessage,
 }
@@ -1102,7 +1102,7 @@ impl GooseAttack {
         if let Some(oneshot_tx) = request.response_channel {
             if oneshot_tx
                 .send(GooseControllerResponse {
-                    client_id: request.client_id,
+                    _client_id: request.client_id,
                     response,
                 })
                 .is_err()


### PR DESCRIPTION
- fix clippy warning

```
% cargo clippy
   Compiling goose v0.15.2-dev (.../goose)
warning: field is never read: `client_id`
   --> src/controller.rs:223:5
    |
223 |     pub client_id: u32,
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `goose` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 1.90s
```