### PR TITLE
#405: Move GooseMetrics::record_users_per_second() call to the main loop.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1705,6 +1705,10 @@ impl GooseAttack {
                 // By reaching the Shutdown phase, break out of the GooseAttack loop.
                 AttackPhase::Shutdown => break,
             }
+
+            // Record current users for users per second graph in HTML report.
+            self.metrics.record_users_per_second();
+
             // Regularly synchronize metrics.
             self.sync_metrics(&mut goose_attack_run_state, false)
                 .await?;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2399,9 +2399,6 @@ impl GooseAttack {
                 }
             }
 
-            // Record current users for users per second graph in HTML report.
-            self.metrics.record_users_per_second();
-
             // Load messages from user threads until the receiver queue is empty.
             let received_message = self.receive_metrics(goose_attack_run_state, flush).await?;
 


### PR DESCRIPTION
Closes #405.