### PR TITLE
[WIP] Update to tokio 1.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = [
 serde_cbor = "0.11"
 serde_json = "1.0"
 simplelog = "0.10"
-tokio = { version = "~1.15.0", features = [
+tokio = { version = "1.16.1", features = [
     "fs",
     "io-util",
     "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ tokio = { version = "1.16.1", features = [
     "time",
     "sync",
 ] }
-tokio-tungstenite = "0.15"
-tungstenite = "0.15"
+tokio-tungstenite = "0.16.1"
+tungstenite = "0.16.0"
 url = "2"
 
 # optional dependencies
@@ -57,7 +57,7 @@ nng = { version = "1.0", optional = true }
 [features]
 default = ["reqwest/default-tls"]
 gaggle = ["nng"]
-rustls-tls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls"]
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -403,7 +403,7 @@ impl GooseControllerState {
                         None => {
                             // Returning with no data means the client disconnected.
                             info!(
-                                "Telnet client [{}] disconnected from {}",
+                                "WebSocket client [{}] disconnected from {}",
                                 self.thread_id, self.peer_address
                             );
                             break;
@@ -417,7 +417,7 @@ impl GooseControllerState {
                             if self.execute_command(&mut ws_sender, request_message).await {
                                 // If execute_command() returns true, it's time to exit.
                                 info!(
-                                    "Telnet client [{}] disconnected from {}",
+                                    "WebSocket client [{}] disconnected from {}",
                                     self.thread_id, self.peer_address
                                 );
                                 break;

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -580,12 +580,16 @@ async fn run_standalone_test(test_type: TestType) {
         }
     });
 
-    // Run the Goose Attack.
-    let goose_metrics = common::run_load_test(
-        common::build_load_test(configuration.clone(), &get_tasks(), None, None),
-        None,
+    // Run the Goose Attack. Add timeout to be sure Goose exits even if the controller tests fail.
+    let goose_metrics = tokio::time::timeout(
+        tokio::time::Duration::from_secs(60),
+        common::run_load_test(
+            common::build_load_test(configuration.clone(), &get_tasks(), None, None),
+            None,
+        ),
     )
-    .await;
+    .await
+    .expect("load test timed out");
 
     // Confirm that the load test ran correctly.
     validate_one_taskset(


### PR DESCRIPTION
 - update Tokio to 1.16.1+ (fixes #419)
 - timeout Goose if controller tests fail to shut it down after 60 seconds

@TODO: Solve the issue where tests appear to not be running in threads