### PR TITLE
tag 0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.16.0-dev
+## 0.16.0 May 1, 2022
  - [#431](https://github.com/tag1consulting/goose/pull/431) rename `--no-granular-data` to `--no-granular-report`
  - [#415](https://github.com/tag1consulting/goose/pull/415) display granular data in HTML graphs, introduce `--no-granular-data` to disable it and display graphs as they were until this change
  - [#406](https://github.com/tag1consulting/goose/pull/406) make sure that the graphs are built correctly if the load test is interrupted during the starting phase

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.16.0-dev"
+version = "0.16.0"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/examples/drupal_memcache.rs
+++ b/examples/drupal_memcache.rs
@@ -8,7 +8,7 @@
 //!
 //! ## License
 //!
-//! Copyright 2020 Jeremy Andrews
+//! Copyright 2020-2022 Jeremy Andrews
 //!
 //! Licensed under the Apache License, Version 2.0 (the "License");
 //! you may not use this file except in compliance with the License.

--- a/examples/session.rs
+++ b/examples/session.rs
@@ -3,7 +3,7 @@
 //!
 //! ## License
 //!
-//! Copyright 2020 Jeremy Andrews
+//! Copyright 2020-2022 Jeremy Andrews
 //!
 //! Licensed under the Apache License, Version 2.0 (the "License");
 //! you may not use this file except in compliance with the License.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,7 +3,7 @@
 //!
 //! ## License
 //!
-//! Copyright 2020 Jeremy Andrews
+//! Copyright 2020-2022 Jeremy Andrews
 //!
 //! Licensed under the Apache License, Version 2.0 (the "License");
 //! you may not use this file except in compliance with the License.

--- a/src/docs/goose-book/src/getting-started/creating.md
+++ b/src/docs/goose-book/src/getting-started/creating.md
@@ -38,7 +38,7 @@ use goose::prelude::*;
 
 > **Note:** Using the above prelude automatically adds the following `use` statements necessary when writing a load test, so you don't need to manually add all of them:
 >
-> ```rust
+> ```rust,ignore
 > use crate::config::{GooseDefault, GooseDefaultType};
 > use crate::goose::{
 >     GooseMethod, GooseRequest, GooseUser, Scenario, Transaction, TransactionError,

--- a/src/docs/goose-book/src/getting-started/tips.md
+++ b/src/docs/goose-book/src/getting-started/tips.md
@@ -11,13 +11,13 @@
 
 By default, Goose will time out requests that take longer than 60 seconds to return, and display a `WARN` level message saying, "operation timed out". For example:
 
-```
+```ignore
 11:52:17 [WARN] "/node/3672": error sending request for url (http://apache/node/3672): operation timed out
 ```
 
 These will also show up in the error summary displayed with the final metrics. For example:
 
-```
+```ignore
  === ERRORS ===
  ------------------------------------------------------------------------------
  Count       | Error

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -273,7 +273,7 @@
 //!
 //! ## License
 //!
-//! Copyright 2020 Jeremy Andrews
+//! Copyright 2020-2022 Jeremy Andrews
 //!
 //! Licensed under the Apache License, Version 2.0 (the "License");
 //! you may not use this file except in compliance with the License.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! ## License
 //!
-//! Copyright 2020-21 Jeremy Andrews
+//! Copyright 2020-2022 Jeremy Andrews
 //!
 //! Licensed under the Apache License, Version 2.0 (the "License");
 //! you may not use this file except in compliance with the License.


### PR DESCRIPTION
 - update version to 0.16.0
 - update copyright headers (per https://apache.org/legal/src-headers.html)
 - closes https://github.com/tag1consulting/goose/issues/459