### PR TITLE
Introduce `--test-plan` for more complex test plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
    o **note**: `-v` now sets Goose to `DEBUG` level verbosity which when enabled will negatively impact load test performance; set `-q` to restore previous level of verbosity
  - [#379](https://github.com/tag1consulting/goose/pull/379) **API change**: remove `.print()` which is no longer required to display metrics after a load test, disable with `--no-print-metrics` or `GooseDefault::NoPrintMetrics`
  - @TODO: introduce `--test-plan` and `GooseDefault::TestPlan`
+    o internally represent all load tests as `Vec<(usize, usize)>`l test plan
     
 ## 0.15.2 December 13, 2021
  - [#391](https://github.com/tag1consulting/goose/pull/391) properly sleep for configured `set_wait_time()` walking regularly to exit quickly if the load test ends

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@
  - [#379](https://github.com/tag1consulting/goose/pull/379) **API change**: default to `INFO` level verbosity, introduce `-q` to reduce Goose verbosity
    o **note**: `-v` now sets Goose to `DEBUG` level verbosity which when enabled will negatively impact load test performance; set `-q` to restore previous level of verbosity
  - [#379](https://github.com/tag1consulting/goose/pull/379) **API change**: remove `.print()` which is no longer required to display metrics after a load test, disable with `--no-print-metrics` or `GooseDefault::NoPrintMetrics`
- - @TODO: introduce `--test-plan` and `GooseDefault::TestPlan`
+ - [#422](https://github.com/tag1consulting/goose/pull/422) **API change**: introduce `--test-plan` and `GooseDefault::TestPlan`
     o internally represent all load tests as `Vec<(usize, usize)>`l test plan
+    o use [FromStr] to auto convert --test-plan "{users},{timespan};{users},{timespan}", where {users} must be an integer, ie "100", and {timespan} can be integer seconds or "30s", "20m", "3h", "1h30m", etc, to internal Vec<(usize, usize)> representation
+    o don't allow `--test-plan` together with `--users`, `--startup-time`, `--hatch-rate`, `--run-time`, `--no-reset-metrics`, `--manager` and `--worker`
+    o internal `AttackPhase`s renamed: `Starting` -> `Increase`, `Running` -> `Maintain`, `Stopping` -> `Decrease`
     
 ## 0.15.2 December 13, 2021
  - [#391](https://github.com/tag1consulting/goose/pull/391) properly sleep for configured `set_wait_time()` walking regularly to exit quickly if the load test ends

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  - [#379](https://github.com/tag1consulting/goose/pull/379) **API change**: default to `INFO` level verbosity, introduce `-q` to reduce Goose verbosity
    o **note**: `-v` now sets Goose to `DEBUG` level verbosity which when enabled will negatively impact load test performance; set `-q` to restore previous level of verbosity
  - [#379](https://github.com/tag1consulting/goose/pull/379) **API change**: remove `.print()` which is no longer required to display metrics after a load test, disable with `--no-print-metrics` or `GooseDefault::NoPrintMetrics`
+ - @TODO: introduce `--test-plan` and `GooseDefault::TestPlan`
     
 ## 0.15.2 December 13, 2021
  - [#391](https://github.com/tag1consulting/goose/pull/391) properly sleep for configured `set_wait_time()` walking regularly to exit quickly if the load test ends

--- a/src/config.rs
+++ b/src/config.rs
@@ -435,8 +435,6 @@ impl TestPlan {
                 }
             }
 
-            println!("TEST_PLAN: {:#?}", steps);
-
             // Define test plan from options.
             TestPlan { steps, current: 0 }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,14 +6,13 @@
 //! Goose can be configured programmatically with [`GooseDefaultType::set_default`].
 
 use gumdrop::Options;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use simplelog::*;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use crate::logger::GooseLogFormat;
 use crate::metrics::GooseCoordinatedOmissionMitigation;
+use crate::test_plan::TestPlan;
 use crate::util;
 use crate::{GooseAttack, GooseError};
 
@@ -373,126 +372,6 @@ pub(crate) struct GooseDefaults {
     pub manager_host: Option<String>,
     /// An optional default for port Worker connects to.
     pub manager_port: Option<u16>,
-}
-
-/// Internal data structure representing a test plan.
-//#[derive(Options, Debug, Clone, Serialize, Deserialize)]
-#[derive(Options, Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct TestPlan {
-    // A test plan is a vector of tuples each indicating a # of users and milliseconds.
-    pub(crate) steps: Vec<(usize, usize)>,
-    // Which step of the test_plan is currently running.
-    pub(crate) current: usize,
-}
-
-/// Automatically represent all load tests internally as a test plan.
-///
-/// Load tests launched using `--users`, `--startup-time`, `--hatch-rate`, and/or `--run-time` are
-/// automatically converted to a `Vec<(usize, usize)>` test plan.
-impl TestPlan {
-    pub(crate) fn new() -> TestPlan {
-        TestPlan {
-            steps: Vec::new(),
-            current: 0,
-        }
-    }
-
-    pub(crate) fn build(configuration: &GooseConfiguration) -> TestPlan {
-        if let Some(test_plan) = configuration.test_plan.as_ref() {
-            // Test plan was manually defined, clone and return as is.
-            test_plan.clone()
-        } else {
-            let mut steps: Vec<(usize, usize)> = Vec::new();
-
-            // Build a simple test plan from configured options if possible.
-            if let Some(users) = configuration.users {
-                if configuration.startup_time != "0" {
-                    // Load test is configured with --startup-time.
-                    steps.push((
-                        users,
-                        util::parse_timespan(&configuration.startup_time) * 1_000,
-                    ));
-                } else {
-                    // Load test is configured with --hatch-rate.
-                    let hatch_rate = if let Some(hatch_rate) = configuration.hatch_rate.as_ref() {
-                        util::get_hatch_rate(Some(hatch_rate.to_string()))
-                    } else {
-                        util::get_hatch_rate(None)
-                    };
-                    // Convert hatch_rate to milliseconds.
-                    let ms_hatch_rate = 1.0 / hatch_rate * 1_000.0;
-                    // Finally, multiply the hatch rate by the number of users to hatch.
-                    let total_time = ms_hatch_rate * users as f32;
-                    steps.push((users, total_time as usize));
-                }
-
-                // A run-time is set, configure the load plan to run for the specified time then shut down.
-                if configuration.run_time != "0" {
-                    // Maintain the configured number of users for the configured run-time.
-                    steps.push((users, util::parse_timespan(&configuration.run_time) * 1_000));
-                    // Then shut down the load test as quickly as possible.
-                    steps.push((0, 0));
-                }
-            }
-
-            // Define test plan from options.
-            TestPlan { steps, current: 0 }
-        }
-    }
-
-    // Determine the maximum number of users configured during the test plan.
-    pub(crate) fn max_users(&self) -> usize {
-        let mut max_users = 0;
-        for step in &self.steps {
-            if step.0 > max_users {
-                max_users = step.0;
-            }
-        }
-        max_users
-    }
-}
-
-/// Implement [`FromStr`] to convert `"users,timespan"` string formatted test plans to Goose's
-/// internal representation of Vec<(usize, usize)>.
-///
-/// Users are represented simply as an integer.
-///
-/// Time span can be specified as an integer, indicating seconds. Or can use integers together
-/// with one or more of "h", "m", and "s", in that order, indicating "hours", "minutes", and
-/// "seconds". Valid formats include: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.
-impl FromStr for TestPlan {
-    type Err = GooseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Convert string into a TestPlan.
-        let mut steps: Vec<(usize, usize)> = Vec::new();
-        // Each line of the test plan must be in the format "{users},{timespan}", white space is ignored
-        let re = Regex::new(r"^\s*(\d+)\s*,\s*(\d+|((\d+?)h)?((\d+?)m)?((\d+?)s)?)\s*$").unwrap();
-        // A test plan can have multiple lines split by the semicolon ";".
-        let lines = s.split(';');
-        for line in lines {
-            if let Some(cap) = re.captures(line) {
-                let left = cap[1]
-                    .parse::<usize>()
-                    .expect("failed to convert \\d to usize");
-                let right = util::parse_timespan(&cap[2]) * 1_000;
-                steps.push((left, right));
-            } else {
-                // Logger isn't initialized yet, provide helpful debug output.
-                eprintln!("ERROR: invalid `configuration.test_plan` value: '{}'", line);
-                eprintln!("  Expected format: --test-plan \"{{users}},{{timespan}};{{users}},{{timespan}}\"");
-                eprintln!("    {{users}} must be an integer, ie \"100\"");
-                eprintln!("    {{timespan}} can be integer seconds or \"30s\", \"20m\", \"3h\", \"1h30m\", etc");
-                return Err(GooseError::InvalidOption {
-                    option: "`configuration.test_plan".to_string(),
-                    value: line.to_string(),
-                    detail: "invalid `configuration.test_plan` value.".to_string(),
-                });
-            }
-        }
-        // The steps are only valid if the logic gets this far.
-        Ok(TestPlan { steps, current: 0 })
-    }
 }
 
 /// Defines all [`GooseConfiguration`] options that can be programmatically configured with

--- a/src/config.rs
+++ b/src/config.rs
@@ -2434,6 +2434,20 @@ impl GooseConfiguration {
                         .to_string(),
                 });
             }
+            if self.manager {
+                return Err(GooseError::InvalidOption {
+                    option: "`configuration.test_plan".to_string(),
+                    value: format!("{:?}", self.test_plan),
+                    detail: "`configuration.test_plan` can not be set in Manager mode.".to_string(),
+                });
+            }
+            if self.worker {
+                return Err(GooseError::InvalidOption {
+                    option: "`configuration.test_plan".to_string(),
+                    value: format!("{:?}", self.test_plan),
+                    detail: "`configuration.test_plan` can not be set in Worker mode.".to_string(),
+                });
+            }
         }
 
         // Validate `no_metrics`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -406,7 +406,7 @@ impl TestPlan {
 
             // Build a simple test plan from configured options if possible.
             if let Some(users) = configuration.users {
-                if !configuration.startup_time.is_empty() {
+                if configuration.startup_time != "0" {
                     // Load test is configured with --startup-time.
                     steps.push((
                         users,
@@ -419,7 +419,11 @@ impl TestPlan {
                     } else {
                         util::get_hatch_rate(None)
                     };
-                    steps.push((users, ((hatch_rate * users as f32) * 1_000.0) as usize));
+                    // Convert hatch_rate to milliseconds.
+                    let ms_hatch_rate = 1.0 / hatch_rate * 1_000.0;
+                    // Finally, multiply the hatch rate by the number of users to hatch.
+                    let total_time = ms_hatch_rate * users as f32;
+                    steps.push((users, total_time as usize));
                 }
 
                 // A run-time is set, configure the load plan to run for the specified time then shut down.
@@ -430,6 +434,8 @@ impl TestPlan {
                     steps.push((0, 0));
                 }
             }
+
+            println!("TEST_PLAN: {:#?}", steps);
 
             // Define test plan from options.
             TestPlan { steps, current: 0 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -3,8 +3,9 @@
 //! By default, Goose launches both a telnet Controller and a WebSocket Controller, allowing
 //! real-time control of the running load test.
 
-use crate::config::{GooseConfiguration, TestPlan};
-use crate::metrics::{GooseMetrics, TestPlanHistory, TestPlanStepAction};
+use crate::config::GooseConfiguration;
+use crate::metrics::GooseMetrics;
+use crate::test_plan::{TestPlan, TestPlanHistory, TestPlanStepAction};
 use crate::util;
 use crate::{AttackPhase, GooseAttack, GooseAttackRunState, GooseError};
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1149,9 +1149,9 @@ impl GooseAttack {
                         GooseControllerCommand::Start => {
                             // We can only start an idle load test.
                             if self.attack_phase == AttackPhase::Idle {
+                                self.test_plan = TestPlan::build(&self.configuration);
                                 if self.prepare_load_test().is_ok() {
                                     // Rebuild test plan in case any parameters have been changed.
-                                    self.test_plan = TestPlan::build(&self.configuration);
                                     self.set_attack_phase(
                                         goose_attack_run_state,
                                         AttackPhase::Increase,

--- a/src/docs/goose-book/src/SUMMARY.md
+++ b/src/docs/goose-book/src/SUMMARY.md
@@ -8,6 +8,7 @@
     - [Running A Load Test](getting-started/running.md)
     - [Run-Time Options](getting-started/runtime-options.md)
         - [Common Options](getting-started/common.md)
+        - [Test Plan](getting-started/test-plan.md)
         - [Throttle](getting-started/throttle.md)
     - [Metrics](getting-started/metrics.md)
     - [Tips](getting-started/tips.md)

--- a/src/docs/goose-book/src/config/defaults.md
+++ b/src/docs/goose-book/src/config/defaults.md
@@ -22,6 +22,7 @@ The following defaults can be configured with a `&str`:
  - requests log file format: `GooseDefault::RequestsFormat`
  - debug log file name: `GooseDefault::DebugFile`
  - debug log file format: `GooseDefault::DebugFormat`
+ - test plan: `GooseDefault::TestPlan`
  - host to bind telnet Controller to: `GooseDefault::TelnetHost`
  - host to bind WebSocket Controller to: `GooseDefault::WebSocketHost`
  - host to bind Manager to: `GooseDefault::ManagerBindHost`

--- a/src/docs/goose-book/src/getting-started/runtime-options.md
+++ b/src/docs/goose-book/src/getting-started/runtime-options.md
@@ -44,6 +44,7 @@ Metrics:
   --status-codes             Tracks additional status code metrics
 
 Advanced:
+  --test-plan "TESTPLAN"     Defines a more complex test plan ("10,60;0,30")
   --no-telnet                Doesn't enable telnet Controller
   --telnet-host HOST         Sets telnet Controller host (default: 0.0.0.0)
   --telnet-port PORT         Sets telnet Controller TCP port (default: 5116)

--- a/src/docs/goose-book/src/getting-started/test-plan.md
+++ b/src/docs/goose-book/src/getting-started/test-plan.md
@@ -1,0 +1,24 @@
+# Test Plan
+
+The simplest way to configure a Goose load test is with the `--startup-time` or `--hatch-rate` options together with `--users` and `--run-time`. However, if you need a more complex test plan, you can instead use the `--test-plan` option.
+
+A test plan is a series of integer pairs which define the number of users and number of seconds. For example, "10,60" means "10 users" for "60 seconds". Multiple pairs can be strung together if separated by a semicolon, for example, "10,60;10,300". In this example, Goose will take 60 seconds to launch 10 users, then it will leave those users running for 5 minutes, before shutting down.
+
+## Simple Example
+
+The following two examples are identical:
+```bash
+$ cargo run --release -- -H http://local.dev/ --test-plan "10,60;10,300"
+```
+
+```bash
+$ cargo run --release -- -H http://local.dev/ --startup-time 60 --users 10 --run-time 300
+```
+
+## Complex Example
+
+The next example shows how to craft a more complex test plan. It tells Goose to spend 60 seconds launching 10 users and then to let them run for 5 minutes, then to increase the user count to 1,000 in 30 seconds and to let them run for another minute, then to decrease back to 10 users again in 30 seconds leaving those 10 users running for another 5 minutes, and finally to spend 90 seconds shutting down the load test.
+
+```bash
+$ cargo run --release -- -H http://local.dev/ --test-plan "10,60;10,300;1000,30;1000,60;10,30;10,300;0,90"
+```

--- a/src/docs/goose-book/src/getting-started/test-plan.md
+++ b/src/docs/goose-book/src/getting-started/test-plan.md
@@ -18,7 +18,7 @@ The exact same behaviour can be defined with the following test plan:
 $ cargo run --release -- -H http://local.dev/ --test-plan "10,1m;10,5m;0,0"
 ```
 
-## Ramp Down
+## Ramp Down Example
 
 Goose will stop a load test as quickly as it can when the specified `--run-time` completes. To instead configure a load test to ramp down slowly you can use a test plan. In the following example, Goose starts 1000 users in 2 minutes and then slowly stops them over 500 seconds (stopping 2 users per second):
 
@@ -26,7 +26,7 @@ Goose will stop a load test as quickly as it can when the specified `--run-time`
 $ cargo run --release -- -H http://local.dev/ --test-plan "1000,2m;0,500"
 ```
 
-## Load Spikes
+## Load Spike Example
 
 Another possibility when specifying a test plan is to add load spikes into otherwise steady load. For example, in the following example Goose starts 500 users over 5 minutes and lets it run with a couple of traffic spikes to 2,500 users:
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1138,7 +1138,7 @@ impl GooseUser {
             .build();
 
         // Make the request and return the GooseResponse.
-        Ok(self.request(goose_request).await?)
+        self.request(goose_request).await
     }
 
     /// A helper to make a named `GET` request of a path and collect relevant metrics.
@@ -1179,7 +1179,7 @@ impl GooseUser {
             .build();
 
         // Make the request and return the GooseResponse.
-        Ok(self.request(goose_request).await?)
+        self.request(goose_request).await
     }
 
     /// A helper to make a `POST` request of a path and collect relevant metrics.
@@ -1223,7 +1223,7 @@ impl GooseUser {
             .build();
 
         // Make the request and return the GooseResponse.
-        Ok(self.request(goose_request).await?)
+        self.request(goose_request).await
     }
 
     /// A helper to make a `POST` request of a form on a path and collect relevant metrics.
@@ -1268,7 +1268,7 @@ impl GooseUser {
             .build();
 
         // Make the request and return the GooseResponse.
-        Ok(self.request(goose_request).await?)
+        self.request(goose_request).await
     }
 
     /// A helper to make a `POST` request of json on a path and collect relevant metrics.
@@ -1316,7 +1316,7 @@ impl GooseUser {
             .build();
 
         // Make the request and return the GooseResponse.
-        Ok(self.request(goose_request).await?)
+        self.request(goose_request).await
     }
 
     /// A helper to make a `HEAD` request of a path and collect relevant metrics.
@@ -1352,7 +1352,7 @@ impl GooseUser {
             .build();
 
         // Make the request and return the GooseResponse.
-        Ok(self.request(goose_request).await?)
+        self.request(goose_request).await
     }
 
     /// A helper to make a `DELETE` request of a path and collect relevant metrics.
@@ -1388,7 +1388,7 @@ impl GooseUser {
             .build();
 
         // Make the request and return the GooseResponse.
-        Ok(self.request(goose_request).await?)
+        self.request(goose_request).await
     }
 
     /// Used to get a [`reqwest::RequestBuilder`] object. If no [`reqwest::RequestBuilder`] is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,13 +266,12 @@ pub enum AttackMode {
 pub enum AttackPhase {
     /// No load test is running, configuration can be changed by a Controller.
     Idle,
-    /// [`GooseUser`](./goose/struct.GooseUser.html)s are launching and beginning to generate
-    /// load.
-    Starting,
-    /// All [`GooseUser`](./goose/struct.GooseUser.html)s have launched and are generating load.
-    Running,
+    /// [`GooseUser`](./goose/struct.GooseUser.html)s are launching.
+    Increase,
+    /// [`GooseUser`](./goose/struct.GooseUser.html)s have been launched and are generating load.
+    Maintain,
     /// [`GooseUser`](./goose/struct.GooseUser.html)s are stopping.
-    Stopping,
+    Decrease,
     /// Exiting the load test.
     Shutdown,
 }
@@ -372,11 +371,9 @@ pub struct GooseAttack {
     /// Optional default values for Goose run-time options.
     defaults: GooseDefaults,
     /// Internal Goose test plan representation.
-    _test_plan: GooseTestPlan,
+    test_plan: GooseTestPlan,
     /// Configuration object holding options set when launching the load test.
     configuration: GooseConfiguration,
-    /// How long (in seconds) the load test should run.
-    run_time: usize,
     /// The load test operates in only one of the following modes: StandAlone, Manager, or Worker.
     attack_mode: AttackMode,
     /// Which phase the load test is currently operating in.
@@ -391,6 +388,7 @@ pub struct GooseAttack {
     /// All data for report graphs.
     graph_data: GraphData,
 }
+
 /// Goose's internal global state.
 impl GooseAttack {
     /// Load configuration and initialize a [`GooseAttack`](./struct.GooseAttack.html).
@@ -411,9 +409,8 @@ impl GooseAttack {
             weighted_gaggle_users: Vec::new(),
             defaults: GooseDefaults::default(),
             graph_data: GraphData::new(),
-            _test_plan: GooseTestPlan::from_configuration(&configuration),
+            test_plan: GooseTestPlan::new(),
             configuration,
-            run_time: 0,
             attack_mode: AttackMode::Undefined,
             attack_phase: AttackPhase::Idle,
             scheduler: GooseScheduler::RoundRobin,
@@ -447,9 +444,8 @@ impl GooseAttack {
             weighted_gaggle_users: Vec::new(),
             defaults: GooseDefaults::default(),
             graph_data: GraphData::new(),
-            _test_plan: GooseTestPlan::from_configuration(&configuration),
+            test_plan: GooseTestPlan::new(),
             configuration,
-            run_time: 0,
             attack_mode: AttackMode::Undefined,
             attack_phase: AttackPhase::Idle,
             scheduler: GooseScheduler::RoundRobin,
@@ -725,14 +721,14 @@ impl GooseAttack {
         weighted_task_sets
     }
 
-    /// Allocate a vector of weighted [`GooseUser`](./goose/struct.GooseUser.html)s.
+    /// Pre-allocate a vector of weighted [`GooseUser`](./goose/struct.GooseUser.html)s.
     fn weight_task_set_users(&mut self) -> Result<Vec<GooseUser>, GooseError> {
         trace!("weight_task_set_users");
 
         let weighted_task_sets = self.allocate_task_sets();
 
         // Allocate a state for each user that will be hatched.
-        info!("initializing user states...");
+        info!("initializing {} user states...", self.test_plan.max_users());
         let mut weighted_users = Vec::new();
         let mut user_count = 0;
         loop {
@@ -754,8 +750,7 @@ impl GooseAttack {
                     self.metrics.hash,
                 )?);
                 user_count += 1;
-                // Users are required here so unwrap() is safe.
-                if user_count >= self.configuration.users.unwrap() {
+                if user_count == self.test_plan.max_users() {
                     debug!("created {} weighted_users", user_count);
                     return Ok(weighted_users);
                 }
@@ -787,8 +782,7 @@ impl GooseAttack {
                     self.metrics.hash,
                 ));
                 user_count += 1;
-                // Users are required here so unwrap() is safe.
-                if user_count >= self.configuration.users.unwrap() {
+                if user_count == self.test_plan.max_users() {
                     debug!("prepared {} weighted_gaggle_users", user_count);
                     return Ok(weighted_users);
                 }
@@ -815,11 +809,6 @@ impl GooseAttack {
 
         // Update the current phase.
         self.attack_phase = phase;
-    }
-
-    fn set_run_time(&mut self) -> Result<(), GooseError> {
-        self.run_time = util::parse_timespan(&self.configuration.run_time);
-        Ok(())
     }
 
     // If enabled, returns the path of the report_file, otherwise returns None.
@@ -900,8 +889,8 @@ impl GooseAttack {
         // Validate GooseConfiguration.
         self.configuration.validate()?;
 
-        // Configure the validated run time.
-        self.set_run_time()?;
+        // Build GooseTestPlan.
+        self.test_plan = GooseTestPlan::build(&self.configuration);
 
         // With a validated GooseConfiguration, enter a run mode.
         self.attack_mode = if self.configuration.manager {
@@ -1307,27 +1296,30 @@ impl GooseAttack {
         Ok(goose_attack_run_state)
     }
 
-    // Spawn [`GooseUser`](./goose/struct.GooseUser.html) threads to generate a
-    // [`GooseAttack`](./struct.GooseAttack.html).
-    async fn spawn_attack(
+    // Increase the number of active [`GooseUser`](./goose/struct.GooseUser.html) threads in the
+    // active [`GooseAttack`](./struct.GooseAttack.html).
+    async fn increase_attack(
         &mut self,
         goose_attack_run_state: &mut GooseAttackRunState,
     ) -> Result<(), GooseError> {
-        // If `startup_time` has been configured, calculate the hatch_rate.
-        let hatch_rate = if self.configuration.startup_time != "0" {
-            if let Some(users) = self.configuration.users {
-                // Divide the number of users by the total time to start up to calculate the
-                // hatch rate.
-                users as f32 / util::parse_timespan(&self.configuration.startup_time) as f32
-            } else {
-                // Users have to be configured.
-                unreachable!();
-            }
-        // Otherwise either `hatch_rate` was configured or Goose will default to launching
-        // one GooseUser per second.
+        // If this is the first load plan step, then there were no previously started users.
+        let previous_users = if self.test_plan.step == 0 {
+            0
+        // Otherwise retreive the number of users configured in the previous step.
         } else {
-            util::get_hatch_rate(self.configuration.hatch_rate.clone())
+            self.test_plan.test_plan[self.test_plan.step - 1].0
         };
+
+        // Sanity check: increase_attack can only be called if the number of users is increasing
+        // in the current step.
+        debug_assert!(self.test_plan.test_plan[self.test_plan.step].0 > previous_users);
+
+        // Divide the number of new users to launch by the time configured to launch them.
+        let hatch_rate: f32 = (self.test_plan.test_plan[self.test_plan.step].0 - previous_users)
+            as f32
+            / self.test_plan.test_plan[self.test_plan.step].1 as f32
+            // Convert from milliseconds to seconds.
+            * 1_000.0;
 
         // Determine if it's time to spawn a GooseUser.
         if goose_attack_run_state.spawn_user_in_ms == 0
@@ -1443,10 +1435,13 @@ impl GooseAttack {
             }
 
             self.reset_metrics(goose_attack_run_state).await?;
-            self.set_attack_phase(goose_attack_run_state, AttackPhase::Running);
+            self.set_attack_phase(goose_attack_run_state, AttackPhase::Maintain);
             self.graph_data.set_started(Utc::now());
+            // Update start-time of this AttackPhase.
+            self.started = Some(time::Instant::now());
+            self.test_plan.step += 1;
             // Also record a formattable timestamp, for human readable reports.
-            self.metrics.started = Some(Local::now());
+            self.metrics.history.push(Local::now());
         }
 
         Ok(())
@@ -1458,11 +1453,39 @@ impl GooseAttack {
         &mut self,
         goose_attack_run_state: &mut GooseAttackRunState,
     ) -> Result<(), GooseError> {
-        // Exit if run_time timer expires.
-        if util::timer_expired(self.started.unwrap(), self.run_time) {
-            self.set_attack_phase(goose_attack_run_state, AttackPhase::Stopping);
+        // Determine if it's time to move to the next Test Plan Step
+        if util::ms_timer_expired(
+            self.started.unwrap(),
+            self.test_plan.test_plan[self.test_plan.step].1,
+        ) {
+            warn!("TIMER EXPIRED");
+            // @TODO: check if there's a next step, and what's changing
+
+            // Move on to the next step.
+            if self.test_plan.test_plan.len() > self.test_plan.step {
+                warn!("MOVE TO NEXT STEP");
+                println!("step: {}", self.test_plan.step);
+                println!(
+                    "next step: {:#?}",
+                    self.test_plan.test_plan[self.test_plan.step + 1]
+                );
+                std::process::exit(1);
+
+                // This was the last step.
+            } else {
+                panic!("STAY HERE FOREVER!");
+                // There is no shut down step, so move into AttackPhase::Maintain and run until canceled.
+                self.set_attack_phase(goose_attack_run_state, AttackPhase::Maintain);
+                // Move to a nonexistent Load Test Step, which leaves the load test running.
+                self.test_plan.step += 1;
+                // Store timestamp of when moved to this next step.
+                self.metrics.history.push(Local::now());
+            }
+            /*
+            self.set_attack_phase(goose_attack_run_state, AttackPhase::Decrease);
             self.metrics.stopping = Some(Local::now());
             self.graph_data.set_stopping(Utc::now());
+            */
         } else {
             // Subtract the time spent doing other things, running the main parent loop twice
             // per second.
@@ -1476,7 +1499,7 @@ impl GooseAttack {
         Ok(())
     }
 
-    async fn stop_running_users(
+    async fn decrease_attack(
         &mut self,
         goose_attack_run_state: &mut GooseAttackRunState,
     ) -> Result<(), GooseError> {
@@ -1682,31 +1705,30 @@ impl GooseAttack {
                     } else {
                         // Prepare to start the load test, resetting timers and counters.
                         self.reset_run_state(&mut goose_attack_run_state).await?;
-                        self.set_attack_phase(&mut goose_attack_run_state, AttackPhase::Starting);
-                        self.metrics.starting = Some(Local::now());
+                        self.metrics.history.push(Local::now());
                         self.graph_data.set_starting(Utc::now());
+                        self.set_attack_phase(&mut goose_attack_run_state, AttackPhase::Increase);
                     }
                 }
-                // In the Start phase, Goose launches GooseUser threads and starts a GooseAttack.
-                AttackPhase::Starting => {
+                // In the Increase phase, Goose launches GooseUser threads.
+                AttackPhase::Increase => {
                     self.update_duration();
-                    self.spawn_attack(&mut goose_attack_run_state)
+                    self.increase_attack(&mut goose_attack_run_state)
                         .await
-                        .expect("failed to start GooseAttack");
+                        .expect("failed to increase GooseAttack");
                 }
-                // In the Running phase, Goose maintains the configured GooseAttack.
-                AttackPhase::Running => {
+                // In the Maintain phase, Goose continues runnning all launched GooseUser threads.
+                AttackPhase::Maintain => {
                     self.update_duration();
                     self.monitor_attack(&mut goose_attack_run_state).await?;
                 }
-                // In the Stopping phase, Goose stops all GooseUser threads and optionally reports
-                // any collected metrics.
-                AttackPhase::Stopping => {
+                // In the Decrease phase, Goose stops GooseUser threads.
+                AttackPhase::Decrease => {
                     // If displaying metrics, update internal state reflecting how long load test
                     // has been running.
                     self.update_duration();
-                    // Tell all running GooseUsers to stop.
-                    self.stop_running_users(&mut goose_attack_run_state).await?;
+                    // Reduce the number of GooseUsers running.
+                    self.decrease_attack(&mut goose_attack_run_state).await?;
                     // Stop any running GooseUser threads.
                     self.stop_attack().await?;
                     // Collect all metrics sent by GooseUser threads.
@@ -1715,7 +1737,7 @@ impl GooseAttack {
                     self.graph_data
                         .record_users_per_second(self.metrics.users, Utc::now());
                     // The load test is fully stopped at this point.
-                    self.metrics.stopped = Some(Local::now());
+                    self.metrics.history.push(Local::now());
                     self.graph_data.set_stopped(Utc::now());
                     // Write an html report, if enabled.
                     self.write_html_report(&mut goose_attack_run_state).await?;
@@ -1759,8 +1781,8 @@ impl GooseAttack {
                 }
 
                 // Cleanly stop the load test.
-                self.set_attack_phase(&mut goose_attack_run_state, AttackPhase::Stopping);
-                self.metrics.stopping = Some(Local::now());
+                self.set_attack_phase(&mut goose_attack_run_state, AttackPhase::Decrease);
+                self.metrics.history.push(Local::now());
                 self.graph_data.set_stopping(Utc::now());
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,20 +43,20 @@ extern crate log;
 pub mod config;
 pub mod controller;
 pub mod goose;
-mod graph;
+//mod graph;
 pub mod logger;
 #[cfg(feature = "gaggle")]
 mod manager;
 pub mod metrics;
 pub mod prelude;
-mod report;
+//mod report;
 mod throttle;
 mod user;
 pub mod util;
 #[cfg(feature = "gaggle")]
 mod worker;
 
-use chrono::prelude::*;
+//use chrono::prelude::*;
 use gumdrop::Options;
 use lazy_static::lazy_static;
 #[cfg(feature = "gaggle")]
@@ -77,7 +77,7 @@ use tokio::fs::File;
 use crate::config::{GooseConfiguration, GooseDefaults, TestPlan};
 use crate::controller::{GooseControllerProtocol, GooseControllerRequest};
 use crate::goose::{GaggleUser, GooseTask, GooseTaskSet, GooseUser, GooseUserCommand};
-use crate::graph::GraphData;
+//use crate::graph::GraphData;
 use crate::logger::{GooseLoggerJoinHandle, GooseLoggerTx};
 use crate::metrics::{GooseMetric, GooseMetrics, TestPlanHistory, TestPlanStepAction};
 #[cfg(feature = "gaggle")]
@@ -387,8 +387,8 @@ pub struct GooseAttack {
     step_started: Option<time::Instant>,
     /// All metrics merged together.
     metrics: GooseMetrics,
-    /// All data for report graphs.
-    graph_data: GraphData,
+    // /// All data for report graphs.
+    //graph_data: GraphData,
 }
 
 /// Goose's internal global state.
@@ -410,7 +410,6 @@ impl GooseAttack {
             weighted_users: Vec::new(),
             weighted_gaggle_users: Vec::new(),
             defaults: GooseDefaults::default(),
-            graph_data: GraphData::new(),
             configuration,
             attack_mode: AttackMode::Undefined,
             attack_phase: AttackPhase::Idle,
@@ -419,6 +418,7 @@ impl GooseAttack {
             test_plan: TestPlan::new(),
             step_started: None,
             metrics: GooseMetrics::default(),
+            //graph_data: GraphData::new(),
         })
     }
 
@@ -446,7 +446,6 @@ impl GooseAttack {
             weighted_users: Vec::new(),
             weighted_gaggle_users: Vec::new(),
             defaults: GooseDefaults::default(),
-            graph_data: GraphData::new(),
             configuration,
             attack_mode: AttackMode::Undefined,
             attack_phase: AttackPhase::Idle,
@@ -455,6 +454,7 @@ impl GooseAttack {
             test_plan: TestPlan::new(),
             step_started: None,
             metrics: GooseMetrics::default(),
+            //graph_data: GraphData::new(),
         })
     }
 
@@ -1741,7 +1741,7 @@ impl GooseAttack {
                         self.metrics
                             .history
                             .push(TestPlanHistory::step(TestPlanStepAction::Increasing, 0));
-                        self.graph_data.set_starting(Utc::now());
+                        //self.graph_data.set_starting(Utc::now());
                         self.set_attack_phase(&mut goose_attack_run_state, AttackPhase::Increase);
                     }
                 }
@@ -1769,15 +1769,15 @@ impl GooseAttack {
                     // Collect all metrics sent by GooseUser threads.
                     self.sync_metrics(&mut goose_attack_run_state, true).await?;
                     // Record last users for users per second graph in HTML report.
-                    self.graph_data
-                        .record_users_per_second(self.metrics.users, Utc::now());
+                    //self.graph_data.record_users_per_second(self.metrics.users, Utc::now());
                     // The load test is fully stopped at this point.
                     self.metrics
                         .history
                         .push(TestPlanHistory::step(TestPlanStepAction::Finished, 0));
-                    self.graph_data.set_stopped(Utc::now());
+                    //self.graph_data.set_stopped(Utc::now());
                     // Write an html report, if enabled.
-                    self.write_html_report(&mut goose_attack_run_state).await?;
+                    // @TODO: Fixme!
+                    //self.write_html_report(&mut goose_attack_run_state).await?;
                     // Shutdown Goose or go into an idle waiting state.
                     if goose_attack_run_state.shutdown_after_stop {
                         self.set_attack_phase(&mut goose_attack_run_state, AttackPhase::Shutdown);
@@ -1794,8 +1794,7 @@ impl GooseAttack {
             }
 
             // Record current users for users per second graph in HTML report.
-            self.graph_data
-                .record_users_per_second(self.metrics.users, Utc::now());
+            //self.graph_data.record_users_per_second(self.metrics.users, Utc::now());
 
             // Regularly synchronize metrics.
             self.sync_metrics(&mut goose_attack_run_state, false)
@@ -1823,7 +1822,7 @@ impl GooseAttack {
                     TestPlanStepAction::Decreasing,
                     self.metrics.users,
                 ));
-                self.graph_data.set_stopping(Utc::now());
+                //self.graph_data.set_stopping(Utc::now());
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ use std::time::{self, Duration};
 use std::{fmt, io};
 use tokio::fs::File;
 
-use crate::config::{GooseConfiguration, GooseDefaults};
+use crate::config::{GooseConfiguration, GooseDefaults, GooseTestPlan};
 use crate::controller::{GooseControllerProtocol, GooseControllerRequest};
 use crate::goose::{GaggleUser, GooseTask, GooseTaskSet, GooseUser, GooseUserCommand};
 use crate::graph::GraphData;
@@ -371,6 +371,8 @@ pub struct GooseAttack {
     weighted_gaggle_users: Vec<GaggleUser>,
     /// Optional default values for Goose run-time options.
     defaults: GooseDefaults,
+    /// Internal Goose test plan representation.
+    _test_plan: GooseTestPlan,
     /// Configuration object holding options set when launching the load test.
     configuration: GooseConfiguration,
     /// How long (in seconds) the load test should run.
@@ -409,6 +411,7 @@ impl GooseAttack {
             weighted_gaggle_users: Vec::new(),
             defaults: GooseDefaults::default(),
             graph_data: GraphData::new(),
+            _test_plan: GooseTestPlan::from_configuration(&configuration),
             configuration,
             run_time: 0,
             attack_mode: AttackMode::Undefined,
@@ -444,6 +447,7 @@ impl GooseAttack {
             weighted_gaggle_users: Vec::new(),
             defaults: GooseDefaults::default(),
             graph_data: GraphData::new(),
+            _test_plan: GooseTestPlan::from_configuration(&configuration),
             configuration,
             run_time: 0,
             attack_mode: AttackMode::Undefined,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -7,7 +7,6 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time;
 
-use crate::config::TestPlan;
 use crate::metrics::{
     self, GooseErrorMetricAggregate, GooseErrorMetrics, GooseRequestMetricAggregate,
     GooseRequestMetrics, GooseTaskMetricAggregate, GooseTaskMetrics,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time;
 
+use crate::config::TestPlan;
 use crate::metrics::{
     self, GooseErrorMetricAggregate, GooseErrorMetrics, GooseRequestMetricAggregate,
     GooseRequestMetrics, GooseTaskMetricAggregate, GooseTaskMetrics,
@@ -27,8 +28,6 @@ pub struct GooseUserInitializer {
     pub base_url: String,
     /// A local copy of the global GooseConfiguration.
     pub config: GooseConfiguration,
-    /// How long the load test should run, in seconds.
-    pub run_time: usize,
     /// Numerical identifier for worker.
     pub worker_id: usize,
 }
@@ -288,8 +287,7 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
     let mut workers: HashSet<Pipe> = HashSet::new();
 
     // Track start time, we'll reset this when the test actually starts.
-    let mut started = time::Instant::now();
-    goose_attack.started = Some(started);
+    goose_attack.started = Some(time::Instant::now());
     let mut running_metrics_timer = time::Instant::now();
     let mut exit_timer = time::Instant::now();
     let mut load_test_running = false;
@@ -311,8 +309,13 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
 
     // Update metrics, which doesn't happen automatically on the Master as we don't
     // invoke start_attack. Hatch rate is required here so unwrap() is safe.
-    let hatch_rate = util::get_hatch_rate(goose_attack.configuration.hatch_rate.clone());
-    let maximum_hatched = hatch_rate * goose_attack.run_time as f32;
+    // Divide the number of new users to launch by the time configured to launch them.
+    let hatch_rate: f32 = (goose_attack.test_plan.steps[0].0)
+        as f32
+        / goose_attack.test_plan.steps[0].1 as f32
+        // Convert from milliseconds to seconds.
+        * 1_000.0;
+    let maximum_hatched = hatch_rate * goose_attack.test_plan.steps[1].1 as f32;
     if maximum_hatched < goose_attack.configuration.users.unwrap() as f32 {
         goose_attack.metrics.users = maximum_hatched as usize;
     } else {
@@ -329,7 +332,7 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                 if load_test_running {
                     info!(
                         "worker went away, stopping gracefully after {} seconds...",
-                        started.elapsed().as_secs()
+                        goose_attack.started.unwrap().elapsed().as_secs()
                     );
                     load_test_finished = true;
                     exit_timer = time::Instant::now();
@@ -344,10 +347,15 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
         if load_test_running {
             if !load_test_finished {
                 // Test ran to completion or was canceled with ctrl-c.
-                if util::timer_expired(started, goose_attack.run_time)
-                    || canceled.load(Ordering::SeqCst)
+                if util::ms_timer_expired(
+                    goose_attack.started.unwrap(),
+                    goose_attack.test_plan.steps[1].1,
+                ) || canceled.load(Ordering::SeqCst)
                 {
-                    info!("stopping after {} seconds...", started.elapsed().as_secs());
+                    info!(
+                        "stopping after {} seconds...",
+                        goose_attack.started.unwrap().elapsed().as_secs()
+                    );
                     goose_attack.metrics.duration =
                         goose_attack.started.unwrap().elapsed().as_secs() as usize;
                     load_test_finished = true;
@@ -470,7 +478,6 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                                 task_sets_index: user.task_sets_index,
                                 base_url: user.base_url.read().await.to_string(),
                                 config: user.config.clone(),
-                                run_time: goose_attack.run_time,
                                 worker_id: workers.len(),
                             });
                         }
@@ -501,8 +508,7 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                         {
                             info!("gaggle distributed load test started");
                             // Reset start time, the distributed load test is truly starting now.
-                            started = time::Instant::now();
-                            goose_attack.started = Some(started);
+                            goose_attack.started = Some(time::Instant::now());
                             running_metrics_timer = time::Instant::now();
                             load_test_running = true;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1022,32 +1022,34 @@ impl GooseMetrics {
             let fails_precision = determine_precision(fails);
             // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
             if fail_percent as usize == 100 || fail_percent as usize == 0 {
+                let fail_and_percent = format!(
+                    "{} ({}%)",
+                    request.fail_count.to_formatted_string(&Locale::en),
+                    fail_percent as usize
+                );
                 writeln!(
                     fmt,
                     " {:<24} | {:>13} | {:>14} | {:>8.reqs_p$} | {:>7.fails_p$}",
                     util::truncate_string(request_key, 24),
                     total_count.to_formatted_string(&Locale::en),
-                    format!(
-                        "{} ({}%)",
-                        request.fail_count.to_formatted_string(&Locale::en),
-                        fail_percent as usize
-                    ),
+                    fail_and_percent,
                     reqs,
                     fails,
                     reqs_p = reqs_precision,
                     fails_p = fails_precision,
                 )?;
             } else {
+                let fail_and_percent = format!(
+                    "{} ({:.1}%)",
+                    request.fail_count.to_formatted_string(&Locale::en),
+                    fail_percent
+                );
                 writeln!(
                     fmt,
                     " {:<24} | {:>13} | {:>14} | {:>8.reqs_p$} | {:>7.fails_p$}",
                     util::truncate_string(request_key, 24),
                     total_count.to_formatted_string(&Locale::en),
-                    format!(
-                        "{} ({:.1}%)",
-                        request.fail_count.to_formatted_string(&Locale::en),
-                        fail_percent
-                    ),
+                    fail_and_percent,
                     reqs,
                     fails,
                     reqs_p = reqs_precision,
@@ -1073,32 +1075,34 @@ impl GooseMetrics {
             let fails_precision = determine_precision(fails);
             // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
             if aggregate_fail_percent as usize == 100 || aggregate_fail_percent as usize == 0 {
+                let fail_and_percent = format!(
+                    "{} ({}%)",
+                    aggregate_fail_count.to_formatted_string(&Locale::en),
+                    aggregate_fail_percent as usize
+                );
                 writeln!(
                     fmt,
                     " {:<24} | {:>13} | {:>14} | {:>8.reqs_p$} | {:>7.fails_p$}",
                     "Aggregated",
                     aggregate_total_count.to_formatted_string(&Locale::en),
-                    format!(
-                        "{} ({}%)",
-                        aggregate_fail_count.to_formatted_string(&Locale::en),
-                        aggregate_fail_percent as usize
-                    ),
+                    fail_and_percent,
                     reqs,
                     fails,
                     reqs_p = reqs_precision,
                     fails_p = fails_precision,
                 )?;
             } else {
+                let fail_and_percent = format!(
+                    "{} ({:.1}%)",
+                    aggregate_fail_count.to_formatted_string(&Locale::en),
+                    aggregate_fail_percent
+                );
                 writeln!(
                     fmt,
                     " {:<24} | {:>13} | {:>14} | {:>8.reqs_p$} | {:>7.fails_p$}",
                     "Aggregated",
                     aggregate_total_count.to_formatted_string(&Locale::en),
-                    format!(
-                        "{} ({:.1}%)",
-                        aggregate_fail_count.to_formatted_string(&Locale::en),
-                        aggregate_fail_percent
-                    ),
+                    fail_and_percent,
                     reqs,
                     fails,
                     reqs_p = reqs_precision,
@@ -1166,6 +1170,11 @@ impl GooseMetrics {
                 }
 
                 if fail_percent as usize == 100 || fail_percent as usize == 0 {
+                    let fail_and_percent = format!(
+                        "{} ({}%)",
+                        task.fail_count.to_formatted_string(&Locale::en),
+                        fail_percent as usize
+                    );
                     writeln!(
                         fmt,
                         " {:<24} | {:>13} | {:>14} | {:>8.runs_p$} | {:>7.fails_p$}",
@@ -1174,17 +1183,18 @@ impl GooseMetrics {
                             24
                         ),
                         total_count.to_formatted_string(&Locale::en),
-                        format!(
-                            "{} ({}%)",
-                            task.fail_count.to_formatted_string(&Locale::en),
-                            fail_percent as usize
-                        ),
+                        fail_and_percent,
                         runs,
                         fails,
                         runs_p = runs_precision,
                         fails_p = fails_precision,
                     )?;
                 } else {
+                    let fail_and_percent = format!(
+                        "{} ({:.1}%)",
+                        task.fail_count.to_formatted_string(&Locale::en),
+                        fail_percent
+                    );
                     writeln!(
                         fmt,
                         " {:<24} | {:>13} | {:>14} | {:>8.runs_p$} | {:>7.fails_p$}",
@@ -1193,11 +1203,7 @@ impl GooseMetrics {
                             24
                         ),
                         total_count.to_formatted_string(&Locale::en),
-                        format!(
-                            "{} ({:.1}%)",
-                            task.fail_count.to_formatted_string(&Locale::en),
-                            fail_percent
-                        ),
+                        fail_and_percent,
                         runs,
                         fails,
                         runs_p = runs_precision,
@@ -1225,32 +1231,34 @@ impl GooseMetrics {
 
             // Compress 100.0 and 0.0 to 100 and 0 respectively to save width.
             if aggregate_fail_percent as usize == 100 || aggregate_fail_percent as usize == 0 {
+                let fail_and_percent = format!(
+                    "{} ({}%)",
+                    aggregate_fail_count.to_formatted_string(&Locale::en),
+                    aggregate_fail_percent as usize
+                );
                 writeln!(
                     fmt,
                     " {:<24} | {:>13} | {:>14} | {:>8.runs_p$} | {:>7.fails_p$}",
                     "Aggregated",
                     aggregate_total_count.to_formatted_string(&Locale::en),
-                    format!(
-                        "{} ({}%)",
-                        aggregate_fail_count.to_formatted_string(&Locale::en),
-                        aggregate_fail_percent as usize
-                    ),
+                    fail_and_percent,
                     runs,
                     fails,
                     runs_p = runs_precision,
                     fails_p = fails_precision,
                 )?;
             } else {
+                let fail_and_percent = format!(
+                    "{} ({:.1}%)",
+                    aggregate_fail_count.to_formatted_string(&Locale::en),
+                    aggregate_fail_percent
+                );
                 writeln!(
                     fmt,
                     " {:<24} | {:>13} | {:>14} | {:>8.runs_p$} | {:>7.fails_p$}",
                     "Aggregated",
                     aggregate_total_count.to_formatted_string(&Locale::en),
-                    format!(
-                        "{} ({:.1}%)",
-                        aggregate_fail_count.to_formatted_string(&Locale::en),
-                        aggregate_fail_percent
-                    ),
+                    fail_and_percent,
                     runs,
                     fails,
                     runs_p = runs_precision,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2314,7 +2314,7 @@ impl GooseAttack {
             self.sync_metrics(goose_attack_run_state, true).await?;
 
             goose_attack_run_state.all_users_spawned = true;
-            // @TODO: reset only makes sense if not using `--test-plan`
+            // Only reset metrics on startup if not using `--test-plan`.
             if self.configuration.test_plan.is_none() {
                 let users = self.configuration.users.unwrap();
                 if !self.configuration.no_reset_metrics {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2070,8 +2070,8 @@ impl GooseMetrics {
 
         writeln!(
             fmt,
-            " {:<12} {:<19} {:<17} {:<10} {}",
-            "Action", "Started", "Stopped", "Elapsed", "Users"
+            " {:<12} {:<19} {:<17} {:<10} Users",
+            "Action", "Started", "Stopped", "Elapsed",
         )?;
         writeln!(
             fmt,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -8,7 +8,6 @@
 //! contained [`GooseTaskMetrics`], [`GooseRequestMetrics`], and
 //! [`GooseErrorMetrics`] are displayed in tables.
 
-use chrono::prelude::*;
 use http::StatusCode;
 use itertools::Itertools;
 use num_format::{Locale, ToFormattedString};
@@ -25,6 +24,7 @@ use crate::config::GooseDefaults;
 use crate::goose::{get_base_url, GooseMethod, GooseTaskSet};
 use crate::logger::GooseLog;
 //use crate::report;
+use crate::test_plan::{TestPlanHistory, TestPlanStepAction};
 use crate::util;
 #[cfg(feature = "gaggle")]
 use crate::worker::{self, GaggleMetrics};
@@ -730,41 +730,6 @@ impl GooseTaskMetricAggregate {
         debug!("incremented {} counter: {}", rounded_time, counter);
     }
 }
-
-/// A test plan is a series of steps performing one of the following actions.
-#[derive(Clone, Debug)]
-pub enum TestPlanStepAction {
-    /// A test plan step that is increasing the number of GooseUser threads.
-    Increasing,
-    /// A test plan step that is maintaining the number of GooseUser threads.
-    Maintaining,
-    /// A test plan step that is increasing the number of GooseUser threads.
-    Decreasing,
-    /// The final step indicating that the load test is finished.
-    Finished,
-}
-
-/// A historical record of a single test plan step, used to generate reports from the metrics.
-#[derive(Clone, Debug)]
-pub struct TestPlanHistory {
-    /// What action happend in this step.
-    pub action: TestPlanStepAction,
-    /// A timestamp of when the step started.
-    pub timestamp: DateTime<Utc>,
-    /// The number of users when the step started.
-    pub users: usize,
-}
-impl TestPlanHistory {
-    /// A helper to record a new test plan step in the historical record.
-    pub(crate) fn step(action: TestPlanStepAction, users: usize) -> TestPlanHistory {
-        TestPlanHistory {
-            action,
-            timestamp: Utc::now(),
-            users,
-        }
-    }
-}
-
 /// All metrics optionally collected during a Goose load test.
 ///
 /// By default, Goose collects metrics during a load test in a `GooseMetrics` object

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -19,12 +19,12 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::str::FromStr;
 use std::{f32, fmt};
-use tokio::io::AsyncWriteExt;
+//use tokio::io::AsyncWriteExt;
 
 use crate::config::GooseDefaults;
 use crate::goose::{get_base_url, GooseMethod, GooseTaskSet};
 use crate::logger::GooseLog;
-use crate::report;
+//use crate::report;
 use crate::util;
 #[cfg(feature = "gaggle")]
 use crate::worker::{self, GaggleMetrics};
@@ -2518,6 +2518,7 @@ impl GooseAttack {
                         // `GooseMetrics.requests`, and write to the requests log if enabled.
                         self.record_request_metric(&request_metric).await;
 
+                        /* @FIXME
                         if !self.configuration.report_file.is_empty() {
                             let seconds_since_start = (request_metric.elapsed / 1000) as usize;
 
@@ -2533,6 +2534,7 @@ impl GooseAttack {
                                     .record_errors_per_second(seconds_since_start);
                             }
                         }
+                         */
                     }
                 }
                 GooseMetric::Task(raw_task) => {
@@ -2540,10 +2542,12 @@ impl GooseAttack {
                     self.metrics.tasks[raw_task.taskset_index][raw_task.task_index]
                         .set_time(raw_task.run_time, raw_task.success);
 
+                    /* @FIXME
                     if !self.configuration.report_file.is_empty() {
                         self.graph_data
                             .record_tasks_per_second((raw_task.elapsed / 1000) as usize);
                     }
+                    */
                 }
             }
             // Unless flushing all metrics, break out of receive loop after timeout.
@@ -2616,12 +2620,12 @@ impl GooseAttack {
         };
     }
 
+    /* @FIXME:
     // Write an HTML-formatted report, if enabled.
     pub(crate) async fn write_html_report(
         &mut self,
         goose_attack_run_state: &mut GooseAttackRunState,
     ) -> Result<(), GooseError> {
-        /* @FIXME:
         // Only write the report if enabled.
         if let Some(report_file) = goose_attack_run_state.report_file.as_mut() {
             // Prepare report summary variables.
@@ -3108,10 +3112,10 @@ impl GooseAttack {
                 self.get_report_file_path().unwrap()
             );
         }
-        */
 
         Ok(())
     }
+    */
 }
 
 /// Helper to calculate requests and fails per seconds.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2552,11 +2552,11 @@ impl GooseAttack {
 
     // Update metrics showing how long the load test has been running.
     pub(crate) fn update_duration(&mut self) {
-        if let Some(started) = self.started {
-            self.metrics.duration = started.elapsed().as_secs() as usize;
+        self.metrics.duration = if self.started.is_some() {
+            self.started.unwrap().elapsed().as_secs() as usize
         } else {
-            self.metrics.duration = 0;
-        }
+            0
+        };
     }
 
     // Write an HTML-formatted report, if enabled.

--- a/src/test_plan.rs
+++ b/src/test_plan.rs
@@ -1,0 +1,223 @@
+//! Test plan structures and functions.
+//!
+//! Internally, Goose represents all load tests as a series of Test Plan steps.
+
+use chrono::prelude::*;
+use gumdrop::Options;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::str::FromStr;
+use std::time;
+
+use crate::config::GooseConfiguration;
+use crate::util;
+use crate::{AttackPhase, GooseAttack, GooseAttackRunState, GooseError};
+
+/// Internal data structure representing a test plan.
+//#[derive(Options, Debug, Clone, Serialize, Deserialize)]
+#[derive(Options, Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct TestPlan {
+    // A test plan is a vector of tuples each indicating a # of users and milliseconds.
+    pub(crate) steps: Vec<(usize, usize)>,
+    // Which step of the test_plan is currently running.
+    pub(crate) current: usize,
+}
+
+/// Automatically represent all load tests internally as a test plan.
+///
+/// Load tests launched using `--users`, `--startup-time`, `--hatch-rate`, and/or `--run-time` are
+/// automatically converted to a `Vec<(usize, usize)>` test plan.
+impl TestPlan {
+    /// Create a new, empty TestPlan structure.
+    pub(crate) fn new() -> TestPlan {
+        TestPlan {
+            steps: Vec::new(),
+            current: 0,
+        }
+    }
+
+    /// Build a test plan from current configuration.
+    pub(crate) fn build(configuration: &GooseConfiguration) -> TestPlan {
+        if let Some(test_plan) = configuration.test_plan.as_ref() {
+            // Test plan was manually defined, clone and return as is.
+            test_plan.clone()
+        } else {
+            let mut steps: Vec<(usize, usize)> = Vec::new();
+
+            // Build a simple test plan from configured options if possible.
+            if let Some(users) = configuration.users {
+                if configuration.startup_time != "0" {
+                    // Load test is configured with --startup-time.
+                    steps.push((
+                        users,
+                        util::parse_timespan(&configuration.startup_time) * 1_000,
+                    ));
+                } else {
+                    // Load test is configured with --hatch-rate.
+                    let hatch_rate = if let Some(hatch_rate) = configuration.hatch_rate.as_ref() {
+                        util::get_hatch_rate(Some(hatch_rate.to_string()))
+                    } else {
+                        util::get_hatch_rate(None)
+                    };
+                    // Convert hatch_rate to milliseconds.
+                    let ms_hatch_rate = 1.0 / hatch_rate * 1_000.0;
+                    // Finally, multiply the hatch rate by the number of users to hatch.
+                    let total_time = ms_hatch_rate * users as f32;
+                    steps.push((users, total_time as usize));
+                }
+
+                // A run-time is set, configure the load plan to run for the specified time then shut down.
+                if configuration.run_time != "0" {
+                    // Maintain the configured number of users for the configured run-time.
+                    steps.push((users, util::parse_timespan(&configuration.run_time) * 1_000));
+                    // Then shut down the load test as quickly as possible.
+                    steps.push((0, 0));
+                }
+            }
+
+            // Define test plan from options.
+            TestPlan { steps, current: 0 }
+        }
+    }
+
+    // Determine the maximum number of users configured during the test plan.
+    pub(crate) fn max_users(&self) -> usize {
+        let mut max_users = 0;
+        for step in &self.steps {
+            if step.0 > max_users {
+                max_users = step.0;
+            }
+        }
+        max_users
+    }
+}
+
+/// Implement [`FromStr`] to convert `"users,timespan"` string formatted test plans to Goose's
+/// internal representation of Vec<(usize, usize)>.
+///
+/// Users are represented simply as an integer.
+///
+/// Time span can be specified as an integer, indicating seconds. Or can use integers together
+/// with one or more of "h", "m", and "s", in that order, indicating "hours", "minutes", and
+/// "seconds". Valid formats include: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.
+impl FromStr for TestPlan {
+    type Err = GooseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Convert string into a TestPlan.
+        let mut steps: Vec<(usize, usize)> = Vec::new();
+        // Each line of the test plan must be in the format "{users},{timespan}", white space is ignored
+        let re = Regex::new(r"^\s*(\d+)\s*,\s*(\d+|((\d+?)h)?((\d+?)m)?((\d+?)s)?)\s*$").unwrap();
+        // A test plan can have multiple lines split by the semicolon ";".
+        let lines = s.split(';');
+        for line in lines {
+            if let Some(cap) = re.captures(line) {
+                let left = cap[1]
+                    .parse::<usize>()
+                    .expect("failed to convert \\d to usize");
+                let right = util::parse_timespan(&cap[2]) * 1_000;
+                steps.push((left, right));
+            } else {
+                // Logger isn't initialized yet, provide helpful debug output.
+                eprintln!("ERROR: invalid `configuration.test_plan` value: '{}'", line);
+                eprintln!("  Expected format: --test-plan \"{{users}},{{timespan}};{{users}},{{timespan}}\"");
+                eprintln!("    {{users}} must be an integer, ie \"100\"");
+                eprintln!("    {{timespan}} can be integer seconds or \"30s\", \"20m\", \"3h\", \"1h30m\", etc");
+                return Err(GooseError::InvalidOption {
+                    option: "`configuration.test_plan".to_string(),
+                    value: line.to_string(),
+                    detail: "invalid `configuration.test_plan` value.".to_string(),
+                });
+            }
+        }
+        // The steps are only valid if the logic gets this far.
+        Ok(TestPlan { steps, current: 0 })
+    }
+}
+
+/// A test plan is a series of steps performing one of the following actions.
+#[derive(Clone, Debug)]
+pub enum TestPlanStepAction {
+    /// A test plan step that is increasing the number of GooseUser threads.
+    Increasing,
+    /// A test plan step that is maintaining the number of GooseUser threads.
+    Maintaining,
+    /// A test plan step that is increasing the number of GooseUser threads.
+    Decreasing,
+    /// The final step indicating that the load test is finished.
+    Finished,
+}
+
+/// A historical record of a single test plan step, used to generate reports from the metrics.
+#[derive(Clone, Debug)]
+pub struct TestPlanHistory {
+    /// What action happend in this step.
+    pub action: TestPlanStepAction,
+    /// A timestamp of when the step started.
+    pub timestamp: DateTime<Utc>,
+    /// The number of users when the step started.
+    pub users: usize,
+}
+impl TestPlanHistory {
+    /// A helper to record a new test plan step in the historical record.
+    pub(crate) fn step(action: TestPlanStepAction, users: usize) -> TestPlanHistory {
+        TestPlanHistory {
+            action,
+            timestamp: Utc::now(),
+            users,
+        }
+    }
+}
+
+impl GooseAttack {
+    // Advance the active [`GooseAttack`](./struct.GooseAttack.html) to the next TestPlan step.
+    pub(crate) fn advance_test_plan(&mut self, goose_attack_run_state: &mut GooseAttackRunState) {
+        // Record the instant this new step starts, for use with timers.
+        self.step_started = Some(time::Instant::now());
+
+        let action = if self.test_plan.current == self.test_plan.steps.len() - 1 {
+            // If this is the last TestPlan step and there are 0 users, shut down.
+            if self.test_plan.steps[self.test_plan.current].0 == 0 {
+                // @TODO: don't shut down if stopped by a controller...
+                self.set_attack_phase(goose_attack_run_state, AttackPhase::Shutdown);
+                TestPlanStepAction::Finished
+            }
+            // Otherwise maintain the number of GooseUser threads until canceled.
+            else {
+                self.set_attack_phase(goose_attack_run_state, AttackPhase::Maintain);
+                TestPlanStepAction::Maintaining
+            }
+        // If this is not the last TestPlan step, determine what happens next.
+        } else if self.test_plan.current < self.test_plan.steps.len() {
+            match self.test_plan.steps[self.test_plan.current]
+                .0
+                .cmp(&self.test_plan.steps[self.test_plan.current + 1].0)
+            {
+                Ordering::Less => {
+                    self.set_attack_phase(goose_attack_run_state, AttackPhase::Increase);
+                    TestPlanStepAction::Increasing
+                }
+                Ordering::Greater => {
+                    self.set_attack_phase(goose_attack_run_state, AttackPhase::Decrease);
+                    TestPlanStepAction::Decreasing
+                }
+                Ordering::Equal => {
+                    self.set_attack_phase(goose_attack_run_state, AttackPhase::Maintain);
+                    TestPlanStepAction::Maintaining
+                }
+            }
+        } else {
+            unreachable!("Advanced 2 steps beyond the end of the TestPlan.")
+        };
+
+        // Record details about new new TestPlan step that is starting.
+        self.metrics.history.push(TestPlanHistory::step(
+            action,
+            self.test_plan.steps[self.test_plan.current].0,
+        ));
+
+        // Always advance the TestPlan step
+        self.test_plan.current += 1;
+    }
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -8,10 +8,10 @@ use url::Url;
 
 const EMPTY_ARGS: Vec<&str> = vec![];
 
-use crate::config::TestPlan;
 use crate::goose::{GooseUser, GooseUserCommand};
 use crate::manager::GooseUserInitializer;
 use crate::metrics::{GooseErrorMetrics, GooseRequestMetrics, GooseTaskMetrics};
+use crate::test_plan::TestPlan;
 use crate::{get_worker_id, AttackMode, GooseAttack, GooseConfiguration, WORKER_ID};
 
 /// Workers send GaggleMetrics to the Manager process to be aggregated together.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -8,6 +8,7 @@ use url::Url;
 
 const EMPTY_ARGS: Vec<&str> = vec![];
 
+use crate::config::TestPlan;
 use crate::goose::{GooseUser, GooseUserCommand};
 use crate::manager::GooseUserInitializer;
 use crate::metrics::{GooseErrorMetrics, GooseRequestMetrics, GooseTaskMetrics};
@@ -100,7 +101,6 @@ pub(crate) async fn worker_main(goose_attack: GooseAttack) -> GooseAttack {
     let mut config: GooseConfiguration = GooseConfiguration::parse_args_default(&EMPTY_ARGS)
         .expect("failed to generate default configuration");
     let mut weighted_users: Vec<GooseUser> = Vec::new();
-    let mut run_time: usize = 0;
 
     // Wait for the manager to send user parameters.
     info!("waiting for instructions from manager");
@@ -145,11 +145,9 @@ pub(crate) async fn worker_main(goose_attack: GooseAttack) -> GooseAttack {
         .map_err(|error| eprintln!("{:?} worker_id({})", error, get_worker_id()))
         .expect("failed to create socket");
 
-        // The initializer.config and run_time are the same for all users, only copy it
-        // one time.
+        // The initializer.config is the same for all users, only copy it one time.
         if weighted_users.is_empty() {
             config = initializer.config;
-            run_time = initializer.run_time;
         }
         weighted_users.push(user);
     }
@@ -214,8 +212,6 @@ pub(crate) async fn worker_main(goose_attack: GooseAttack) -> GooseAttack {
 
     worker_goose_attack.started = Some(time::Instant::now());
     worker_goose_attack.task_sets = goose_attack.task_sets.clone();
-    // Use the run_time from the Manager so Worker can shut down in a timely manner.
-    worker_goose_attack.run_time = run_time;
     worker_goose_attack.weighted_users = weighted_users;
     // This is a Worker instance, not a Manager instance.
     worker_goose_attack.configuration.manager = false;
@@ -245,6 +241,7 @@ pub(crate) async fn worker_main(goose_attack: GooseAttack) -> GooseAttack {
         goose_attack.configuration.throttle_requests;
     worker_goose_attack.attack_mode = AttackMode::Worker;
     worker_goose_attack.defaults = goose_attack.defaults.clone();
+    worker_goose_attack.test_plan = TestPlan::build(&worker_goose_attack.configuration);
 
     worker_goose_attack
         .start_attack(Some(manager))


### PR DESCRIPTION
 - introduce `--test-plan` and `GooseDefault::TestPlan` for configuring test plans
 - closes https://github.com/tag1consulting/goose/issues/365
 - use [`FromStr`] to auto convert `--test-plan "{users},{timespan};{users},{timespan}"`, where `{users}` must be an integer, ie "100", and `{timespan}` can be integer seconds or "30s", "20m", "3h", "1h30m", etc, to internal `Vec<(usize, usize)>` representation
 - don't allow `--test-plan` together with `--users`, `--startup-time`, `--hatch-rate` or `--run-time`
 - add page to https://book.goose.rs/ explaining how to configure test plans

### From the new book page:
> The following command tells Goose to start 10 users over 60 seconds and then to run for 5 minutes before shutting down:
> ```bash
> $ cargo run --release -- -H http://local.dev/ --startup-time 1m --users 10 --run-time 5m
> ```
>
> The exact same behavior can be defined with the following test plan:
> ```bash
> $ cargo run --release -- -H http://local.dev/ --test-plan "10,1m;10,5m;0,0"
> ```
>
> Another possibility when specifying a test plan is to add load spikes into otherwise steady load. For example, in the  following example Goose starts 500 users over 5 minutes and lets it run with a couple of traffic spikes to 2,500 users:
> ```bash
> $ cargo run --release -- -H http://local.dev/ --test-plan "500,5m;500,5m;2500,45;500,45;500,5m;2500,45;500,45;500,5m;0,0"
> ```

In the current implementation, a test plan can only Increase and Maintain, the load test will shut down any time it defines a Decrease. This will be resolved in a followup.

An example run:
```bash
% cargo run --release --example drupal_memcache -- --host http://apache.fosciana/ --test-plan "10,5;20,5;30,5;30,5;60,10;60,2;0,0"
```

Includes the follow overview in the metrics:
```
 === OVERVIEW ===
 ------------------------------------------------------------------------------
 Action       Started             Stopped           Elapsed    Users
 ------------------------------------------------------------------------------
 Increasing:  22-04-18 07:07:06 - 22-04-18 07:07:11 (00:00:05, 0 -> 10)
 Increasing:  22-04-18 07:07:11 - 22-04-18 07:07:17 (00:00:06, 10 -> 20)
 Increasing:  22-04-18 07:07:17 - 22-04-18 07:07:22 (00:00:05, 20 -> 30)
 Maintaining: 22-04-18 07:07:22 - 22-04-18 07:07:27 (00:00:05, 30)
 Increasing:  22-04-18 07:07:27 - 22-04-18 07:07:40 (00:00:13, 30 -> 60)
 Maintaining: 22-04-18 07:07:40 - 22-04-18 07:07:42 (00:00:02, 60)
 Decreasing:  22-04-18 07:07:42 - 22-04-18 07:07:42 (00:00:00, 0 <- 60)

 Target host: http://apache.fosciana/
 goose v0.16.0-dev
 ------------------------------------------------------------------------------
```