### PR TITLE
#440: Re-enable HTML report after introduction of test plans.

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -254,7 +254,7 @@ impl<'a, T: Clone + TimeSeriesValue<T, U>, U: Serialize + Copy + PartialEq + Par
                         r#"[
                             {{
                                 xAxis: '{started}',
-                                itemStyle: {{ borderColor: 'rgba(44, 102, 79, 1)', borderWidth: 1 }},
+                                itemStyle: {{ borderColor: 'rgba(44, 102, 79, 0.25)', borderWidth: 1 }},
                             }},
                             {{
                                 xAxis: '{started}'
@@ -263,7 +263,7 @@ impl<'a, T: Clone + TimeSeriesValue<T, U>, U: Serialize + Copy + PartialEq + Par
                         [
                             {{
                                 xAxis: '{started}',
-                                itemStyle: {{ color: 'rgba(44, 102, 79, 0.25)' }},
+                                itemStyle: {{ color: 'rgba(44, 102, 79, 0.05)' }},
                             }},
                             {{
                                 xAxis: '{stopped}'
@@ -272,7 +272,7 @@ impl<'a, T: Clone + TimeSeriesValue<T, U>, U: Serialize + Copy + PartialEq + Par
                         [
                             {{
                                 xAxis: '{stopped}',
-                                itemStyle: {{ borderColor: 'rgba(44, 102, 79, 1)', borderWidth: 1 }},
+                                itemStyle: {{ borderColor: 'rgba(44, 102, 79, 0.25)', borderWidth: 1 }},
                             }},
                             {{
                                 xAxis: '{stopped}'
@@ -288,7 +288,7 @@ impl<'a, T: Clone + TimeSeriesValue<T, U>, U: Serialize + Copy + PartialEq + Par
                         r#"[
                             {{
                                 xAxis: '{started}',
-                                itemStyle: {{ borderColor: 'rgba(179, 65, 65, 1)', borderWidth: 1 }},
+                                itemStyle: {{ borderColor: 'rgba(179, 65, 65, 0.25)', borderWidth: 1 }},
                             }},
                             {{
                                 xAxis: '{started}'
@@ -297,7 +297,7 @@ impl<'a, T: Clone + TimeSeriesValue<T, U>, U: Serialize + Copy + PartialEq + Par
                         [
                             {{
                                 xAxis: '{started}',
-                                itemStyle: {{ color: 'rgba(179, 65, 65, 0.25)' }},
+                                itemStyle: {{ color: 'rgba(179, 65, 65, 0.05)' }},
                             }},
                             {{
                                 xAxis: '{stopped}'
@@ -306,7 +306,7 @@ impl<'a, T: Clone + TimeSeriesValue<T, U>, U: Serialize + Copy + PartialEq + Par
                         [
                             {{
                                 xAxis: '{stopped}',
-                                itemStyle: {{ borderColor: 'rgba(179, 65, 65, 1)', borderWidth: 1 }},
+                                itemStyle: {{ borderColor: 'rgba(179, 65, 65, 0.25)', borderWidth: 1 }},
                             }},
                             {{
                                 xAxis: '{stopped}'
@@ -1619,7 +1619,7 @@ mod test {
                                         [
                             {{
                                 xAxis: '{increasing}',
-                                itemStyle: {{ borderColor: 'rgba(44, 102, 79, 1)', borderWidth: 1 }},
+                                itemStyle: {{ borderColor: 'rgba(44, 102, 79, 0.25)', borderWidth: 1 }},
                             }},
                             {{
                                 xAxis: '{increasing}'
@@ -1628,7 +1628,7 @@ mod test {
                         [
                             {{
                                 xAxis: '{increasing}',
-                                itemStyle: {{ color: 'rgba(44, 102, 79, 0.25)' }},
+                                itemStyle: {{ color: 'rgba(44, 102, 79, 0.05)' }},
                             }},
                             {{
                                 xAxis: '{decreasing}'
@@ -1637,7 +1637,7 @@ mod test {
                         [
                             {{
                                 xAxis: '{decreasing}',
-                                itemStyle: {{ borderColor: 'rgba(44, 102, 79, 1)', borderWidth: 1 }},
+                                itemStyle: {{ borderColor: 'rgba(44, 102, 79, 0.25)', borderWidth: 1 }},
                             }},
                             {{
                                 xAxis: '{decreasing}'
@@ -1645,7 +1645,7 @@ mod test {
                         ],[
                             {{
                                 xAxis: '{decreasing}',
-                                itemStyle: {{ borderColor: 'rgba(179, 65, 65, 1)', borderWidth: 1 }},
+                                itemStyle: {{ borderColor: 'rgba(179, 65, 65, 0.25)', borderWidth: 1 }},
                             }},
                             {{
                                 xAxis: '{decreasing}'
@@ -1654,7 +1654,7 @@ mod test {
                         [
                             {{
                                 xAxis: '{decreasing}',
-                                itemStyle: {{ color: 'rgba(179, 65, 65, 0.25)' }},
+                                itemStyle: {{ color: 'rgba(179, 65, 65, 0.05)' }},
                             }},
                             {{
                                 xAxis: '{finishing}'
@@ -1663,7 +1663,7 @@ mod test {
                         [
                             {{
                                 xAxis: '{finishing}',
-                                itemStyle: {{ borderColor: 'rgba(179, 65, 65, 1)', borderWidth: 1 }},
+                                itemStyle: {{ borderColor: 'rgba(179, 65, 65, 0.25)', borderWidth: 1 }},
                             }},
                             {{
                                 xAxis: '{finishing}'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1742,7 +1742,6 @@ impl GooseAttack {
                     self.metrics
                         .history
                         .push(TestPlanHistory::step(TestPlanStepAction::Finished, 0));
-                    //self.graph_data.set_stopped(Utc::now());
                     // Write an html report, if enabled.
                     self.write_html_report(&mut goose_attack_run_state).await?;
                     // Shutdown Goose or go into an idle waiting state.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,6 @@ pub mod util;
 #[cfg(feature = "gaggle")]
 mod worker;
 
-//use chrono::prelude::*;
 use gumdrop::Options;
 use lazy_static::lazy_static;
 #[cfg(feature = "gaggle")]
@@ -84,7 +83,6 @@ use crate::metrics::{GooseMetric, GooseMetrics};
 use crate::test_plan::{TestPlan, TestPlanHistory, TestPlanStepAction};
 #[cfg(feature = "gaggle")]
 use crate::worker::{register_shutdown_pipe_handler, GaggleMetrics};
-use chrono::prelude::*;
 
 /// Constant defining Goose's default telnet Controller port.
 const DEFAULT_TELNET_PORT: &str = "5116";
@@ -1663,7 +1661,6 @@ impl GooseAttack {
 
         // Record when the GooseAttack officially started.
         self.started = Some(time::Instant::now());
-        self.graph_data.set_started(Utc::now());
 
         Ok(())
     }
@@ -1735,8 +1732,10 @@ impl GooseAttack {
                     // Collect all metrics sent by GooseUser threads.
                     self.sync_metrics(&mut goose_attack_run_state, true).await?;
                     // Record last users for users per second graph in HTML report.
-                    self.graph_data
-                        .record_users_per_second(self.metrics.users, Utc::now());
+                    self.graph_data.record_users_per_second(
+                        self.metrics.users,
+                        self.started.unwrap().elapsed().as_secs() as usize,
+                    );
                     // The load test is fully stopped at this point.
                     self.metrics
                         .history
@@ -1763,8 +1762,10 @@ impl GooseAttack {
             }
 
             // Record current users for users per second graph in HTML report.
-            self.graph_data
-                .record_users_per_second(self.metrics.users, Utc::now());
+            self.graph_data.record_users_per_second(
+                self.metrics.users,
+                self.started.unwrap().elapsed().as_secs() as usize,
+            );
 
             // Regularly synchronize metrics.
             self.sync_metrics(&mut goose_attack_run_state, false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1662,9 +1662,8 @@ impl GooseAttack {
         };
 
         // Record when the GooseAttack officially started.
-        let now = time::Instant::now();
-        self.started = Some(now);
-        self.graph_data.set_started(now, Utc::now());
+        self.started = Some(time::Instant::now());
+        self.graph_data.set_started(Utc::now());
 
         Ok(())
     }
@@ -1736,7 +1735,8 @@ impl GooseAttack {
                     // Collect all metrics sent by GooseUser threads.
                     self.sync_metrics(&mut goose_attack_run_state, true).await?;
                     // Record last users for users per second graph in HTML report.
-                    self.graph_data.record_users_per_second(self.metrics.users);
+                    self.graph_data
+                        .record_users_per_second(self.metrics.users, Utc::now());
                     // The load test is fully stopped at this point.
                     self.metrics
                         .history
@@ -1763,7 +1763,8 @@ impl GooseAttack {
             }
 
             // Record current users for users per second graph in HTML report.
-            self.graph_data.record_users_per_second(self.metrics.users);
+            self.graph_data
+                .record_users_per_second(self.metrics.users, Utc::now());
 
             // Regularly synchronize metrics.
             self.sync_metrics(&mut goose_attack_run_state, false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ use crate::metrics::{GooseMetric, GooseMetrics};
 use crate::test_plan::{TestPlan, TestPlanHistory, TestPlanStepAction};
 #[cfg(feature = "gaggle")]
 use crate::worker::{register_shutdown_pipe_handler, GaggleMetrics};
+use chrono::prelude::*;
 
 /// Constant defining Goose's default telnet Controller port.
 const DEFAULT_TELNET_PORT: &str = "5116";
@@ -1663,7 +1664,7 @@ impl GooseAttack {
         // Record when the GooseAttack officially started.
         let now = time::Instant::now();
         self.started = Some(now);
-        self.graph_data.set_started(now);
+        self.graph_data.set_started(now, Utc::now());
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,13 +43,13 @@ extern crate log;
 pub mod config;
 pub mod controller;
 pub mod goose;
-//mod graph;
+mod graph;
 pub mod logger;
 #[cfg(feature = "gaggle")]
 mod manager;
 pub mod metrics;
 pub mod prelude;
-//mod report;
+mod report;
 mod test_plan;
 mod throttle;
 mod user;
@@ -78,7 +78,7 @@ use tokio::fs::File;
 use crate::config::{GooseConfiguration, GooseDefaults};
 use crate::controller::{GooseControllerProtocol, GooseControllerRequest};
 use crate::goose::{GaggleUser, GooseTask, GooseTaskSet, GooseUser, GooseUserCommand};
-//use crate::graph::GraphData;
+use crate::graph::GraphData;
 use crate::logger::{GooseLoggerJoinHandle, GooseLoggerTx};
 use crate::metrics::{GooseMetric, GooseMetrics};
 use crate::test_plan::{TestPlan, TestPlanHistory, TestPlanStepAction};
@@ -389,8 +389,8 @@ pub struct GooseAttack {
     step_started: Option<time::Instant>,
     /// All metrics merged together.
     metrics: GooseMetrics,
-    // /// All data for report graphs.
-    //graph_data: GraphData,
+    /// All data for report graphs.
+    graph_data: GraphData,
 }
 
 /// Goose's internal global state.
@@ -420,7 +420,7 @@ impl GooseAttack {
             test_plan: TestPlan::new(),
             step_started: None,
             metrics: GooseMetrics::default(),
-            //graph_data: GraphData::new(),
+            graph_data: GraphData::new(),
         })
     }
 
@@ -456,7 +456,7 @@ impl GooseAttack {
             test_plan: TestPlan::new(),
             step_started: None,
             metrics: GooseMetrics::default(),
-            //graph_data: GraphData::new(),
+            graph_data: GraphData::new(),
         })
     }
 
@@ -1661,7 +1661,9 @@ impl GooseAttack {
         };
 
         // Record when the GooseAttack officially started.
-        self.started = Some(time::Instant::now());
+        let now = time::Instant::now();
+        self.started = Some(now);
+        self.graph_data.set_started(now);
 
         Ok(())
     }
@@ -1733,15 +1735,14 @@ impl GooseAttack {
                     // Collect all metrics sent by GooseUser threads.
                     self.sync_metrics(&mut goose_attack_run_state, true).await?;
                     // Record last users for users per second graph in HTML report.
-                    //self.graph_data.record_users_per_second(self.metrics.users, Utc::now());
+                    self.graph_data.record_users_per_second(self.metrics.users);
                     // The load test is fully stopped at this point.
                     self.metrics
                         .history
                         .push(TestPlanHistory::step(TestPlanStepAction::Finished, 0));
                     //self.graph_data.set_stopped(Utc::now());
                     // Write an html report, if enabled.
-                    // @TODO: Fixme!
-                    //self.write_html_report(&mut goose_attack_run_state).await?;
+                    self.write_html_report(&mut goose_attack_run_state).await?;
                     // Shutdown Goose or go into an idle waiting state.
                     if goose_attack_run_state.shutdown_after_stop {
                         self.set_attack_phase(&mut goose_attack_run_state, AttackPhase::Shutdown);
@@ -1761,7 +1762,7 @@ impl GooseAttack {
             }
 
             // Record current users for users per second graph in HTML report.
-            //self.graph_data.record_users_per_second(self.metrics.users, Utc::now());
+            self.graph_data.record_users_per_second(self.metrics.users);
 
             // Regularly synchronize metrics.
             self.sync_metrics(&mut goose_attack_run_state, false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1732,10 +1732,12 @@ impl GooseAttack {
                     // Collect all metrics sent by GooseUser threads.
                     self.sync_metrics(&mut goose_attack_run_state, true).await?;
                     // Record last users for users per second graph in HTML report.
-                    self.graph_data.record_users_per_second(
-                        self.metrics.users,
-                        self.started.unwrap().elapsed().as_secs() as usize,
-                    );
+                    if let Some(started) = self.started {
+                        self.graph_data.record_users_per_second(
+                            self.metrics.users,
+                            started.elapsed().as_secs() as usize,
+                        );
+                    };
                     // The load test is fully stopped at this point.
                     self.metrics
                         .history
@@ -1762,10 +1764,12 @@ impl GooseAttack {
             }
 
             // Record current users for users per second graph in HTML report.
-            self.graph_data.record_users_per_second(
-                self.metrics.users,
-                self.started.unwrap().elapsed().as_secs() as usize,
-            );
+            if let Some(started) = self.started {
+                self.graph_data.record_users_per_second(
+                    self.metrics.users,
+                    started.elapsed().as_secs() as usize,
+                );
+            };
 
             // Regularly synchronize metrics.
             self.sync_metrics(&mut goose_attack_run_state, false)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2606,6 +2606,8 @@ impl GooseAttack {
     ) -> Result<(), GooseError> {
         // Only write the report if enabled.
         if let Some(report_file) = goose_attack_run_state.report_file.as_mut() {
+            let test_start_time = self.metrics.history.first().unwrap().timestamp;
+
             // Prepare report summary variables.
             let users = self.metrics.users.to_string();
 
@@ -2990,7 +2992,7 @@ impl GooseAttack {
                     &tasks_rows.join("\n"),
                     self.graph_data
                         .get_tasks_per_second_graph(!self.configuration.no_granular_report)
-                        .get_markup(&self.metrics.history),
+                        .get_markup(&self.metrics.history, test_start_time),
                 );
             } else {
                 tasks_template = "".to_string();
@@ -3007,7 +3009,7 @@ impl GooseAttack {
                     &error_rows.join("\n"),
                     self.graph_data
                         .get_errors_per_second_graph(!self.configuration.no_granular_report)
-                        .get_markup(&self.metrics.history),
+                        .get_markup(&self.metrics.history, test_start_time),
                 )
             } else {
                 "".to_string()
@@ -3080,15 +3082,15 @@ impl GooseAttack {
                     graph_rps_template: &self
                         .graph_data
                         .get_requests_per_second_graph(!self.configuration.no_granular_report)
-                        .get_markup(&self.metrics.history),
+                        .get_markup(&self.metrics.history, test_start_time),
                     graph_average_response_time_template: &self
                         .graph_data
                         .get_average_response_time_graph(!self.configuration.no_granular_report)
-                        .get_markup(&self.metrics.history),
+                        .get_markup(&self.metrics.history, test_start_time),
                     graph_users_per_second: &self
                         .graph_data
                         .get_active_users_graph(!self.configuration.no_granular_report)
-                        .get_markup(&self.metrics.history),
+                        .get_markup(&self.metrics.history, test_start_time),
                 },
             );
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2989,7 +2989,8 @@ impl GooseAttack {
                 tasks_template = report::task_metrics_template(
                     &tasks_rows.join("\n"),
                     self.graph_data
-                        .get_tasks_per_second_graph(!self.configuration.no_granular_report),
+                        .get_tasks_per_second_graph(!self.configuration.no_granular_report)
+                        .get_markup(&self.metrics.history),
                 );
             } else {
                 tasks_template = "".to_string();
@@ -3005,7 +3006,8 @@ impl GooseAttack {
                 report::errors_template(
                     &error_rows.join("\n"),
                     self.graph_data
-                        .get_errors_per_second_graph(!self.configuration.no_granular_report),
+                        .get_errors_per_second_graph(!self.configuration.no_granular_report)
+                        .get_markup(&self.metrics.history),
                 )
             } else {
                 "".to_string()
@@ -3078,15 +3080,15 @@ impl GooseAttack {
                     graph_rps_template: &self
                         .graph_data
                         .get_requests_per_second_graph(!self.configuration.no_granular_report)
-                        .get_markup(),
+                        .get_markup(&self.metrics.history),
                     graph_average_response_time_template: &self
                         .graph_data
                         .get_average_response_time_graph(!self.configuration.no_granular_report)
-                        .get_markup(),
+                        .get_markup(&self.metrics.history),
                     graph_users_per_second: &self
                         .graph_data
                         .get_active_users_graph(!self.configuration.no_granular_report)
-                        .get_markup(),
+                        .get_markup(&self.metrics.history),
                 },
             );
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -8,6 +8,16 @@
 //! contained [`GooseTaskMetrics`], [`GooseRequestMetrics`], and
 //! [`GooseErrorMetrics`] are displayed in tables.
 
+use crate::config::GooseDefaults;
+use crate::goose::{get_base_url, GooseMethod, GooseTaskSet};
+use crate::logger::GooseLog;
+use crate::report;
+use crate::test_plan::{TestPlanHistory, TestPlanStepAction};
+use crate::util;
+#[cfg(feature = "gaggle")]
+use crate::worker::{self, GaggleMetrics};
+use crate::{AttackMode, GooseAttack, GooseAttackRunState, GooseConfiguration, GooseError};
+use chrono::prelude::*;
 use http::StatusCode;
 use itertools::Itertools;
 use num_format::{Locale, ToFormattedString};
@@ -19,16 +29,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::str::FromStr;
 use std::{f32, fmt};
 use tokio::io::AsyncWriteExt;
-use chrono::prelude::*;
-use crate::config::GooseDefaults;
-use crate::goose::{get_base_url, GooseMethod, GooseTaskSet};
-use crate::logger::GooseLog;
-use crate::report;
-use crate::test_plan::{TestPlanHistory, TestPlanStepAction};
-use crate::util;
-#[cfg(feature = "gaggle")]
-use crate::worker::{self, GaggleMetrics};
-use crate::{AttackMode, GooseAttack, GooseAttackRunState, GooseConfiguration, GooseError};
 
 /// Used to send metrics from [`GooseUser`](../goose/struct.GooseUser.html) threads
 /// to the parent Goose process.

--- a/src/report.rs
+++ b/src/report.rs
@@ -419,7 +419,7 @@ pub fn error_row(error: &metrics::GooseErrorMetricAggregate) -> String {
 /// Build the html report.
 pub(crate) fn build_report(
     users: &str,
-    report_range: &str,
+    steps_rows: &str,
     hosts: &str,
     templates: GooseReportTemplates,
 ) -> String {
@@ -498,8 +498,22 @@ pub(crate) fn build_report(
         <div class="info">
             <p>Users: <span>{users}</span> </p>
             <p>Target Host: <span>{hosts}</span></p>
-            {report_range}
-            <p><span><small><em>{pkg_name} v{pkg_version}</em></small></span></pr>
+            <p><span><small><em>{pkg_name} v{pkg_version}</em></small></span></p>
+            <h2>Plan overview</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Action</th>
+                            <th>Started</th>
+                            <th>Stopped</th>
+                            <th>Elapsed</th>
+                            <th>Users</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {steps_rows}
+                    </tbody>
+                </table>
         </div>
 
         <div class="requests">
@@ -572,7 +586,7 @@ pub(crate) fn build_report(
 </body>
 </html>"#,
         users = users,
-        report_range = report_range,
+        steps_rows = steps_rows,
         hosts = hosts,
         pkg_name = pkg_name,
         pkg_version = pkg_version,

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,6 +1,5 @@
 //! Optionally writes an html-formatted summary report after running a load test.
 
-use crate::graph::Graph;
 use crate::metrics;
 
 use std::collections::BTreeMap;
@@ -315,7 +314,7 @@ pub(crate) fn status_code_metrics_row(metric: StatusCodeMetric) -> String {
 }
 
 /// If task metrics are enabled, add a task metrics table to the html report.
-pub(crate) fn task_metrics_template(task_rows: &str, graph: Graph<usize, usize>) -> String {
+pub(crate) fn task_metrics_template(task_rows: &str, graph: String) -> String {
     format!(
         r#"<div class="tasks">
         <h2>Task Metrics</h2>
@@ -341,7 +340,7 @@ pub(crate) fn task_metrics_template(task_rows: &str, graph: Graph<usize, usize>)
         </table>
     </div>"#,
         task_rows = task_rows,
-        graph = graph.get_markup(),
+        graph = graph,
     )
 }
 
@@ -380,7 +379,7 @@ pub(crate) fn task_metrics_row(metric: TaskMetric) -> String {
 }
 
 /// If there are errors, add an errors table to the html report.
-pub(crate) fn errors_template(error_rows: &str, graph: Graph<u32, u32>) -> String {
+pub(crate) fn errors_template(error_rows: &str, graph: String) -> String {
     format!(
         r#"<div class="errors">
         <h2>Errors</h2>
@@ -400,7 +399,7 @@ pub(crate) fn errors_template(error_rows: &str, graph: Graph<u32, u32>) -> Strin
         </table>
     </div>"#,
         error_rows = error_rows,
-        graph = graph.get_markup(),
+        graph = graph,
     )
 }
 


### PR DESCRIPTION
Closes #440. 

- Re-enables report file
- Instead of starting, started, stopping, stopped summary displays a table of plan steps overview
- Removes "Starting" and "Stopping" section from graphs
- Add increasing (green) and decreasing (red) sections to the graph

![Screenshot 2022-04-21 at 12-24-03 Goose Attack Report](https://user-images.githubusercontent.com/376889/164440920-38cf1487-4f93-4ece-9efd-3928c38204e8.png)


