### PR TITLE
expose `startup_time` to  controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.16.1-dev
+ - [#464](https://github.com/tag1consulting/goose/pull/464) add `startuptime` (and `startup_time`) TIME to controllers, setting how long the load test should spend starting configured number of users
 
 ## 0.16.0 May 1, 2022
  - [#431](https://github.com/tag1consulting/goose/pull/431) rename `--no-granular-data` to `--no-granular-report`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ serde = { version = "1.0", features = [
 serde_cbor = "0.11"
 serde_json = "1.0"
 simplelog = "0.10"
+strum = "0.24"
+strum_macros = "0.24"
 tokio = { version = "~1.15.0", features = [
     "fs",
     "io-util",

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -16,6 +16,8 @@ use serde::{Deserialize, Serialize};
 use std::io;
 use std::str;
 use std::str::FromStr;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message;
@@ -39,63 +41,14 @@ pub(crate) enum GooseControllerProtocol {
 ///  1. Define the command here in the GooseControllerCommand enum.
 ///  2. Add the regular expression for matching the new command in the `command`
 /// [`regex::RegexSet`](https://docs.rs/regex/*/regex/struct.RegexSet.html) in
-/// `controller_main()`.
-///      1. If a value needs to be captured, define the regular expression in a variable
-///         outside the set, and add the variable to the top section of the set with the
-///         other regex variables.
-///      2. In the same function, also add the variable to the `captures` Vector, in the
-///         same order that it was added to the `command` `RegexSet`. Order is important
-///         as this is how the regex is later identified.
-///  3. Check for a match to the new regex in `get_match()`, any additional validation
-///      beyond the regex must be performed here (for example, the regular expression
-///      for capturing hosts simply confirms that the host starts with http or https,
-///      then in `get_match()` it calls [`util::is_valid_host()`](../util/fn.is_valid_host.html)
-///      to be sure it is truly a valid host before passing it to the parent process).
-///  4. Add any parent process logic for the command to `handle_controller_requests()`.
-///  5. Handle the response in `process_response()`, returning a `Result<String, String>`
+/// [`GooseControllerCommand::get_regex`].
+///      - See `Hatchrate` and `Users for a regex that also captures a value.
+///      - See `Host` for a regex that also reuires manual validation afterward.
+///  3. Add any parent process logic for the command to `handle_controller_requests()`.
+///  4. Handle the response in `process_response()`, returning a `Result<String, String>`
 ///     succinctly describing success or failure.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, EnumIter, PartialEq)]
 pub enum GooseControllerCommand {
-    /// Configure the host to load test.
-    ///
-    /// # Example
-    /// Tells Goose to generate load against <http://example.com/>.
-    /// ```notest
-    /// host http://example.com/
-    /// ```
-    ///
-    /// Goose must be idle to process this command.
-    Host,
-    /// Configure how many [`GooseUser`](../goose/struct.GooseUser.html)s are launched.
-    ///
-    /// # Example
-    /// Tells Goose to simulate 100 concurrent users.
-    /// ```notest
-    /// users 100
-    /// ```
-    ///
-    /// Goose must be idle to process this command.
-    Users,
-    /// Configure how quickly new [`GooseUser`](../goose/struct.GooseUser.html)s are launched.
-    ///
-    /// # Example
-    /// Tells Goose to launch a new user every 1.25 seconds.
-    /// ```notest
-    /// hatchrate 1.25
-    /// ```
-    ///
-    /// Goose can be idle or running when processing this command.
-    HatchRate,
-    /// Configure how long the load test should run before stopping and returning to an idle state.
-    ///
-    /// # Example
-    /// Tells Goose to run the load test for 1 minute, before automatically stopping.
-    /// ```notest
-    /// runtime 60
-    /// ```
-    ///
-    /// This can be configured when Goose is idle as well as when a Goose load test is running.
-    RunTime,
     /// Display the current [`GooseConfiguration`](../struct.GooseConfiguration.html)s.
     ///
     /// # Example
@@ -114,6 +67,46 @@ pub enum GooseControllerCommand {
     ///
     /// This command can be run at any time.
     ConfigJson,
+    /// Disconnect from the Controller.
+    ///
+    /// # Example
+    /// Disconnects from the Controller.
+    /// ```notest
+    /// exit
+    /// ```
+    ///
+    /// This command can be run at any time.
+    Exit,
+    /// Configure how quickly new [`GooseUser`](../goose/struct.GooseUser.html)s are launched.
+    ///
+    /// # Example
+    /// Tells Goose to launch a new user every 1.25 seconds.
+    /// ```notest
+    /// hatchrate 1.25
+    /// ```
+    ///
+    /// Goose can be idle or running when processing this command.
+    HatchRate,
+    /// Displays a list of all commands supported by the Controller.
+    ///
+    /// # Example
+    /// Returns the a list of all supported Controller commands.
+    /// ```notest
+    /// help
+    /// ```
+    ///
+    /// This command can be run at any time.
+    Help,
+    /// Configure the host to load test.
+    ///
+    /// # Example
+    /// Tells Goose to generate load against <http://example.com/>.
+    /// ```notest
+    /// host http://example.com/
+    /// ```
+    ///
+    /// Goose must be idle to process this command.
+    Host,
     /// Display the current [`GooseMetric`](../metrics/struct.GooseMetrics.html)s.
     ///
     /// # Example
@@ -134,26 +127,26 @@ pub enum GooseControllerCommand {
     ///
     /// This command can be run at any time.
     MetricsJson,
-    /// Displays a list of all commands supported by the Controller.
+    /// Configure how long the load test should run before stopping and returning to an idle state.
     ///
     /// # Example
-    /// Returns the a list of all supported Controller commands.
+    /// Tells Goose to run the load test for 1 minute, before automatically stopping.
     /// ```notest
-    /// help
+    /// runtime 60
     /// ```
     ///
-    /// This command can be run at any time.
-    Help,
-    /// Disconnect from the Controller.
+    /// This can be configured when Goose is idle as well as when a Goose load test is running.
+    RunTime,
+    /// Tell the load test to shut down (which will disconnect the controller).
     ///
     /// # Example
-    /// Disconnects from the Controller.
+    /// Terminates the Goose process, cleanly shutting down the load test if running.
     /// ```notest
-    /// exit
+    /// shutdown
     /// ```
     ///
-    /// This command can be run at any time.
-    Exit,
+    /// Goose can process this command at any time.
+    Shutdown,
     /// Start an idle test.
     ///
     /// # Example
@@ -174,16 +167,111 @@ pub enum GooseControllerCommand {
     ///
     /// Goose must be running (or starting) to process this command.
     Stop,
-    /// Tell the load test to shut down (which will disconnect the controller).
+    /// Configure how many [`GooseUser`](../goose/struct.GooseUser.html)s are launched.
     ///
     /// # Example
-    /// Terminates the Goose process, cleanly shutting down the load test if running.
+    /// Tells Goose to simulate 100 concurrent users.
     /// ```notest
-    /// shutdown
+    /// users 100
     /// ```
     ///
-    /// Goose can process this command at any time.
-    Shutdown,
+    /// Goose must be idle to process this command.
+    Users,
+}
+
+impl GooseControllerCommand {
+    // Controller commands are recognized by matching against regular expressions.
+    fn get_regex(&self) -> String {
+        match self {
+            GooseControllerCommand::Config => r"(?i)^config$",
+            GooseControllerCommand::ConfigJson => r"(?i)^(configjson|config-json)$",
+            GooseControllerCommand::Exit => r"(?i)^(exit|quit)$",
+            GooseControllerCommand::HatchRate => {
+                r"(?i)^(hatchrate|hatch_rate|hatch-rate) ([0-9]*(\.[0-9]*)?){1}$"
+            }
+            GooseControllerCommand::Help => r"(?i)^(help|\?)$",
+            GooseControllerCommand::Host => {
+                r"(?i)^(host|hostname|host_name|host-name) ((https?)://.+)$"
+            }
+            GooseControllerCommand::Metrics => r"(?i)^(metrics|stats)$",
+            GooseControllerCommand::MetricsJson => {
+                r"(?i)^(metricsjson|metrics-json|statsjson|stats-json)$"
+            }
+            GooseControllerCommand::RunTime => {
+                r"(?i)^(run|runtime|run_time|run-time|) (\d+|((\d+?)h)?((\d+?)m)?((\d+?)s)?)$"
+            }
+            GooseControllerCommand::Shutdown => r"(?i)^shutdown$",
+            GooseControllerCommand::Start => r"(?i)^start$",
+            GooseControllerCommand::Stop => r"(?i)^stop$",
+            GooseControllerCommand::Users => r"(?i)^(users?) (\d+)$",
+        }
+        .to_string()
+    }
+
+    fn get_value(&self, command_string: &str) -> Option<String> {
+        let regex = Regex::new(&self.get_regex())
+            .expect("GooseControllerCommand::get_regex() returned invalid regex [2]");
+        let caps = regex.captures(command_string).unwrap();
+        let value = caps.get(2).map_or("", |m| m.as_str());
+        if value.is_empty() {
+            None
+        } else {
+            // The Regex that captures the host only validates that the host starts with
+            // http:// or https://. Now use a library to properly validate that this is
+            // a valid host before sending to the parent process.
+            if self == &GooseControllerCommand::Host {
+                if util::is_valid_host(value).is_ok() {
+                    Some(value.to_string())
+                } else {
+                    None
+                }
+            // All other Regex that capture values can simply return the value without
+            // additional validation.
+            } else {
+                Some(value.to_string())
+            }
+        }
+    }
+}
+
+/// Implement [`FromStr`] to convert controller commands and optional values to the proper enum
+/// representation.
+impl FromStr for GooseControllerCommand {
+    type Err = GooseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Load all GooseControllerCommand regex into a set.
+        let mut regex_set: Vec<String> = Vec::new();
+        let mut keys = Vec::new();
+        for t in GooseControllerCommand::iter() {
+            keys.push(t.clone());
+            regex_set.push(t.get_regex());
+        }
+        let commands = RegexSet::new(regex_set)
+            .expect("GooseControllerCommand::get_regex() returned invalid regex");
+        let matches: Vec<_> = commands.matches(s).into_iter().collect();
+        // This happens any time the controller receives an invalid command.
+        if matches.is_empty() {
+            return Err(GooseError::InvalidControllerCommand {
+                detail: format!("unrecognized controller command: '{}'.", s),
+            });
+        // This shouldn't ever happen, but if it does report all available information.
+        } else if matches.len() > 1 {
+            let mut matched_commands = Vec::new();
+            for index in matches {
+                matched_commands.push(keys[index].clone())
+            }
+            return Err(GooseError::InvalidControllerCommand {
+                detail: format!(
+                    "matched multiple controller commands: '{}' ({:?}).",
+                    s, matched_commands
+                ),
+            });
+        // Only one command matched.
+        } else {
+            Ok(keys[*matches.first().unwrap()].clone())
+        }
+    }
 }
 
 /// This structure is used to send commands and values to the parent process.
@@ -314,10 +402,6 @@ pub(crate) struct GooseControllerState {
     peer_address: String,
     /// A shared channel for communicating with the parent process.
     channel_tx: flume::Sender<GooseControllerRequest>,
-    /// A compiled set of regular expressions used for matching commands.
-    commands: RegexSet,
-    /// A compiled vector of regular expressions used for capturing values from commands.
-    captures: Vec<Regex>,
     /// Which protocol this Controller understands.
     protocol: GooseControllerProtocol,
 }
@@ -443,104 +527,16 @@ impl GooseControllerState {
     }
 
     // Both Controllers use a common function to identify commands.
-    async fn get_match(&self, command_string: &str) -> Result<GooseControllerRequestMessage, ()> {
-        let matches = self.commands.matches(command_string);
-        if matches.matched(GooseControllerCommand::Help as usize) {
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::Help,
-                value: None,
-            })
-        } else if matches.matched(GooseControllerCommand::Exit as usize) {
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::Exit,
-                value: None,
-            })
-        } else if matches.matched(GooseControllerCommand::Start as usize) {
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::Start,
-                value: None,
-            })
-        } else if matches.matched(GooseControllerCommand::Stop as usize) {
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::Stop,
-                value: None,
-            })
-        } else if matches.matched(GooseControllerCommand::Shutdown as usize) {
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::Shutdown,
-                value: None,
-            })
-        } else if matches.matched(GooseControllerCommand::Config as usize) {
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::Config,
-                value: None,
-            })
-        } else if matches.matched(GooseControllerCommand::ConfigJson as usize) {
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::ConfigJson,
-                value: None,
-            })
-        } else if matches.matched(GooseControllerCommand::Metrics as usize) {
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::Metrics,
-                value: None,
-            })
-        } else if matches.matched(GooseControllerCommand::MetricsJson as usize) {
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::MetricsJson,
-                value: None,
-            })
-        } else if matches.matched(GooseControllerCommand::Host as usize) {
-            // Perform a second regex to capture the host value.
-            let caps = self.captures[GooseControllerCommand::Host as usize]
-                .captures(command_string)
-                .unwrap();
-            let host = caps.get(2).map_or("", |m| m.as_str());
-            // The Regex that captures the host only validates that the host starts with
-            // http:// or https://. Now use a library to properly validate that this is
-            // a valid host before sending to the parent process.
-            if util::is_valid_host(host).is_ok() {
-                Ok(GooseControllerRequestMessage {
-                    command: GooseControllerCommand::Host,
-                    value: Some(host.to_string()),
-                })
-            } else {
-                debug!("invalid host: {}", host);
-                Err(())
-            }
-        } else if matches.matched(GooseControllerCommand::Users as usize) {
-            // Perform a second regex to capture the users value.
-            let caps = self.captures[GooseControllerCommand::Users as usize]
-                .captures(command_string)
-                .unwrap();
-            let users = caps.get(2).map_or("", |m| m.as_str());
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::Users,
-                value: Some(users.to_string()),
-            })
-        } else if matches.matched(GooseControllerCommand::HatchRate as usize) {
-            // Perform a second regex to capture the hatch_rate value.
-            let caps = self.captures[GooseControllerCommand::HatchRate as usize]
-                .captures(command_string)
-                .unwrap();
-            let hatch_rate = caps.get(2).map_or("", |m| m.as_str());
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::HatchRate,
-                value: Some(hatch_rate.to_string()),
-            })
-        } else if matches.matched(GooseControllerCommand::RunTime as usize) {
-            // Perform a second regex to capture the run_time value.
-            let caps = self.captures[GooseControllerCommand::RunTime as usize]
-                .captures(command_string)
-                .unwrap();
-            let run_time = caps.get(2).map_or("", |m| m.as_str());
-            Ok(GooseControllerRequestMessage {
-                command: GooseControllerCommand::RunTime,
-                value: Some(run_time.to_string()),
-            })
-        } else {
-            Err(())
-        }
+    async fn get_match(
+        &self,
+        command_string: &str,
+    ) -> Result<GooseControllerRequestMessage, GooseError> {
+        // Use FromStr to convert &str to GooseControllerCommand.
+        let command: GooseControllerCommand = GooseControllerCommand::from_str(command_string)?;
+        // Extract value if there is one, otherwise will be None.
+        let value: Option<String> = command.get_value(command_string);
+
+        Ok(GooseControllerRequestMessage { command, value })
     }
 
     /// Process a request entirely within the Controller thread, without sending a message
@@ -596,37 +592,6 @@ impl GooseControllerState {
         response: GooseControllerResponseMessage,
     ) -> Result<String, String> {
         match command {
-            GooseControllerCommand::Host => {
-                if let GooseControllerResponseMessage::Bool(true) = response {
-                    Ok("host configured".to_string())
-                } else {
-                    Err(
-                        "failed to reconfigure host, be sure host is valid and load test is idle"
-                            .to_string(),
-                    )
-                }
-            }
-            GooseControllerCommand::Users => {
-                if let GooseControllerResponseMessage::Bool(true) = response {
-                    Ok("users configured".to_string())
-                } else {
-                    Err("load test not idle, failed to reconfigure users".to_string())
-                }
-            }
-            GooseControllerCommand::HatchRate => {
-                if let GooseControllerResponseMessage::Bool(true) = response {
-                    Ok("hatch_rate configured".to_string())
-                } else {
-                    Err("failed to configure hatch_rate".to_string())
-                }
-            }
-            GooseControllerCommand::RunTime => {
-                if let GooseControllerResponseMessage::Bool(true) = response {
-                    Ok("run_time configured".to_string())
-                } else {
-                    Err("failed to configure run_time".to_string())
-                }
-            }
             GooseControllerCommand::Config => {
                 if let GooseControllerResponseMessage::Config(config) = response {
                     Ok(format!("{:#?}", config))
@@ -641,6 +606,29 @@ impl GooseControllerState {
                     Err("error loading configuration".to_string())
                 }
             }
+            GooseControllerCommand::HatchRate => {
+                if let GooseControllerResponseMessage::Bool(true) = response {
+                    Ok("hatch_rate configured".to_string())
+                } else {
+                    Err("failed to configure hatch_rate".to_string())
+                }
+            }
+            // These commands are processed earlier so we should never get here.
+            GooseControllerCommand::Help | GooseControllerCommand::Exit => {
+                let e = "received an impossible HELP or EXIT command";
+                error!("{}", e);
+                Err(e.to_string())
+            }
+            GooseControllerCommand::Host => {
+                if let GooseControllerResponseMessage::Bool(true) = response {
+                    Ok("host configured".to_string())
+                } else {
+                    Err(
+                        "failed to reconfigure host, be sure host is valid and load test is idle"
+                            .to_string(),
+                    )
+                }
+            }
             GooseControllerCommand::Metrics => {
                 if let GooseControllerResponseMessage::Metrics(metrics) = response {
                     Ok(metrics.to_string())
@@ -653,6 +641,20 @@ impl GooseControllerState {
                     Ok(serde_json::to_string(&metrics).expect("unexpected serde failure"))
                 } else {
                     Err("error loading metrics".to_string())
+                }
+            }
+            GooseControllerCommand::RunTime => {
+                if let GooseControllerResponseMessage::Bool(true) = response {
+                    Ok("run_time configured".to_string())
+                } else {
+                    Err("failed to configure run_time".to_string())
+                }
+            }
+            GooseControllerCommand::Shutdown => {
+                if let GooseControllerResponseMessage::Bool(true) = response {
+                    Ok("load test shut down".to_string())
+                } else {
+                    Err("failed to shut down load test".to_string())
                 }
             }
             GooseControllerCommand::Start => {
@@ -673,18 +675,12 @@ impl GooseControllerState {
                     Err("load test not running, failed to stop".to_string())
                 }
             }
-            GooseControllerCommand::Shutdown => {
+            GooseControllerCommand::Users => {
                 if let GooseControllerResponseMessage::Bool(true) = response {
-                    Ok("load test shut down".to_string())
+                    Ok("users configured".to_string())
                 } else {
-                    Err("failed to shut down load test".to_string())
+                    Err("load test not idle, failed to reconfigure users".to_string())
                 }
-            }
-            // These commands are processed earlier so we should never get here.
-            GooseControllerCommand::Help | GooseControllerCommand::Exit => {
-                let e = "received an impossible HELP or EXIT command";
-                error!("{}", e);
-                Err(e.to_string())
             }
         }
     }
@@ -975,59 +971,6 @@ pub(crate) async fn controller_main(
     let listener = TcpListener::bind(&address).await?;
     info!("{:?} controller listening on: {}", protocol, address);
 
-    // These first regular expressions are compiled twice. Once as part of a set used to match
-    // against a command. The second time to capture specific matched values. This is a
-    // limitiation of RegexSet as documented at:
-    // https://docs.rs/regex/1.5.4/regex/struct.RegexSet.html#limitations
-    let host_regex = r"(?i)^(host|hostname|host_name|host-name) ((https?)://.+)$";
-    let users_regex = r"(?i)^(users?) (\d+)$";
-    let hatchrate_regex = r"(?i)^(hatchrate|hatch_rate|hatch-rate) ([0-9]*(\.[0-9]*)?){1}$";
-    let runtime_regex =
-        r"(?i)^(run|runtime|run_time|run-time|) (\d+|((\d+?)h)?((\d+?)m)?((\d+?)s)?)$";
-
-    // The following RegexSet is matched against all commands received through the controller.
-    // Developer note: The order commands are defined here must match the order in which
-    // the commands are defined in the GooseControllerCommand enum, as it is used to determine
-    // which expression matched, if any.
-    let commands = RegexSet::new(&[
-        // Modify the host the load test runs against.
-        host_regex,
-        // Modify how many users hatch.
-        users_regex,
-        // Modify how quickly users hatch.
-        hatchrate_regex,
-        // Modify how long the load test will run.
-        runtime_regex,
-        // Display the current load test configuration.
-        r"(?i)^config$",
-        // Display the current load test configuration in json.
-        r"(?i)^(configjson|config-json)$",
-        // Display running metrics for the currently active load test.
-        r"(?i)^(metrics|stats)$",
-        // Display running metrics for the currently active load test in json.
-        r"(?i)^(metricsjson|metrics-json|statsjson|stats-json)$",
-        // Provide a list of possible commands.
-        r"(?i)^(help|\?)$",
-        // Exit/quit the controller connection, does not affect load test.
-        r"(?i)^(exit|quit)$",
-        // Start an idle load test.
-        r"(?i)^start$",
-        // Stop an idle load test.
-        r"(?i)^stop$",
-        // Shutdown the load test (which will cause the controller connection to quit).
-        r"(?i)^shutdown$",
-    ])
-    .unwrap();
-
-    // The following regular expressions are used when matching against certain commands
-    // to then capture a matched value.
-    let captures = vec![
-        Regex::new(host_regex).unwrap(),
-        Regex::new(users_regex).unwrap(),
-        Regex::new(hatchrate_regex).unwrap(),
-        Regex::new(runtime_regex).unwrap(),
-    ];
-
     // Counter increments each time a controller client connects with this protocol.
     let mut thread_id: u32 = 0;
 
@@ -1045,8 +988,6 @@ pub(crate) async fn controller_main(
             thread_id,
             peer_address,
             channel_tx: channel_tx.clone(),
-            commands: commands.clone(),
-            captures: captures.clone(),
             protocol: protocol.clone(),
         };
 
@@ -1246,9 +1187,13 @@ impl GooseAttack {
                                         GooseControllerResponseMessage::Bool(true),
                                     );
                                 } else {
-                                    warn!(
-                                        "Controller didn't provide host: {:#?}",
+                                    debug!(
+                                        "controller didn't provide host: {:#?}",
                                         &message.request
+                                    );
+                                    self.reply_to_controller(
+                                        message,
+                                        GooseControllerResponseMessage::Bool(false),
                                     );
                                 }
                             } else {

--- a/src/docs/goose-book/src/controller/telnet.md
+++ b/src/docs/goose-book/src/controller/telnet.md
@@ -20,6 +20,7 @@ goose 0.16.0 controller commands:
  host HOST          set host to load test, ie http://localhost/
  users INT          set number of simulated users
  hatchrate FLOAT    set per-second rate users hatch
+ startup-time TIME  set time to take starting users
  runtime TIME       set how long to run test, ie 1h30m5s
  config             display load test configuration
  config-json        display load test configuration in json format

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,11 @@ pub enum GooseError {
         /// An optional explanation of the error.
         detail: String,
     },
+    /// Invalid controller command.
+    InvalidControllerCommand {
+        /// An optional explanation of the error.
+        detail: String,
+    },
     /// [`GooseAttack`](./struct.GooseAttack.html) has no [`Scenario`](./goose/struct.Scenario.html) defined.
     NoScenarios {
         /// An optional explanation of the error.
@@ -185,6 +190,7 @@ impl GooseError {
             GooseError::InvalidOption { .. } => "invalid option or value specified",
             GooseError::InvalidWaitTime { .. } => "invalid wait_time specified",
             GooseError::InvalidWeight { .. } => "invalid weight specified",
+            GooseError::InvalidControllerCommand { .. } => "invalid controller command",
             GooseError::NoScenarios { .. } => "no scenarios defined",
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1560,7 +1560,7 @@ impl GooseAttack {
         // If this is the last step of the load test and there are 0 users, shut down.
         if goose_attack_run_state.active_users == 0
             // Subtract 1 from len() as it starts at 1 while current starts at 0.
-            && self.test_plan.current == self.test_plan.steps.len() - 1
+            && self.test_plan.current >= self.test_plan.steps.len() - 1
         {
             // Load test is shutting down, update pipe handler so there is no panic
             // when the Manager goes away.

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -24,6 +24,7 @@ const ABOUT_KEY: usize = 1;
 const USERS: usize = 5;
 const HATCH_RATE: usize = 10;
 const RUN_TIME: usize = 10;
+const STARTUP_TIME: usize = 1;
 
 // There are multiple test variations in this file.
 #[derive(Clone)]
@@ -364,6 +365,45 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
+                GooseControllerCommand::StartupTime => {
+                    match test_state.step {
+                        // Try to configure a decimal StartupTime.
+                        0 => {
+                            make_request(&mut test_state, "startup-time .1\r\n");
+                        }
+                        // Configure a StartupTime with hms notation.
+                        1 => {
+                            assert!(response.starts_with("unrecognized command"));
+
+                            make_request(&mut test_state, "startup-time 1h2m3s\r\n");
+                        }
+                        // Configure a proper StartupTime.
+                        2 => {
+                            assert!(response.starts_with("startup_time configured"));
+
+                            make_request(
+                                &mut test_state,
+                                &["startup_time ", &STARTUP_TIME.to_string(), "\r\n"].concat(),
+                            );
+                        }
+                        // Restore the HatchRate.
+                        3 => {
+                            assert!(response.starts_with("startup_time configured"));
+
+                            // Configure hatch_rate with a single integer.
+                            make_request(
+                                &mut test_state,
+                                &["hatchrate ", &HATCH_RATE.to_string(), "\r\n"].concat(),
+                            );
+                        }
+                        // Confirm hatch_rate is configured.
+                        _ => {
+                            assert!(response.starts_with("hatch_rate configured"));
+
+                            test_state = update_state(Some(test_state), &test_type);
+                        }
+                    }
+                }
                 GooseControllerCommand::RunTime => {
                     match test_state.step {
                         // Configure run_time using h:m:s format.
@@ -606,6 +646,7 @@ fn update_state(test_state: Option<TestState>, test_type: &TestType) -> TestStat
         GooseControllerCommand::Host,
         GooseControllerCommand::Users,
         GooseControllerCommand::HatchRate,
+        GooseControllerCommand::StartupTime,
         GooseControllerCommand::RunTime,
         GooseControllerCommand::Start,
         GooseControllerCommand::Config,

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -288,7 +288,7 @@ async fn run_standalone_test(test_type: TestType) {
                         // Confirm that we can't configure an invalid host that does
                         // match the regex.
                         _ => {
-                            assert!(response.starts_with("unrecognized command"));
+                            assert!(response.starts_with("failed to reconfigure host"));
 
                             // Move onto the next command.
                             test_state = update_state(Some(test_state), &test_type);


### PR DESCRIPTION
- de-duplicate controller logic to make less fragile (add [`strum`](https://docs.rs/strum) to allow walking of Enum and avoid having to declare all command twice and in the same identical order)
- expose `startup_time` to controllers, resets `hatch_rate` to `None` if previously set
- setting `hatch_rate` resets `startup_time` to `0 if previously set
- test coverage
- closes https://github.com/tag1consulting/goose/issues/425