### PR TITLE
fix error-log documentation

### DIFF
--- a/src/docs/goose-book/src/logging/errors.md
+++ b/src/docs/goose-book/src/logging/errors.md
@@ -1,6 +1,6 @@
 # Error Log
 
-Goose can optionally log details about all load test errors to a file. To enable, add the `--error-file=<error.log>` command line option, where `<error.log>` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
+Goose can optionally log details about all load test errors to a file. To enable, add the `--error-log=<error.log>` command line option, where `<error.log>` is either a relative or absolute path of the log file to create. Any existing file that may already exist will be overwritten.
 
 Logs include the entire [`GooseErrorMetric`](https://docs.rs/goose/*/goose/metrics/struct.GooseErrorMetric.html) object, created any time a request results in an error.
 
@@ -17,4 +17,4 @@ The `--errors-format` option can be used to change the log format to `csv`, `jso
 
 ## Gaggle Mode
 
-When operating in Gaggle-mode, the `--error-file` option can only be enabled on the Worker processes, configuring Goose to spread out the overhead of writing logs.
+When operating in Gaggle-mode, the `--error-log` option can only be enabled on the Worker processes, configuring Goose to spread out the overhead of writing logs.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2500,7 +2500,7 @@ impl GooseAttack {
         raw_request: &GooseRequestMetric,
         goose_attack_run_state: &mut GooseAttackRunState,
     ) {
-        // If error-file is enabled, convert the raw request to a GooseErrorMetric and send it
+        // If error-log is enabled, convert the raw request to a GooseErrorMetric and send it
         // to the logger thread.
         if !self.configuration.error_log.is_empty() {
             if let Some(logger) = goose_attack_run_state.all_threads_logger_tx.as_ref() {


### PR DESCRIPTION
Hello, from what I understand, `--error-file` has been renamed to `--error-log`, but that change was missing in the documentation.