### PR TITLE
Add granular data to the HTML report graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.16.0-dev
+ - [#415](https://github.com/tag1consulting/goose/pull/415) display granular data in HTML graphs, introduce `--no-granular-data` to disable it and display graphs as they were until this change
  - [#406](https://github.com/tag1consulting/goose/pull/406) make sure that the graphs are built correctly if the load test is interrupted during the starting phase
  - [#408](https://github.com/tag1consulting/goose/pull/408) update 'Running the load test' page in the Goose book to show HTML report
  - [#411](https://github.com/tag1consulting/goose/pull/411) **API change**: some public APIs have been made private or removed

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -72,12 +72,12 @@ impl GraphData {
     }
 
     /// Record requests per second metric.
-    pub(crate) fn record_requests_per_second(&mut self, key: String, second: usize) {
-        if !self.requests_per_second.contains_key(&key) {
+    pub(crate) fn record_requests_per_second(&mut self, key: &str, second: usize) {
+        if !self.requests_per_second.contains_key(key) {
             self.requests_per_second
-                .insert(key.clone(), TimeSeries::new());
+                .insert(key.to_string(), TimeSeries::new());
         }
-        let data = self.requests_per_second.get_mut(&key).unwrap();
+        let data = self.requests_per_second.get_mut(key).unwrap();
         data.increase(second, 1);
 
         debug!(
@@ -88,12 +88,12 @@ impl GraphData {
     }
 
     /// Record errors per second metric.
-    pub(crate) fn record_errors_per_second(&mut self, key: String, second: usize) {
-        if !self.errors_per_second.contains_key(&key) {
+    pub(crate) fn record_errors_per_second(&mut self, key: &str, second: usize) {
+        if !self.errors_per_second.contains_key(key) {
             self.errors_per_second
-                .insert(key.clone(), TimeSeries::new());
+                .insert(key.to_string(), TimeSeries::new());
         }
-        let data = self.errors_per_second.get_mut(&key).unwrap();
+        let data = self.errors_per_second.get_mut(key).unwrap();
         data.increase(second, 1);
 
         debug!(
@@ -959,15 +959,15 @@ mod test {
         let mut graph = GraphData::new();
         assert_eq!(graph.requests_per_second.len(), 0);
 
-        graph.record_requests_per_second("GET /".to_string(), 0);
-        graph.record_requests_per_second("GET /".to_string(), 0);
-        graph.record_requests_per_second("GET /".to_string(), 0);
-        graph.record_requests_per_second("GET /".to_string(), 1);
-        graph.record_requests_per_second("GET /".to_string(), 2);
-        graph.record_requests_per_second("GET /".to_string(), 2);
-        graph.record_requests_per_second("GET /".to_string(), 2);
-        graph.record_requests_per_second("GET /".to_string(), 2);
-        graph.record_requests_per_second("GET /".to_string(), 2);
+        graph.record_requests_per_second("GET /", 0);
+        graph.record_requests_per_second("GET /", 0);
+        graph.record_requests_per_second("GET /", 0);
+        graph.record_requests_per_second("GET /", 1);
+        graph.record_requests_per_second("GET /", 2);
+        graph.record_requests_per_second("GET /", 2);
+        graph.record_requests_per_second("GET /", 2);
+        graph.record_requests_per_second("GET /", 2);
+        graph.record_requests_per_second("GET /", 2);
         assert_eq!(
             graph.requests_per_second.get("GET /").unwrap().data.len(),
             3
@@ -976,13 +976,13 @@ mod test {
         assert_eq!(graph.requests_per_second.get("GET /").unwrap().data[1], 1);
         assert_eq!(graph.requests_per_second.get("GET /").unwrap().data[2], 5);
 
-        graph.record_requests_per_second("GET /".to_string(), 100);
-        graph.record_requests_per_second("GET /".to_string(), 100);
-        graph.record_requests_per_second("GET /".to_string(), 100);
-        graph.record_requests_per_second("GET /".to_string(), 0);
-        graph.record_requests_per_second("GET /".to_string(), 1);
-        graph.record_requests_per_second("GET /".to_string(), 2);
-        graph.record_requests_per_second("GET /".to_string(), 5);
+        graph.record_requests_per_second("GET /", 100);
+        graph.record_requests_per_second("GET /", 100);
+        graph.record_requests_per_second("GET /", 100);
+        graph.record_requests_per_second("GET /", 0);
+        graph.record_requests_per_second("GET /", 1);
+        graph.record_requests_per_second("GET /", 2);
+        graph.record_requests_per_second("GET /", 5);
         assert_eq!(
             graph.requests_per_second.get("GET /").unwrap().data.len(),
             101
@@ -1001,11 +1001,11 @@ mod test {
             );
         }
 
-        graph.record_requests_per_second("GET /user".to_string(), 0);
-        graph.record_requests_per_second("GET /user".to_string(), 1);
-        graph.record_requests_per_second("GET /user".to_string(), 1);
-        graph.record_requests_per_second("GET /".to_string(), 2);
-        graph.record_requests_per_second("GET /".to_string(), 5);
+        graph.record_requests_per_second("GET /user", 0);
+        graph.record_requests_per_second("GET /user", 1);
+        graph.record_requests_per_second("GET /user", 1);
+        graph.record_requests_per_second("GET /", 2);
+        graph.record_requests_per_second("GET /", 5);
         assert_eq!(
             graph
                 .requests_per_second
@@ -1042,11 +1042,11 @@ mod test {
             );
         }
 
-        graph.record_requests_per_second("GET /user".to_string(), 100);
-        graph.record_requests_per_second("GET /user".to_string(), 0);
-        graph.record_requests_per_second("GET /user".to_string(), 1);
-        graph.record_requests_per_second("GET /".to_string(), 0);
-        graph.record_requests_per_second("GET /".to_string(), 1);
+        graph.record_requests_per_second("GET /user", 100);
+        graph.record_requests_per_second("GET /user", 0);
+        graph.record_requests_per_second("GET /user", 1);
+        graph.record_requests_per_second("GET /", 0);
+        graph.record_requests_per_second("GET /", 1);
         assert_eq!(
             graph
                 .requests_per_second
@@ -1100,27 +1100,27 @@ mod test {
         let mut graph = GraphData::new();
         assert_eq!(graph.errors_per_second.len(), 0);
 
-        graph.record_errors_per_second("GET /".to_string(), 0);
-        graph.record_errors_per_second("GET /".to_string(), 0);
-        graph.record_errors_per_second("GET /".to_string(), 0);
-        graph.record_errors_per_second("GET /".to_string(), 1);
-        graph.record_errors_per_second("GET /".to_string(), 2);
-        graph.record_errors_per_second("GET /".to_string(), 2);
-        graph.record_errors_per_second("GET /".to_string(), 2);
-        graph.record_errors_per_second("GET /".to_string(), 2);
-        graph.record_errors_per_second("GET /".to_string(), 2);
+        graph.record_errors_per_second("GET /", 0);
+        graph.record_errors_per_second("GET /", 0);
+        graph.record_errors_per_second("GET /", 0);
+        graph.record_errors_per_second("GET /", 1);
+        graph.record_errors_per_second("GET /", 2);
+        graph.record_errors_per_second("GET /", 2);
+        graph.record_errors_per_second("GET /", 2);
+        graph.record_errors_per_second("GET /", 2);
+        graph.record_errors_per_second("GET /", 2);
         assert_eq!(graph.errors_per_second.get("GET /").unwrap().data.len(), 3);
         assert_eq!(graph.errors_per_second.get("GET /").unwrap().data[0], 3);
         assert_eq!(graph.errors_per_second.get("GET /").unwrap().data[1], 1);
         assert_eq!(graph.errors_per_second.get("GET /").unwrap().data[2], 5);
 
-        graph.record_errors_per_second("GET /".to_string(), 100);
-        graph.record_errors_per_second("GET /".to_string(), 100);
-        graph.record_errors_per_second("GET /".to_string(), 100);
-        graph.record_errors_per_second("GET /".to_string(), 0);
-        graph.record_errors_per_second("GET /".to_string(), 1);
-        graph.record_errors_per_second("GET /".to_string(), 2);
-        graph.record_errors_per_second("GET /".to_string(), 5);
+        graph.record_errors_per_second("GET /", 100);
+        graph.record_errors_per_second("GET /", 100);
+        graph.record_errors_per_second("GET /", 100);
+        graph.record_errors_per_second("GET /", 0);
+        graph.record_errors_per_second("GET /", 1);
+        graph.record_errors_per_second("GET /", 2);
+        graph.record_errors_per_second("GET /", 5);
         assert_eq!(
             graph.errors_per_second.get("GET /").unwrap().data.len(),
             101

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2461,7 +2461,7 @@ impl GooseAttack {
                             let key =
                                 format!("{} {}", request_metric.raw.method, request_metric.name);
                             self.graph_data
-                                .record_requests_per_second(key, seconds_since_start);
+                                .record_requests_per_second(key.clone(), seconds_since_start);
                             self.graph_data.record_average_response_time_per_second(
                                 seconds_since_start,
                                 request_metric.response_time,
@@ -2469,7 +2469,7 @@ impl GooseAttack {
 
                             if !request_metric.success {
                                 self.graph_data
-                                    .record_errors_per_second(seconds_since_start);
+                                    .record_errors_per_second(key, seconds_since_start);
                             }
                         }
                     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2458,8 +2458,10 @@ impl GooseAttack {
                         if !self.configuration.report_file.is_empty() {
                             let seconds_since_start = (request_metric.elapsed / 1000) as usize;
 
+                            let key =
+                                format!("{} {}", request_metric.raw.method, request_metric.name);
                             self.graph_data
-                                .record_requests_per_second(seconds_since_start);
+                                .record_requests_per_second(key, seconds_since_start);
                             self.graph_data.record_average_response_time_per_second(
                                 seconds_since_start,
                                 request_metric.response_time,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2463,6 +2463,7 @@ impl GooseAttack {
                             self.graph_data
                                 .record_requests_per_second(key.clone(), seconds_since_start);
                             self.graph_data.record_average_response_time_per_second(
+                                key.clone(),
                                 seconds_since_start,
                                 request_metric.response_time,
                             );

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2461,7 +2461,7 @@ impl GooseAttack {
                             let key =
                                 format!("{} {}", request_metric.raw.method, request_metric.name);
                             self.graph_data
-                                .record_requests_per_second(key.clone(), seconds_since_start);
+                                .record_requests_per_second(&key, seconds_since_start);
                             self.graph_data.record_average_response_time_per_second(
                                 key.clone(),
                                 seconds_since_start,
@@ -2470,7 +2470,7 @@ impl GooseAttack {
 
                             if !request_metric.success {
                                 self.graph_data
-                                    .record_errors_per_second(key, seconds_since_start);
+                                    .record_errors_per_second(&key, seconds_since_start);
                             }
                         }
                     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2934,7 +2934,8 @@ impl GooseAttack {
 
                 tasks_template = report::task_metrics_template(
                     &tasks_rows.join("\n"),
-                    self.graph_data.get_tasks_per_second_graph(),
+                    self.graph_data
+                        .get_tasks_per_second_graph(!self.configuration.no_granular_data),
                 );
             } else {
                 tasks_template = "".to_string();
@@ -2949,7 +2950,8 @@ impl GooseAttack {
 
                 report::errors_template(
                     &error_rows.join("\n"),
-                    self.graph_data.get_errors_per_second_graph(),
+                    self.graph_data
+                        .get_errors_per_second_graph(!self.configuration.no_granular_data),
                 )
             } else {
                 "".to_string()
@@ -3021,13 +3023,16 @@ impl GooseAttack {
                     errors_template: &errors_template,
                     graph_rps_template: &self
                         .graph_data
-                        .get_requests_per_second_graph()
+                        .get_requests_per_second_graph(!self.configuration.no_granular_data)
                         .get_markup(),
                     graph_average_response_time_template: &self
                         .graph_data
-                        .get_average_response_time_graph()
+                        .get_average_response_time_graph(!self.configuration.no_granular_data)
                         .get_markup(),
-                    graph_users_per_second: &self.graph_data.get_active_users_graph().get_markup(),
+                    graph_users_per_second: &self
+                        .graph_data
+                        .get_active_users_graph(!self.configuration.no_granular_data)
+                        .get_markup(),
                 },
             );
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -315,7 +315,7 @@ pub(crate) fn status_code_metrics_row(metric: StatusCodeMetric) -> String {
 }
 
 /// If task metrics are enabled, add a task metrics table to the html report.
-pub(crate) fn task_metrics_template<T: Serialize>(task_rows: &str, graph: Graph<T>) -> String {
+pub(crate) fn task_metrics_template(task_rows: &str, graph: Graph<usize, usize>) -> String {
     format!(
         r#"<div class="tasks">
         <h2>Task Metrics</h2>
@@ -380,7 +380,7 @@ pub(crate) fn task_metrics_row(metric: TaskMetric) -> String {
 }
 
 /// If there are errors, add an errors table to the html report.
-pub(crate) fn errors_template(error_rows: &str, graph: Graph<u32>) -> String {
+pub(crate) fn errors_template(error_rows: &str, graph: Graph<u32, u32>) -> String {
     format!(
         r#"<div class="errors">
         <h2>Errors</h2>


### PR DESCRIPTION
Closes #410.

I used the default color scheme for now. I don't particularly like it, but I didn't have any better idea either.

<img width="1022" alt="Screenshot 2022-02-10 at 23 34 32" src="https://user-images.githubusercontent.com/376889/153492214-34b083e1-af37-4db6-a120-9f5cd225247e.png">
<img width="1022" alt="Screenshot 2022-02-10 at 23 34 18" src="https://user-images.githubusercontent.com/376889/153492230-fa66e9d0-63ce-44c3-b3cd-72938e685c5b.png">
