### PR TITLE
combine controller command logic into central place

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -13,29 +13,14 @@ use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
 use regex::{Regex, RegexSet};
 use serde::{Deserialize, Serialize};
-use std::io;
-use std::str;
-use std::str::FromStr;
+use std::io::{self, Write};
+use std::str::{self, FromStr};
 use std::time::Duration;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message;
-
-/// Goose supports two different Controller protocols: telnet and WebSocket.
-#[derive(Clone, Debug)]
-pub(crate) enum ControllerProtocol {
-    /// Allows control of Goose via telnet.
-    Telnet,
-    /// Allows control of Goose via a WebSocket.
-    WebSocket,
-}
-
-pub(crate) struct ControllerCommandDetails {
-    regex: String,
-    process_response: Box<dyn Fn(ControllerResponseMessage) -> Result<String, String>>,
-}
 
 /// All commands recognized by the Goose Controllers.
 ///
@@ -44,17 +29,119 @@ pub(crate) struct ControllerCommandDetails {
 /// [ControllerWebSocketRequest](./struct.ControllerWebSocketRequest.html).
 ///
 /// GOOSE DEVELOPER NOTE: The following steps are required to add a new command:
-///  1. Define the command here in the ControllerCommand enum.
-///  2. Add the regular expression for matching the new command in the `command`
-/// [`regex::RegexSet`](https://docs.rs/regex/*/regex/struct.RegexSet.html) in
-/// [`ControllerCommand::get_regex`].
-///      - See `Hatchrate` and `Users for a regex that also captures a value.
-///      - See `Host` for a regex that also reuires manual validation afterward.
-///  3. Add any parent process logic for the command to `handle_controller_requests()`.
-///  4. Handle the response in `process_response()`, returning a `Result<String, String>`
-///     succinctly describing success or failure.
+///  1. Define the new command here in the ControllerCommand enum.
+///      - Commands will be displayed in the help screen in the order defined here, so
+///        they should be logically grouped.
+///  2. Add the new command to `ControllerCommand::details` and populate all
+///    `ControllerCommandDetails`, using other commands as an implementation reference.
+///      - The `regex` is used to identify the command, and optionally to extract a
+///        value (for example see `Hatchrate` and `Users`)
+///      - If additional validation is required beyond the regular expression, add
+///        the necessary logic to `ControllerCommand::validate_value`.
+///  3. Add any necessary parent process logic for the command to
+///    `GooseAttack::handle_controller_requests` (also in this file).
 #[derive(Clone, Debug, EnumIter, PartialEq)]
 pub enum ControllerCommand {
+    /// Displays a list of all commands supported by the Controller.
+    ///
+    /// # Example
+    /// Returns the a list of all supported Controller commands.
+    /// ```notest
+    /// help
+    /// ```
+    ///
+    /// This command can be run at any time.
+    Help,
+    /// Disconnect from the Controller.
+    ///
+    /// # Example
+    /// Disconnects from the Controller.
+    /// ```notest
+    /// exit
+    /// ```
+    ///
+    /// This command can be run at any time.
+    Exit,
+    /// Start an idle test.
+    ///
+    /// # Example
+    /// Starts an idle load test.
+    /// ```notest
+    /// start
+    /// ```
+    ///
+    /// Goose must be idle to process this command.
+    Start,
+    /// Stop a running test, putting it into an idle state.
+    ///
+    /// # Example
+    /// Stops a running (or stating) load test.
+    /// ```notest
+    /// stop
+    /// ```
+    ///
+    /// Goose must be running (or starting) to process this command.
+    Stop,
+    /// Tell the load test to shut down (which will disconnect the controller).
+    ///
+    /// # Example
+    /// Terminates the Goose process, cleanly shutting down the load test if running.
+    /// ```notest
+    /// shutdown
+    /// ```
+    ///
+    /// Goose can process this command at any time.
+    Shutdown,
+    /// Configure the host to load test.
+    ///
+    /// # Example
+    /// Tells Goose to generate load against <http://example.com/>.
+    /// ```notest
+    /// host http://example.com/
+    /// ```
+    ///
+    /// Goose must be idle to process this command.
+    Host,
+    /// Configure how quickly new [`GooseUser`](../goose/struct.GooseUser.html)s are launched.
+    ///
+    /// # Example
+    /// Tells Goose to launch a new user every 1.25 seconds.
+    /// ```notest
+    /// hatchrate 1.25
+    /// ```
+    ///
+    /// Goose can be idle or running when processing this command.
+    HatchRate,
+    /// Configure how long to take to launch all [`GooseUser`](../goose/struct.GooseUser.html)s.
+    ///
+    /// # Example
+    /// Tells Goose to launch a new user every 1.25 seconds.
+    /// ```notest
+    /// startuptime 1.25
+    /// ```
+    ///
+    /// Goose must be idle to process this command.
+    StartupTime,
+    /// Configure how many [`GooseUser`](../goose/struct.GooseUser.html)s to launch.
+    ///
+    /// # Example
+    /// Tells Goose to simulate 100 concurrent users.
+    /// ```notest
+    /// users 100
+    /// ```
+    ///
+    /// Can be configured on an idle or running load test.
+    Users,
+    /// Configure how long the load test should run before stopping and returning to an idle state.
+    ///
+    /// # Example
+    /// Tells Goose to run the load test for 1 minute, before automatically stopping.
+    /// ```notest
+    /// runtime 60
+    /// ```
+    ///
+    /// This can be configured when Goose is idle as well as when a Goose load test is running.
+    RunTime,
     /// Display the current [`GooseConfiguration`](../struct.GooseConfiguration.html)s.
     ///
     /// # Example
@@ -73,46 +160,6 @@ pub enum ControllerCommand {
     ///
     /// This command can be run at any time.
     ConfigJson,
-    /// Disconnect from the Controller.
-    ///
-    /// # Example
-    /// Disconnects from the Controller.
-    /// ```notest
-    /// exit
-    /// ```
-    ///
-    /// This command can be run at any time.
-    Exit,
-    /// Configure how quickly new [`GooseUser`](../goose/struct.GooseUser.html)s are launched.
-    ///
-    /// # Example
-    /// Tells Goose to launch a new user every 1.25 seconds.
-    /// ```notest
-    /// hatchrate 1.25
-    /// ```
-    ///
-    /// Goose can be idle or running when processing this command.
-    HatchRate,
-    /// Displays a list of all commands supported by the Controller.
-    ///
-    /// # Example
-    /// Returns the a list of all supported Controller commands.
-    /// ```notest
-    /// help
-    /// ```
-    ///
-    /// This command can be run at any time.
-    Help,
-    /// Configure the host to load test.
-    ///
-    /// # Example
-    /// Tells Goose to generate load against <http://example.com/>.
-    /// ```notest
-    /// host http://example.com/
-    /// ```
-    ///
-    /// Goose must be idle to process this command.
-    Host,
     /// Display the current [`GooseMetric`](../metrics/struct.GooseMetrics.html)s.
     ///
     /// # Example
@@ -133,154 +180,120 @@ pub enum ControllerCommand {
     ///
     /// This command can be run at any time.
     MetricsJson,
-    /// Configure how long the load test should run before stopping and returning to an idle state.
-    ///
-    /// # Example
-    /// Tells Goose to run the load test for 1 minute, before automatically stopping.
-    /// ```notest
-    /// runtime 60
-    /// ```
-    ///
-    /// This can be configured when Goose is idle as well as when a Goose load test is running.
-    RunTime,
-    /// Tell the load test to shut down (which will disconnect the controller).
-    ///
-    /// # Example
-    /// Terminates the Goose process, cleanly shutting down the load test if running.
-    /// ```notest
-    /// shutdown
-    /// ```
-    ///
-    /// Goose can process this command at any time.
-    Shutdown,
-    /// Start an idle test.
-    ///
-    /// # Example
-    /// Starts an idle load test.
-    /// ```notest
-    /// start
-    /// ```
-    ///
-    /// Goose must be idle to process this command.
-    Start,
-    /// Configure how long to take to launch all [`GooseUser`](../goose/struct.GooseUser.html)s.
-    ///
-    /// # Example
-    /// Tells Goose to launch a new user every 1.25 seconds.
-    /// ```notest
-    /// startuptime 1.25
-    /// ```
-    ///
-    /// Goose must be idle to process this command.
-    StartupTime,
-    /// Stop a running test, putting it into an idle state.
-    ///
-    /// # Example
-    /// Stops a running (or stating) load test.
-    /// ```notest
-    /// stop
-    /// ```
-    ///
-    /// Goose must be running (or starting) to process this command.
-    Stop,
-    /// Configure how many [`GooseUser`](../goose/struct.GooseUser.html)s to launch.
-    ///
-    /// # Example
-    /// Tells Goose to simulate 100 concurrent users.
-    /// ```notest
-    /// users 100
-    /// ```
-    ///
-    /// Can be configured on an idle or running load test.
-    Users,
 }
 
+/// Defines details around identifying and processing ControllerCommands.
 impl ControllerCommand {
+    /// Each ControllerCommand must define complete ControllerCommentDetails.
+    ///  - `help` returns a ControllerHelp struct that is used to provide inline help.
+    ///  - `regex` returns an &str defining the regular expression used to match the command
+    ///    (and optionally to grab a value being set).
+    ///  - `process_response` contains a boxed closure that receives the parent process
+    ///    response to the command and responds to the controller appropriately.
     fn details(&self) -> ControllerCommandDetails {
         match self {
-            ControllerCommand::Config => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^config$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Config(config) = response {
-                            Ok(format!("{:#?}", config))
-                        } else {
-                            Err("error loading configuration".to_string())
-                        }
-                    }),
-                }
-            }
-            ControllerCommand::ConfigJson => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^(configjson|config-json)$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Config(config) = response {
-                            Ok(serde_json::to_string(&config).expect("unexpected serde failure"))
-                        } else {
-                            Err("error loading configuration".to_string())
-                        }
-                    }),
-                }
-            }
-            ControllerCommand::Exit => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^(exit|quit)$".to_string(),
-                    process_response: Box::new(|_| {
-                        let e = "received an impossible EXIT command";
-                        error!("{}", e);
-                        Err(e.to_string())
-                    }),
-                }
-            }
-            ControllerCommand::HatchRate => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^(hatchrate|hatch_rate|hatch-rate) ([0-9]*(\.[0-9]*)?){1}$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Bool(true) = response {
-                            Ok("hatch_rate configured".to_string())
-                        } else {
-                            Err("failed to configure hatch_rate".to_string())
-                        }
-                    }),
-                }
-            }
-            ControllerCommand::Help => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^(help|\?)$".to_string(),
-                    process_response: Box::new(|_| {
-                        let e = "received an impossible HELP command";
-                        error!("{}", e);
-                        Err(e.to_string())
-                    }),
-                }
-            }
-            ControllerCommand::Host => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^(host|hostname|host_name|host-name) ((https?)://.+)$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Bool(true) = response {
-                            Ok("host configured".to_string())
-                        } else {
-                            Err("failed to reconfigure host, be sure host is valid and load test is idle".to_string())
-                        }
-                    }),
-                }
-            }
-            ControllerCommand::Metrics => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^(metrics|stats)$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Metrics(metrics) = response {
-                            Ok(metrics.to_string())
-                        } else {
-                            Err("error loading metrics".to_string())
-                        }
-                    }),
-                }
-            }
+            ControllerCommand::Config => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "config",
+                    description: "display load test configuration\n",
+                },
+                regex: r"(?i)^config$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Config(config) = response {
+                        Ok(format!("{:#?}", config))
+                    } else {
+                        Err("error loading configuration".to_string())
+                    }
+                }),
+            },
+            ControllerCommand::ConfigJson => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "config-json",
+                    description: "display load test configuration in json format\n",
+                },
+                regex: r"(?i)^(configjson|config-json)$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Config(config) = response {
+                        Ok(serde_json::to_string(&config).expect("unexpected serde failure"))
+                    } else {
+                        Err("error loading configuration".to_string())
+                    }
+                }),
+            },
+            ControllerCommand::Exit => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "exit",
+                    description: "exit controller\n\n",
+                },
+                regex: r"(?i)^(exit|quit|q)$",
+                process_response: Box::new(|_| {
+                    let e = "received an impossible EXIT command";
+                    error!("{}", e);
+                    Err(e.to_string())
+                }),
+            },
+            ControllerCommand::HatchRate => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "hatchrate FLOAT",
+                    description: "set per-second rate users hatch\n",
+                },
+                regex: r"(?i)^(hatchrate|hatch_rate|hatch-rate) ([0-9]*(\.[0-9]*)?){1}$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Bool(true) = response {
+                        Ok("hatch_rate configured".to_string())
+                    } else {
+                        Err("failed to configure hatch_rate".to_string())
+                    }
+                }),
+            },
+            ControllerCommand::Help => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "help",
+                    description: "this help\n",
+                },
+                regex: r"(?i)^(help|\?)$",
+                process_response: Box::new(|_| {
+                    let e = "received an impossible HELP command";
+                    error!("{}", e);
+                    Err(e.to_string())
+                }),
+            },
+            ControllerCommand::Host => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "host HOST",
+                    description: "set host to load test, ie https://web.site/\n",
+                },
+                regex: r"(?i)^(host|hostname|host_name|host-name) ((https?)://.+)$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Bool(true) = response {
+                        Ok("host configured".to_string())
+                    } else {
+                        Err("failed to reconfigure host, be sure host is valid and load test is idle".to_string())
+                    }
+                }),
+            },
+            ControllerCommand::Metrics => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "metrics",
+                    description: "display metrics for current load test\n",
+                },
+                regex: r"(?i)^(metrics|stats)$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Metrics(metrics) = response {
+                        Ok(metrics.to_string())
+                    } else {
+                        Err("error loading metrics".to_string())
+                    }
+                }),
+            },
             ControllerCommand::MetricsJson => {
                 ControllerCommandDetails {
-                    regex: r"(?i)^(metricsjson|metrics-json|statsjson|stats-json)$".to_string(),
+                    help: ControllerHelp {
+                        name: "metrics-json",
+                        // No new-line as this is the last line of the help screen.
+                        description: "display metrics for current load test in json format",
+                    },
+                    regex: r"(?i)^(metricsjson|metrics-json|statsjson|stats-json)$",
                     process_response: Box::new(|response| {
                         if let ControllerResponseMessage::Metrics(metrics) = response {
                             Ok(serde_json::to_string(&metrics).expect("unexpected serde failure"))
@@ -290,33 +303,41 @@ impl ControllerCommand {
                     }),
                 }
             }
-            ControllerCommand::RunTime => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^(run|runtime|run_time|run-time|) (\d+|((\d+?)h)?((\d+?)m)?((\d+?)s)?)$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Bool(true) = response {
-                            Ok("run_time configured".to_string())
-                        } else {
-                            Err("failed to configure run_time".to_string())
-                        }
-                    }),
-                }
-            }
-            ControllerCommand::Shutdown => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^shutdown$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Bool(true) = response {
-                            Ok("load test shut down".to_string())
-                        } else {
-                            Err("failed to shut down load test".to_string())
-                        }
-                    }),
-                }
-            }
+            ControllerCommand::RunTime => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "runtime TIME",
+                    description: "set how long to run test, ie 1h30m5s\n\n",
+                },
+                regex: r"(?i)^(run|runtime|run_time|run-time|) (\d+|((\d+?)h)?((\d+?)m)?((\d+?)s)?)$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Bool(true) = response {
+                        Ok("run_time configured".to_string())
+                    } else {
+                        Err("failed to configure run_time".to_string())
+                    }
+                }),
+            },
+            ControllerCommand::Shutdown => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "shutdown",
+                    description: "shutdown load test and exit controller\n\n",
+                },
+                regex: r"(?i)^shutdown$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Bool(true) = response {
+                        Ok("load test shut down".to_string())
+                    } else {
+                        Err("failed to shut down load test".to_string())
+                    }
+                }),
+            },
             ControllerCommand::Start => {
                 ControllerCommandDetails {
-                    regex: r"(?i)^start$".to_string(),
+                    help: ControllerHelp {
+                        name: "start",
+                        description: "start an idle load test\n",
+                    },
+                    regex: r"(?i)^start$",
                     process_response: Box::new(|response| {
                         if let ControllerResponseMessage::Bool(true) = response {
                             Ok("load test started".to_string())
@@ -326,789 +347,112 @@ impl ControllerCommand {
                     }),
                 }
             }
-            ControllerCommand::StartupTime => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^(starttime|start_time|start-time|startup|startuptime|startup_time|startup-time) (\d+|((\d+?)h)?((\d+?)m)?((\d+?)s)?)$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Bool(true) = response {
-                            Ok("startup_time configured".to_string())
-                        } else {
-                            Err("failed to configure startup_time, be sure load test is idle".to_string())
-                        }
-                    }),
-                }
-            }
-            ControllerCommand::Stop => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^stop$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Bool(true) = response {
-                            Ok("load test stopped".to_string())
-                        } else {
-                            Err("load test not running, failed to stop".to_string())
-                        }
-                    }),
-                }
-            }
-            ControllerCommand::Users => {
-                ControllerCommandDetails {
-                    regex: r"(?i)^(users?) (\d+)$".to_string(),
-                    process_response: Box::new(|response| {
-                        if let ControllerResponseMessage::Bool(true) = response {
-                            Ok("users configured".to_string())
-                        } else {
-                            Err("load test not idle, failed to reconfigure users".to_string())
-                        }
-                    }),
-                }
-            }
+            ControllerCommand::StartupTime => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "startup-time TIME",
+                    description: "set total time to take starting users\n",
+                },
+                regex: r"(?i)^(starttime|start_time|start-time|startup|startuptime|startup_time|startup-time) (\d+|((\d+?)h)?((\d+?)m)?((\d+?)s)?)$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Bool(true) = response {
+                        Ok("startup_time configured".to_string())
+                    } else {
+                        Err(
+                            "failed to configure startup_time, be sure load test is idle"
+                                .to_string(),
+                        )
+                    }
+                }),
+            },
+            ControllerCommand::Stop => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "stop",
+                    description: "stop a running load test and return to idle state\n",
+                },
+                regex: r"(?i)^stop$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Bool(true) = response {
+                        Ok("load test stopped".to_string())
+                    } else {
+                        Err("load test not running, failed to stop".to_string())
+                    }
+                }),
+            },
+            ControllerCommand::Users => ControllerCommandDetails {
+                help: ControllerHelp {
+                    name: "users INT",
+                    description: "set number of simulated users\n",
+                },
+                regex: r"(?i)^(users?) (\d+)$",
+                process_response: Box::new(|response| {
+                    if let ControllerResponseMessage::Bool(true) = response {
+                        Ok("users configured".to_string())
+                    } else {
+                        Err("load test not idle, failed to reconfigure users".to_string())
+                    }
+                }),
+            },
         }
     }
 
+    // Optionally perform validation beyond what is possible with a regular expression.
+    //
+    // Return Some(value) if the value is valid, otherwise return None.
+    fn validate_value(&self, value: &str) -> Option<String> {
+        // The Regex that captures the host only validates that the host starts with
+        // http:// or https://. Now use a library to properly validate that this is
+        // a valid host before sending to the parent process.
+        if self == &ControllerCommand::Host {
+            if util::is_valid_host(value).is_ok() {
+                Some(value.to_string())
+            } else {
+                None
+            }
+        } else if value.is_empty() {
+            None
+        } else {
+            Some(value.to_string())
+        }
+    }
+
+    // If the regular expression that matches this command also matches a value, get and validate
+    // the value.
+    //
+    // Returns Some(value) if the value is valid, otherwise returns None.
     fn get_value(&self, command_string: &str) -> Option<String> {
-        let regex = Regex::new(&self.details().regex)
+        let regex = Regex::new(self.details().regex)
             .expect("ControllerCommand::details().regex returned invalid regex [2]");
         let caps = regex.captures(command_string).unwrap();
         let value = caps.get(2).map_or("", |m| m.as_str());
-        if value.is_empty() {
-            None
-        } else {
-            // The Regex that captures the host only validates that the host starts with
-            // http:// or https://. Now use a library to properly validate that this is
-            // a valid host before sending to the parent process.
-            if self == &ControllerCommand::Host {
-                if util::is_valid_host(value).is_ok() {
-                    Some(value.to_string())
-                } else {
-                    None
-                }
-            // All other Regex that capture values can simply return the value without
-            // additional validation.
-            } else {
-                Some(value.to_string())
-            }
+        self.validate_value(value)
+    }
+
+    // Builds a help screen displayed when a controller receives the `help` command.
+    fn display_help() -> String {
+        let mut help_text = Vec::new();
+        writeln!(
+            &mut help_text,
+            "{} {} controller commands:",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION")
+        )
+        .expect("failed to write to buffer");
+        // Builds help screen in the order commands are defined in the ControllerCommand enum.
+        for command in ControllerCommand::iter() {
+            write!(
+                &mut help_text,
+                "{:<18} {}",
+                command.details().help.name,
+                command.details().help.description
+            )
+            .expect("failed to write to buffer");
         }
+        String::from_utf8(help_text).expect("invalid utf-8 in help text")
     }
-}
-
-/// Implement [`FromStr`] to convert controller commands and optional values to the proper enum
-/// representation.
-impl FromStr for ControllerCommand {
-    type Err = GooseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Load all ControllerCommand regex into a set.
-        let mut regex_set: Vec<String> = Vec::new();
-        let mut keys = Vec::new();
-        for t in ControllerCommand::iter() {
-            keys.push(t.clone());
-            regex_set.push(t.details().regex);
-        }
-        let commands = RegexSet::new(regex_set)
-            .expect("ControllerCommand::details().regex returned invalid regex");
-        let matches: Vec<_> = commands.matches(s).into_iter().collect();
-        // This happens any time the controller receives an invalid command.
-        if matches.is_empty() {
-            return Err(GooseError::InvalidControllerCommand {
-                detail: format!("unrecognized controller command: '{}'.", s),
-            });
-        // This shouldn't ever happen, but if it does report all available information.
-        } else if matches.len() > 1 {
-            let mut matched_commands = Vec::new();
-            for index in matches {
-                matched_commands.push(keys[index].clone())
-            }
-            return Err(GooseError::InvalidControllerCommand {
-                detail: format!(
-                    "matched multiple controller commands: '{}' ({:?}).",
-                    s, matched_commands
-                ),
-            });
-        // Only one command matched.
-        } else {
-            Ok(keys[*matches.first().unwrap()].clone())
-        }
-    }
-}
-
-/// This structure is used to send commands and values to the parent process.
-#[derive(Debug)]
-pub(crate) struct ControllerRequestMessage {
-    /// The command that is being sent to the parent.
-    pub command: ControllerCommand,
-    /// An optional value that is being sent to the parent.
-    pub value: Option<String>,
-}
-
-/// An enumeration of all messages the parent can reply back to the controller thread.
-#[derive(Debug)]
-pub(crate) enum ControllerResponseMessage {
-    /// A response containing a boolean value.
-    Bool(bool),
-    /// A response containing the load test configuration.
-    Config(Box<GooseConfiguration>),
-    /// A response containing current load test metrics.
-    Metrics(Box<GooseMetrics>),
-}
-
-/// The request that's passed from the controller to the parent thread.
-#[derive(Debug)]
-pub(crate) struct ControllerRequest {
-    /// Optional one-shot channel if a reply is required.
-    pub response_channel: Option<tokio::sync::oneshot::Sender<ControllerResponse>>,
-    /// An integer identifying which controller client is making the request.
-    pub client_id: u32,
-    /// The actual request message.
-    pub request: ControllerRequestMessage,
-}
-
-/// The response that's passed from the parent to the controller.
-#[derive(Debug)]
-pub(crate) struct ControllerResponse {
-    /// An integer identifying which controller the parent is responding to.
-    pub _client_id: u32,
-    /// The actual response message.
-    pub response: ControllerResponseMessage,
-}
-
-/// This structure defines the required json format of any request sent to the WebSocket
-/// Controller.
-///
-/// Requests must be made in the following format:
-/// ```json
-/// {
-///     "request": String,
-/// }
-///
-/// ```
-///
-/// The request "String" value must be a valid
-/// [`ControllerCommand`](./enum.ControllerCommand.html).
-///
-/// # Example
-/// The following request will shut down the load test:
-/// ```json
-/// {
-///     "request": "shutdown",
-/// }
-/// ```
-///
-/// Responses will be formatted as defined in
-/// [ControllerWebSocketResponse](./struct.ControllerWebSocketResponse.html).
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ControllerWebSocketRequest {
-    /// A valid command string.
-    pub request: String,
-}
-
-/// This structure defines the json format of any response returned from the WebSocket
-/// Controller.
-///
-/// Responses are in the following format:
-/// ```json
-/// {
-///     "response": String,
-///     "success": bool,
-/// }
-/// ```
-///
-/// # Example
-/// The following response will be returned when a request is made to shut down the
-/// load test:
-/// ```json
-/// {
-///     "response": "load test shut down",
-///     "success": true
-/// }
-/// ```
-///
-/// Requests must be formatted as defined in
-/// [ControllerWebSocketRequest](./struct.ControllerWebSocketRequest.html).
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ControllerWebSocketResponse {
-    /// The response from the controller.
-    pub response: String,
-    /// Whether the request was successful or not.
-    pub success: bool,
-}
-
-/// Return type to indicate whether or not to exit the Controller thread.
-type ControllerExit = bool;
-
-/// The telnet Controller message buffer.
-type ControllerTelnetMessage = [u8; 1024];
-
-/// The WebSocket Controller message buffer.
-type ControllerWebSocketMessage = std::result::Result<
-    tokio_tungstenite::tungstenite::Message,
-    tokio_tungstenite::tungstenite::Error,
->;
-
-/// Simplify the ControllerExecuteCommand trait definition for WebSockets.
-type ControllerWebSocketSender = futures::stream::SplitSink<
-    tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
-    tokio_tungstenite::tungstenite::Message,
->;
-
-/// This state object is created in the main Controller thread and then passed to the specific
-/// per-client thread.
-pub(crate) struct ControllerState {
-    /// Track which controller-thread this is.
-    thread_id: u32,
-    /// Track the ip and port of the connected TCP client.
-    peer_address: String,
-    /// A shared channel for communicating with the parent process.
-    channel_tx: flume::Sender<ControllerRequest>,
-    /// Which protocol this Controller understands.
-    protocol: ControllerProtocol,
-}
-// Defines functions shared by all Controllers.
-impl ControllerState {
-    async fn accept_connections(self, mut socket: tokio::net::TcpStream) {
-        info!(
-            "{:?} client [{}] connected from {}",
-            self.protocol, self.thread_id, self.peer_address
-        );
-        match self.protocol {
-            ControllerProtocol::Telnet => {
-                let mut buf: ControllerTelnetMessage = [0; 1024];
-
-                // Display initial goose> prompt.
-                write_to_socket_raw(&mut socket, "goose> ").await;
-
-                loop {
-                    // Process data received from the client in a loop.
-                    let n = match socket.read(&mut buf).await {
-                        Ok(data) => data,
-                        Err(_) => {
-                            info!(
-                                "Telnet client [{}] disconnected from {}",
-                                self.thread_id, self.peer_address
-                            );
-                            break;
-                        }
-                    };
-
-                    // Invalid request, exit.
-                    if n == 0 {
-                        info!(
-                            "Telnet client [{}] disconnected from {}",
-                            self.thread_id, self.peer_address
-                        );
-                        break;
-                    }
-
-                    // Extract the command string in a protocol-specific way.
-                    if let Ok(command_string) = self.get_command_string(buf).await {
-                        // Extract the command and value in a generic way.
-                        if let Ok(request_message) = self.get_match(command_string.trim()).await {
-                            // Act on the commmand received.
-                            if self.execute_command(&mut socket, request_message).await {
-                                // If execute_command returns true, it's time to exit.
-                                info!(
-                                    "Telnet client [{}] disconnected from {}",
-                                    self.thread_id, self.peer_address
-                                );
-                                break;
-                            }
-                        } else {
-                            self.write_to_socket(
-                                &mut socket,
-                                Err("unrecognized command".to_string()),
-                            )
-                            .await;
-                        }
-                    } else {
-                        // Corrupted request from telnet client, exit.
-                        info!(
-                            "Telnet client [{}] disconnected from {}",
-                            self.thread_id, self.peer_address
-                        );
-                        break;
-                    }
-                }
-            }
-            ControllerProtocol::WebSocket => {
-                let stream = match tokio_tungstenite::accept_async(socket).await {
-                    Ok(s) => s,
-                    Err(e) => {
-                        info!("invalid WebSocket handshake: {}", e);
-                        return;
-                    }
-                };
-                let (mut ws_sender, mut ws_receiver) = stream.split();
-
-                loop {
-                    // Wait until the client sends a command.
-                    let data = match ws_receiver.next().await {
-                        Some(d) => (d),
-                        None => {
-                            // Returning with no data means the client disconnected.
-                            info!(
-                                "Telnet client [{}] disconnected from {}",
-                                self.thread_id, self.peer_address
-                            );
-                            break;
-                        }
-                    };
-
-                    // Extract the command string in a protocol-specific way.
-                    if let Ok(command_string) = self.get_command_string(data).await {
-                        // Extract the command and value in a generic way.
-                        if let Ok(request_message) = self.get_match(command_string.trim()).await {
-                            if self.execute_command(&mut ws_sender, request_message).await {
-                                // If execute_command() returns true, it's time to exit.
-                                info!(
-                                    "Telnet client [{}] disconnected from {}",
-                                    self.thread_id, self.peer_address
-                                );
-                                break;
-                            }
-                        } else {
-                            self.write_to_socket(
-                                &mut ws_sender,
-                                Err("unrecognized command, see Goose README.md".to_string()),
-                            )
-                            .await;
-                        }
-                    } else {
-                        self.write_to_socket(
-                            &mut ws_sender,
-                            Err("unable to parse json, see Goose README.md".to_string()),
-                        )
-                        .await;
-                    }
-                }
-            }
-        }
-    }
-
-    // Both Controllers use a common function to identify commands.
-    async fn get_match(
-        &self,
-        command_string: &str,
-    ) -> Result<ControllerRequestMessage, GooseError> {
-        // Use FromStr to convert &str to ControllerCommand.
-        let command: ControllerCommand = ControllerCommand::from_str(command_string)?;
-        // Extract value if there is one, otherwise will be None.
-        let value: Option<String> = command.get_value(command_string);
-
-        Ok(ControllerRequestMessage { command, value })
-    }
-
-    /// Process a request entirely within the Controller thread, without sending a message
-    /// to the parent thread.
-    fn process_local_command(&self, request_message: &ControllerRequestMessage) -> Option<String> {
-        match request_message.command {
-            ControllerCommand::Help => Some(display_help()),
-            ControllerCommand::Exit => Some("goodbye!".to_string()),
-            // All other commands require sending the request to the parent thread.
-            _ => None,
-        }
-    }
-
-    /// Send a message to parent thread, with or without an optional value, and wait for
-    /// a reply.
-    async fn process_command(
-        &self,
-        request: ControllerRequestMessage,
-    ) -> Result<ControllerResponseMessage, String> {
-        // Create a one-shot channel to allow the parent to reply to our request. As flume
-        // doesn't implement a one-shot channel, we use tokio for this temporary channel.
-        let (response_tx, response_rx): (
-            tokio::sync::oneshot::Sender<ControllerResponse>,
-            tokio::sync::oneshot::Receiver<ControllerResponse>,
-        ) = tokio::sync::oneshot::channel();
-
-        if self
-            .channel_tx
-            .try_send(ControllerRequest {
-                response_channel: Some(response_tx),
-                client_id: self.thread_id,
-                request,
-            })
-            .is_err()
-        {
-            return Err("parent process has closed the controller channel".to_string());
-        }
-
-        // Await response from parent.
-        match response_rx.await {
-            Ok(value) => Ok(value.response),
-            Err(e) => Err(format!("one-shot channel dropped without reply: {}", e)),
-        }
-    }
-}
-
-/// Controller-protocol-specific functions, necessary to manage the different way each
-/// Controller protocol communicates with a client.
-#[async_trait]
-trait Controller<T> {
-    // Extract the command string from a Controller client request.
-    async fn get_command_string(&self, raw_value: T) -> Result<String, String>;
-}
-#[async_trait]
-impl Controller<ControllerTelnetMessage> for ControllerState {
-    // Extract the command string from a telnet Controller client request.
-    async fn get_command_string(
-        &self,
-        raw_value: ControllerTelnetMessage,
-    ) -> Result<String, String> {
-        let command_string = match str::from_utf8(&raw_value) {
-            Ok(m) => {
-                if let Some(c) = m.lines().next() {
-                    c
-                } else {
-                    ""
-                }
-            }
-            Err(e) => {
-                let error = format!("ignoring unexpected input from telnet controller: {}", e);
-                info!("{}", error);
-                return Err(error);
-            }
-        };
-
-        Ok(command_string.to_string())
-    }
-}
-#[async_trait]
-impl Controller<ControllerWebSocketMessage> for ControllerState {
-    // Extract the command string from a WebSocket Controller client request.
-    async fn get_command_string(
-        &self,
-        raw_value: ControllerWebSocketMessage,
-    ) -> Result<String, String> {
-        if let Ok(request) = raw_value {
-            if request.is_text() {
-                if let Ok(request) = request.into_text() {
-                    debug!("websocket request: {:?}", request.trim());
-                    let command_string: ControllerWebSocketRequest =
-                        match serde_json::from_str(&request) {
-                            Ok(c) => c,
-                            Err(_) => {
-                                return Err("unrecognized json request, refer to Goose README.md"
-                                    .to_string())
-                            }
-                        };
-                    return Ok(command_string.request);
-                } else {
-                    // Failed to consume the WebSocket message and convert it to a String.
-                    return Err("unsupported string format".to_string());
-                }
-            } else {
-                // Received a non-text WebSocket message.
-                return Err("unsupported format, requests must be sent as text".to_string());
-            }
-        }
-        // Improper WebSocket handshake.
-        Err("WebSocket handshake error".to_string())
-    }
-}
-#[async_trait]
-trait ControllerExecuteCommand<T> {
-    // Run the command received from a Controller request. Returns a boolean, if true exit.
-    async fn execute_command(
-        &self,
-        socket: &mut T,
-        request_message: ControllerRequestMessage,
-    ) -> ControllerExit;
-
-    // Send response to Controller client. The response is wrapped in a Result to indicate
-    // if the request was successful or not.
-    async fn write_to_socket(&self, socket: &mut T, response_message: Result<String, String>);
-}
-#[async_trait]
-impl ControllerExecuteCommand<tokio::net::TcpStream> for ControllerState {
-    // Run the command received from a telnet Controller request.
-    async fn execute_command(
-        &self,
-        socket: &mut tokio::net::TcpStream,
-        request_message: ControllerRequestMessage,
-    ) -> ControllerExit {
-        // First handle commands that don't require interaction with the parent process.
-        if let Some(message) = self.process_local_command(&request_message) {
-            self.write_to_socket(socket, Ok(message)).await;
-            // If Exit was received return true to exit, otherwise return false.
-            return request_message.command == ControllerCommand::Exit;
-        }
-
-        // Retain a copy of the command used when processing the parent response.
-        let command = request_message.command.clone();
-
-        // Now handle commands that require interaction with the parent process.
-        let response = match self.process_command(request_message).await {
-            Ok(r) => r,
-            Err(e) => {
-                // Receiving an error here means the parent closed the communication
-                // channel. Write the error to the Controller client and then return
-                // true to exit.
-                self.write_to_socket(socket, Err(e)).await;
-                return true;
-            }
-        };
-
-        // If Shutdown command was received return true to exit, otherwise return false.
-        let exit_controller = command == ControllerCommand::Shutdown;
-
-        // Write the response to the Controller client socket.
-        let processed_response = (command.details().process_response)(response);
-        self.write_to_socket(socket, processed_response).await;
-
-        // Return true if it's time to exit the Controller.
-        exit_controller
-    }
-
-    // Send response to telnet Controller client.
-    async fn write_to_socket(
-        &self,
-        socket: &mut tokio::net::TcpStream,
-        message: Result<String, String>,
-    ) {
-        // Send result to telnet Controller client, whether Ok() or Err().
-        let response_message = match message {
-            Ok(m) => m,
-            Err(e) => e,
-        };
-        if socket
-            // Add a linefeed to the end of the message, followed by a prompt.
-            .write_all([&response_message, "\ngoose> "].concat().as_bytes())
-            .await
-            .is_err()
-        {
-            warn!("failed to write data to socker");
-        };
-    }
-}
-#[async_trait]
-impl ControllerExecuteCommand<ControllerWebSocketSender> for ControllerState {
-    // Run the command received from a WebSocket Controller request.
-    async fn execute_command(
-        &self,
-        socket: &mut ControllerWebSocketSender,
-        request_message: ControllerRequestMessage,
-    ) -> ControllerExit {
-        // First handle commands that don't require interaction with the parent process.
-        if let Some(message) = self.process_local_command(&request_message) {
-            self.write_to_socket(socket, Ok(message)).await;
-
-            // If Exit was received return true to exit, otherwise return false.
-            let exit_controller = request_message.command == ControllerCommand::Exit;
-            // If exiting, notify the WebSocket client that this connection is closing.
-            if exit_controller
-                && socket
-                    .send(Message::Close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
-                        code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Normal,
-                        reason: std::borrow::Cow::Borrowed("exit"),
-                    })))
-                    .await
-                    .is_err()
-            {
-                warn!("failed to write data to stream");
-            }
-
-            return exit_controller;
-        }
-
-        // WebSocket Controller always returns JSON, convert command where necessary.
-        let command = match request_message.command {
-            ControllerCommand::Config => ControllerCommand::ConfigJson,
-            ControllerCommand::Metrics => ControllerCommand::MetricsJson,
-            _ => request_message.command.clone(),
-        };
-
-        // Now handle commands that require interaction with the parent process.
-        let response = match self.process_command(request_message).await {
-            Ok(r) => r,
-            Err(e) => {
-                // Receiving an error here means the parent closed the communication
-                // channel. Write the error to the Controller client and then return
-                // true to exit.
-                self.write_to_socket(socket, Err(e)).await;
-                return true;
-            }
-        };
-
-        // If Shutdown command was received return true to exit, otherwise return false.
-        let exit_controller = command == ControllerCommand::Shutdown;
-
-        // Write the response to the Controller client socket.
-        let processed_response = (command.details().process_response)(response);
-        self.write_to_socket(socket, processed_response).await;
-
-        // If exiting, notify the WebSocket client that this connection is closing.
-        if exit_controller
-            && socket
-                .send(Message::Close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
-                    code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Normal,
-                    reason: std::borrow::Cow::Borrowed("shutdown"),
-                })))
-                .await
-                .is_err()
-        {
-            warn!("failed to write data to stream");
-        }
-
-        // Return true if it's time to exit the Controller.
-        exit_controller
-    }
-
-    // Send a json-formatted response to the WebSocket.
-    async fn write_to_socket(
-        &self,
-        socket: &mut ControllerWebSocketSender,
-        response_result: Result<String, String>,
-    ) {
-        let success;
-        let response = match response_result {
-            Ok(m) => {
-                success = true;
-                m
-            }
-            Err(e) => {
-                success = false;
-                e
-            }
-        };
-        if let Err(e) = socket
-            .send(Message::Text(
-                match serde_json::to_string(&ControllerWebSocketResponse {
-                    response,
-                    // Success is true if there is no error, false if there is an error.
-                    success,
-                }) {
-                    Ok(json) => json,
-                    Err(e) => {
-                        warn!("failed to json encode response: {}", e);
-                        return;
-                    }
-                },
-            ))
-            .await
-        {
-            info!("failed to write data to websocket: {}", e);
-        }
-    }
-}
-
-/// The control loop listens for connections on the configured TCP port. Each connection
-/// spawns a new thread so multiple clients can connect. Handles incoming connections for
-/// both telnet and WebSocket clients.
-///  -  @TODO: optionally limit how many controller connections are allowed
-///  -  @TODO: optionally require client authentication
-///  -  @TODO: optionally ssl-encrypt client communication
-pub(crate) async fn controller_main(
-    // Expose load test configuration to controller thread.
-    configuration: GooseConfiguration,
-    // For sending requests to the parent process.
-    channel_tx: flume::Sender<ControllerRequest>,
-    // Which type of controller to launch.
-    protocol: ControllerProtocol,
-) -> io::Result<()> {
-    // Build protocol-appropriate address.
-    let address = match &protocol {
-        ControllerProtocol::Telnet => format!(
-            "{}:{}",
-            configuration.telnet_host, configuration.telnet_port
-        ),
-        ControllerProtocol::WebSocket => format!(
-            "{}:{}",
-            configuration.websocket_host, configuration.websocket_port
-        ),
-    };
-
-    // All controllers use a TcpListener port.
-    debug!(
-        "preparing to bind {:?} controller to: {}",
-        protocol, address
-    );
-    let listener = TcpListener::bind(&address).await?;
-    info!("{:?} controller listening on: {}", protocol, address);
-
-    // Counter increments each time a controller client connects with this protocol.
-    let mut thread_id: u32 = 0;
-
-    // Wait for a connection.
-    while let Ok((stream, _)) = listener.accept().await {
-        thread_id += 1;
-
-        // Identify the client ip and port, used primarily for debug logging.
-        let peer_address = stream
-            .peer_addr()
-            .map_or("UNKNOWN ADDRESS".to_string(), |p| p.to_string());
-
-        // Create a per-client Controller state.
-        let controller_state = ControllerState {
-            thread_id,
-            peer_address,
-            channel_tx: channel_tx.clone(),
-            protocol: protocol.clone(),
-        };
-
-        // Spawn a new thread to communicate with a client. The returned JoinHandle is
-        // ignored as the thread simply runs until the client exits or Goose shuts down.
-        let _ = tokio::spawn(controller_state.accept_connections(stream));
-    }
-
-    Ok(())
-}
-
-/// Send a message to the client TcpStream, no prompt or line feed.
-async fn write_to_socket_raw(socket: &mut tokio::net::TcpStream, message: &str) {
-    if socket
-        // Add a linefeed to the end of the message.
-        .write_all(message.as_bytes())
-        .await
-        .is_err()
-    {
-        warn!("failed to write data to socket");
-    }
-}
-
-// A controller help screen.
-fn display_help() -> String {
-    format!(
-        r"{} {} controller commands:
- help (?)           this help
- exit (quit)        exit controller
- start              start an idle load test
- stop               stop a running load test and return to idle state
- shutdown           shutdown running load test (and exit controller)
- host HOST          set host to load test, ie http://localhost/
- users INT          set number of simulated users
- hatchrate FLOAT    set per-second rate users hatch
- startup-time TIME  set time to take starting users
- runtime TIME       set how long to run test, ie 1h30m5s
- config             display load test configuration
- config-json        display load test configuration in json format
- metrics            display metrics for current load test
- metrics-json       display metrics for current load test in json format",
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION")
-    )
 }
 
 /// The parent process side of the Controller functionality.
 impl GooseAttack {
-    /// Use the provided oneshot channel to reply to a controller client request.
-    pub(crate) fn reply_to_controller(
-        &mut self,
-        request: ControllerRequest,
-        response: ControllerResponseMessage,
-    ) {
-        if let Some(oneshot_tx) = request.response_channel {
-            if oneshot_tx
-                .send(ControllerResponse {
-                    _client_id: request.client_id,
-                    response,
-                })
-                .is_err()
-            {
-                warn!("failed to send response to controller via one-shot channel")
-            }
-        }
-    }
-
     /// Handle Controller requests.
     pub(crate) async fn handle_controller_requests(
         &mut self,
@@ -1455,5 +799,731 @@ impl GooseAttack {
             }
         };
         Ok(())
+    }
+
+    /// Use the provided oneshot channel to reply to a controller client request.
+    pub(crate) fn reply_to_controller(
+        &mut self,
+        request: ControllerRequest,
+        response: ControllerResponseMessage,
+    ) {
+        if let Some(oneshot_tx) = request.response_channel {
+            if oneshot_tx
+                .send(ControllerResponse {
+                    _client_id: request.client_id,
+                    response,
+                })
+                .is_err()
+            {
+                warn!("failed to send response to controller via one-shot channel")
+            }
+        }
+    }
+}
+
+/// The control loop listens for connections on the configured TCP port. Each connection
+/// spawns a new thread so multiple clients can connect. Handles incoming connections for
+/// both telnet and WebSocket clients.
+///  -  @TODO: optionally limit how many controller connections are allowed
+///  -  @TODO: optionally require client authentication
+///  -  @TODO: optionally ssl-encrypt client communication
+pub(crate) async fn controller_main(
+    // Expose load test configuration to controller thread.
+    configuration: GooseConfiguration,
+    // For sending requests to the parent process.
+    channel_tx: flume::Sender<ControllerRequest>,
+    // Which type of controller to launch.
+    protocol: ControllerProtocol,
+) -> io::Result<()> {
+    // Build protocol-appropriate address.
+    let address = match &protocol {
+        ControllerProtocol::Telnet => format!(
+            "{}:{}",
+            configuration.telnet_host, configuration.telnet_port
+        ),
+        ControllerProtocol::WebSocket => format!(
+            "{}:{}",
+            configuration.websocket_host, configuration.websocket_port
+        ),
+    };
+
+    // All controllers use a TcpListener port.
+    debug!(
+        "preparing to bind {:?} controller to: {}",
+        protocol, address
+    );
+    let listener = TcpListener::bind(&address).await?;
+    info!("{:?} controller listening on: {}", protocol, address);
+
+    // Counter increments each time a controller client connects with this protocol.
+    let mut thread_id: u32 = 0;
+
+    // Wait for a connection.
+    while let Ok((stream, _)) = listener.accept().await {
+        thread_id += 1;
+
+        // Identify the client ip and port, used primarily for debug logging.
+        let peer_address = stream
+            .peer_addr()
+            .map_or("UNKNOWN ADDRESS".to_string(), |p| p.to_string());
+
+        // Create a per-client Controller state.
+        let controller_state = ControllerState {
+            thread_id,
+            peer_address,
+            channel_tx: channel_tx.clone(),
+            protocol: protocol.clone(),
+        };
+
+        // Spawn a new thread to communicate with a client. The returned JoinHandle is
+        // ignored as the thread simply runs until the client exits or Goose shuts down.
+        let _ = tokio::spawn(controller_state.accept_connections(stream));
+    }
+
+    Ok(())
+}
+
+/// Implement [`FromStr`] to convert controller commands and optional values to the proper enum
+/// representation.
+impl FromStr for ControllerCommand {
+    type Err = GooseError;
+
+    // Use regular expressions to convert controller input to ControllerCommands.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Load all ControllerCommand regex into a set.
+        let mut regex_set: Vec<String> = Vec::new();
+        let mut keys = Vec::new();
+        for t in ControllerCommand::iter() {
+            keys.push(t.clone());
+            regex_set.push(t.details().regex.to_string());
+        }
+        let commands = RegexSet::new(regex_set)
+            .expect("ControllerCommand::details().regex returned invalid regex");
+        let matches: Vec<_> = commands.matches(s).into_iter().collect();
+        // This happens any time the controller receives an invalid command.
+        if matches.is_empty() {
+            return Err(GooseError::InvalidControllerCommand {
+                detail: format!("unrecognized controller command: '{}'.", s),
+            });
+        // This shouldn't ever happen, but if it does report all available information.
+        } else if matches.len() > 1 {
+            let mut matched_commands = Vec::new();
+            for index in matches {
+                matched_commands.push(keys[index].clone())
+            }
+            return Err(GooseError::InvalidControllerCommand {
+                detail: format!(
+                    "matched multiple controller commands: '{}' ({:?}).",
+                    s, matched_commands
+                ),
+            });
+        // Only one command matched.
+        } else {
+            Ok(keys[*matches.first().unwrap()].clone())
+        }
+    }
+}
+
+/// Send a message to the client TcpStream, no prompt or line feed.
+async fn write_to_socket_raw(socket: &mut tokio::net::TcpStream, message: &str) {
+    if socket
+        // Add a linefeed to the end of the message.
+        .write_all(message.as_bytes())
+        .await
+        .is_err()
+    {
+        warn!("failed to write data to socket");
+    }
+}
+
+/// Goose supports two different Controller protocols: telnet and WebSocket.
+#[derive(Clone, Debug)]
+pub(crate) enum ControllerProtocol {
+    /// Allows control of Goose via telnet.
+    Telnet,
+    /// Allows control of Goose via a WebSocket.
+    WebSocket,
+}
+
+/// All commands define their own ControllerHelp to create a help screen.
+#[derive(Clone, Debug)]
+pub(crate) struct ControllerHelp<'a> {
+    // The name of the controller command.
+    name: &'a str,
+    // A description of the contorller command.
+    description: &'a str,
+}
+
+/// Defines the regular expression used to identify a command and optionall the associated
+/// value, as well as the logic for letting the controller know whether or not the
+/// recognized command worked correctly.
+pub(crate) struct ControllerCommandDetails<'a> {
+    // The name and description of the controller command.
+    help: ControllerHelp<'a>,
+    // A [regular expression](https://docs.rs/regex/1.5.5/regex/struct.Regex.html) for
+    // matching the command and option value.
+    regex: &'a str,
+    // The response sent by the controller after handling the incoming controller
+    // request.
+    process_response: Box<dyn Fn(ControllerResponseMessage) -> Result<String, String>>,
+}
+
+/// This structure is used to send commands and values to the parent process.
+#[derive(Debug)]
+pub(crate) struct ControllerRequestMessage {
+    /// The command that is being sent to the parent.
+    pub command: ControllerCommand,
+    /// An optional value that is being sent to the parent.
+    pub value: Option<String>,
+}
+
+/// An enumeration of all messages the parent can reply back to the controller thread.
+#[derive(Debug)]
+pub(crate) enum ControllerResponseMessage {
+    /// A response containing a boolean value.
+    Bool(bool),
+    /// A response containing the load test configuration.
+    Config(Box<GooseConfiguration>),
+    /// A response containing current load test metrics.
+    Metrics(Box<GooseMetrics>),
+}
+
+/// The request that's passed from the controller to the parent thread.
+#[derive(Debug)]
+pub(crate) struct ControllerRequest {
+    /// Optional one-shot channel if a reply is required.
+    pub response_channel: Option<tokio::sync::oneshot::Sender<ControllerResponse>>,
+    /// An integer identifying which controller client is making the request.
+    pub client_id: u32,
+    /// The actual request message.
+    pub request: ControllerRequestMessage,
+}
+
+/// The response that's passed from the parent to the controller.
+#[derive(Debug)]
+pub(crate) struct ControllerResponse {
+    /// An integer identifying which controller the parent is responding to.
+    pub _client_id: u32,
+    /// The actual response message.
+    pub response: ControllerResponseMessage,
+}
+
+/// This structure defines the required json format of any request sent to the WebSocket
+/// Controller.
+///
+/// Requests must be made in the following format:
+/// ```json
+/// {
+///     "request": String,
+/// }
+///
+/// ```
+///
+/// The request "String" value must be a valid
+/// [`ControllerCommand`](./enum.ControllerCommand.html).
+///
+/// # Example
+/// The following request will shut down the load test:
+/// ```json
+/// {
+///     "request": "shutdown",
+/// }
+/// ```
+///
+/// Responses will be formatted as defined in
+/// [ControllerWebSocketResponse](./struct.ControllerWebSocketResponse.html).
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ControllerWebSocketRequest {
+    /// A valid command string.
+    pub request: String,
+}
+
+/// This structure defines the json format of any response returned from the WebSocket
+/// Controller.
+///
+/// Responses are in the following format:
+/// ```json
+/// {
+///     "response": String,
+///     "success": bool,
+/// }
+/// ```
+///
+/// # Example
+/// The following response will be returned when a request is made to shut down the
+/// load test:
+/// ```json
+/// {
+///     "response": "load test shut down",
+///     "success": true
+/// }
+/// ```
+///
+/// Requests must be formatted as defined in
+/// [ControllerWebSocketRequest](./struct.ControllerWebSocketRequest.html).
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ControllerWebSocketResponse {
+    /// The response from the controller.
+    pub response: String,
+    /// Whether the request was successful or not.
+    pub success: bool,
+}
+
+/// Return type to indicate whether or not to exit the Controller thread.
+type ControllerExit = bool;
+
+/// The telnet Controller message buffer.
+type ControllerTelnetMessage = [u8; 1024];
+
+/// The WebSocket Controller message buffer.
+type ControllerWebSocketMessage = std::result::Result<
+    tokio_tungstenite::tungstenite::Message,
+    tokio_tungstenite::tungstenite::Error,
+>;
+
+/// Simplify the ControllerExecuteCommand trait definition for WebSockets.
+type ControllerWebSocketSender = futures::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+    tokio_tungstenite::tungstenite::Message,
+>;
+
+/// This state object is created in the main Controller thread and then passed to the specific
+/// per-client thread.
+pub(crate) struct ControllerState {
+    /// Track which controller-thread this is.
+    thread_id: u32,
+    /// Track the ip and port of the connected TCP client.
+    peer_address: String,
+    /// A shared channel for communicating with the parent process.
+    channel_tx: flume::Sender<ControllerRequest>,
+    /// Which protocol this Controller understands.
+    protocol: ControllerProtocol,
+}
+// Defines functions shared by all Controllers.
+impl ControllerState {
+    async fn accept_connections(self, mut socket: tokio::net::TcpStream) {
+        info!(
+            "{:?} client [{}] connected from {}",
+            self.protocol, self.thread_id, self.peer_address
+        );
+        match self.protocol {
+            ControllerProtocol::Telnet => {
+                let mut buf: ControllerTelnetMessage = [0; 1024];
+
+                // Display initial goose> prompt.
+                write_to_socket_raw(&mut socket, "goose> ").await;
+
+                loop {
+                    // Process data received from the client in a loop.
+                    let n = match socket.read(&mut buf).await {
+                        Ok(data) => data,
+                        Err(_) => {
+                            info!(
+                                "Telnet client [{}] disconnected from {}",
+                                self.thread_id, self.peer_address
+                            );
+                            break;
+                        }
+                    };
+
+                    // Invalid request, exit.
+                    if n == 0 {
+                        info!(
+                            "Telnet client [{}] disconnected from {}",
+                            self.thread_id, self.peer_address
+                        );
+                        break;
+                    }
+
+                    // Extract the command string in a protocol-specific way.
+                    if let Ok(command_string) = self.get_command_string(buf).await {
+                        // Extract the command and value in a generic way.
+                        if let Ok(request_message) = self.get_match(command_string.trim()).await {
+                            // Act on the commmand received.
+                            if self.execute_command(&mut socket, request_message).await {
+                                // If execute_command returns true, it's time to exit.
+                                info!(
+                                    "Telnet client [{}] disconnected from {}",
+                                    self.thread_id, self.peer_address
+                                );
+                                break;
+                            }
+                        } else {
+                            self.write_to_socket(
+                                &mut socket,
+                                Err("unrecognized command".to_string()),
+                            )
+                            .await;
+                        }
+                    } else {
+                        // Corrupted request from telnet client, exit.
+                        info!(
+                            "Telnet client [{}] disconnected from {}",
+                            self.thread_id, self.peer_address
+                        );
+                        break;
+                    }
+                }
+            }
+            ControllerProtocol::WebSocket => {
+                let stream = match tokio_tungstenite::accept_async(socket).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        info!("invalid WebSocket handshake: {}", e);
+                        return;
+                    }
+                };
+                let (mut ws_sender, mut ws_receiver) = stream.split();
+
+                loop {
+                    // Wait until the client sends a command.
+                    let data = match ws_receiver.next().await {
+                        Some(d) => (d),
+                        None => {
+                            // Returning with no data means the client disconnected.
+                            info!(
+                                "Telnet client [{}] disconnected from {}",
+                                self.thread_id, self.peer_address
+                            );
+                            break;
+                        }
+                    };
+
+                    // Extract the command string in a protocol-specific way.
+                    if let Ok(command_string) = self.get_command_string(data).await {
+                        // Extract the command and value in a generic way.
+                        if let Ok(request_message) = self.get_match(command_string.trim()).await {
+                            if self.execute_command(&mut ws_sender, request_message).await {
+                                // If execute_command() returns true, it's time to exit.
+                                info!(
+                                    "Telnet client [{}] disconnected from {}",
+                                    self.thread_id, self.peer_address
+                                );
+                                break;
+                            }
+                        } else {
+                            self.write_to_socket(
+                                &mut ws_sender,
+                                Err("unrecognized command, see Goose README.md".to_string()),
+                            )
+                            .await;
+                        }
+                    } else {
+                        self.write_to_socket(
+                            &mut ws_sender,
+                            Err("unable to parse json, see Goose README.md".to_string()),
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
+
+    // Both Controllers use a common function to identify commands.
+    async fn get_match(
+        &self,
+        command_string: &str,
+    ) -> Result<ControllerRequestMessage, GooseError> {
+        // Use FromStr to convert &str to ControllerCommand.
+        let command: ControllerCommand = ControllerCommand::from_str(command_string)?;
+        // Extract value if there is one, otherwise will be None.
+        let value: Option<String> = command.get_value(command_string);
+
+        Ok(ControllerRequestMessage { command, value })
+    }
+
+    /// Process a request entirely within the Controller thread, without sending a message
+    /// to the parent thread.
+    fn process_local_command(&self, request_message: &ControllerRequestMessage) -> Option<String> {
+        match request_message.command {
+            ControllerCommand::Help => Some(ControllerCommand::display_help()),
+            ControllerCommand::Exit => Some("goodbye!".to_string()),
+            // All other commands require sending the request to the parent thread.
+            _ => None,
+        }
+    }
+
+    /// Send a message to parent thread, with or without an optional value, and wait for
+    /// a reply.
+    async fn process_command(
+        &self,
+        request: ControllerRequestMessage,
+    ) -> Result<ControllerResponseMessage, String> {
+        // Create a one-shot channel to allow the parent to reply to our request. As flume
+        // doesn't implement a one-shot channel, we use tokio for this temporary channel.
+        let (response_tx, response_rx): (
+            tokio::sync::oneshot::Sender<ControllerResponse>,
+            tokio::sync::oneshot::Receiver<ControllerResponse>,
+        ) = tokio::sync::oneshot::channel();
+
+        if self
+            .channel_tx
+            .try_send(ControllerRequest {
+                response_channel: Some(response_tx),
+                client_id: self.thread_id,
+                request,
+            })
+            .is_err()
+        {
+            return Err("parent process has closed the controller channel".to_string());
+        }
+
+        // Await response from parent.
+        match response_rx.await {
+            Ok(value) => Ok(value.response),
+            Err(e) => Err(format!("one-shot channel dropped without reply: {}", e)),
+        }
+    }
+}
+
+/// Controller-protocol-specific functions, necessary to manage the different way each
+/// Controller protocol communicates with a client.
+#[async_trait]
+trait Controller<T> {
+    // Extract the command string from a Controller client request.
+    async fn get_command_string(&self, raw_value: T) -> Result<String, String>;
+}
+#[async_trait]
+impl Controller<ControllerTelnetMessage> for ControllerState {
+    // Extract the command string from a telnet Controller client request.
+    async fn get_command_string(
+        &self,
+        raw_value: ControllerTelnetMessage,
+    ) -> Result<String, String> {
+        let command_string = match str::from_utf8(&raw_value) {
+            Ok(m) => {
+                if let Some(c) = m.lines().next() {
+                    c
+                } else {
+                    ""
+                }
+            }
+            Err(e) => {
+                let error = format!("ignoring unexpected input from telnet controller: {}", e);
+                info!("{}", error);
+                return Err(error);
+            }
+        };
+
+        Ok(command_string.to_string())
+    }
+}
+#[async_trait]
+impl Controller<ControllerWebSocketMessage> for ControllerState {
+    // Extract the command string from a WebSocket Controller client request.
+    async fn get_command_string(
+        &self,
+        raw_value: ControllerWebSocketMessage,
+    ) -> Result<String, String> {
+        if let Ok(request) = raw_value {
+            if request.is_text() {
+                if let Ok(request) = request.into_text() {
+                    debug!("websocket request: {:?}", request.trim());
+                    let command_string: ControllerWebSocketRequest =
+                        match serde_json::from_str(&request) {
+                            Ok(c) => c,
+                            Err(_) => {
+                                return Err("unrecognized json request, refer to Goose README.md"
+                                    .to_string())
+                            }
+                        };
+                    return Ok(command_string.request);
+                } else {
+                    // Failed to consume the WebSocket message and convert it to a String.
+                    return Err("unsupported string format".to_string());
+                }
+            } else {
+                // Received a non-text WebSocket message.
+                return Err("unsupported format, requests must be sent as text".to_string());
+            }
+        }
+        // Improper WebSocket handshake.
+        Err("WebSocket handshake error".to_string())
+    }
+}
+#[async_trait]
+trait ControllerExecuteCommand<T> {
+    // Run the command received from a Controller request. Returns a boolean, if true exit.
+    async fn execute_command(
+        &self,
+        socket: &mut T,
+        request_message: ControllerRequestMessage,
+    ) -> ControllerExit;
+
+    // Send response to Controller client. The response is wrapped in a Result to indicate
+    // if the request was successful or not.
+    async fn write_to_socket(&self, socket: &mut T, response_message: Result<String, String>);
+}
+#[async_trait]
+impl ControllerExecuteCommand<tokio::net::TcpStream> for ControllerState {
+    // Run the command received from a telnet Controller request.
+    async fn execute_command(
+        &self,
+        socket: &mut tokio::net::TcpStream,
+        request_message: ControllerRequestMessage,
+    ) -> ControllerExit {
+        // First handle commands that don't require interaction with the parent process.
+        if let Some(message) = self.process_local_command(&request_message) {
+            self.write_to_socket(socket, Ok(message)).await;
+            // If Exit was received return true to exit, otherwise return false.
+            return request_message.command == ControllerCommand::Exit;
+        }
+
+        // Retain a copy of the command used when processing the parent response.
+        let command = request_message.command.clone();
+
+        // Now handle commands that require interaction with the parent process.
+        let response = match self.process_command(request_message).await {
+            Ok(r) => r,
+            Err(e) => {
+                // Receiving an error here means the parent closed the communication
+                // channel. Write the error to the Controller client and then return
+                // true to exit.
+                self.write_to_socket(socket, Err(e)).await;
+                return true;
+            }
+        };
+
+        // If Shutdown command was received return true to exit, otherwise return false.
+        let exit_controller = command == ControllerCommand::Shutdown;
+
+        // Write the response to the Controller client socket.
+        let processed_response = (command.details().process_response)(response);
+        self.write_to_socket(socket, processed_response).await;
+
+        // Return true if it's time to exit the Controller.
+        exit_controller
+    }
+
+    // Send response to telnet Controller client.
+    async fn write_to_socket(
+        &self,
+        socket: &mut tokio::net::TcpStream,
+        message: Result<String, String>,
+    ) {
+        // Send result to telnet Controller client, whether Ok() or Err().
+        let response_message = match message {
+            Ok(m) => m,
+            Err(e) => e,
+        };
+        if socket
+            // Add a linefeed to the end of the message, followed by a prompt.
+            .write_all([&response_message, "\ngoose> "].concat().as_bytes())
+            .await
+            .is_err()
+        {
+            warn!("failed to write data to socker");
+        };
+    }
+}
+#[async_trait]
+impl ControllerExecuteCommand<ControllerWebSocketSender> for ControllerState {
+    // Run the command received from a WebSocket Controller request.
+    async fn execute_command(
+        &self,
+        socket: &mut ControllerWebSocketSender,
+        request_message: ControllerRequestMessage,
+    ) -> ControllerExit {
+        // First handle commands that don't require interaction with the parent process.
+        if let Some(message) = self.process_local_command(&request_message) {
+            self.write_to_socket(socket, Ok(message)).await;
+
+            // If Exit was received return true to exit, otherwise return false.
+            let exit_controller = request_message.command == ControllerCommand::Exit;
+            // If exiting, notify the WebSocket client that this connection is closing.
+            if exit_controller
+                && socket
+                    .send(Message::Close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                        code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Normal,
+                        reason: std::borrow::Cow::Borrowed("exit"),
+                    })))
+                    .await
+                    .is_err()
+            {
+                warn!("failed to write data to stream");
+            }
+
+            return exit_controller;
+        }
+
+        // WebSocket Controller always returns JSON, convert command where necessary.
+        let command = match request_message.command {
+            ControllerCommand::Config => ControllerCommand::ConfigJson,
+            ControllerCommand::Metrics => ControllerCommand::MetricsJson,
+            _ => request_message.command.clone(),
+        };
+
+        // Now handle commands that require interaction with the parent process.
+        let response = match self.process_command(request_message).await {
+            Ok(r) => r,
+            Err(e) => {
+                // Receiving an error here means the parent closed the communication
+                // channel. Write the error to the Controller client and then return
+                // true to exit.
+                self.write_to_socket(socket, Err(e)).await;
+                return true;
+            }
+        };
+
+        // If Shutdown command was received return true to exit, otherwise return false.
+        let exit_controller = command == ControllerCommand::Shutdown;
+
+        // Write the response to the Controller client socket.
+        let processed_response = (command.details().process_response)(response);
+        self.write_to_socket(socket, processed_response).await;
+
+        // If exiting, notify the WebSocket client that this connection is closing.
+        if exit_controller
+            && socket
+                .send(Message::Close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                    code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Normal,
+                    reason: std::borrow::Cow::Borrowed("shutdown"),
+                })))
+                .await
+                .is_err()
+        {
+            warn!("failed to write data to stream");
+        }
+
+        // Return true if it's time to exit the Controller.
+        exit_controller
+    }
+
+    // Send a json-formatted response to the WebSocket.
+    async fn write_to_socket(
+        &self,
+        socket: &mut ControllerWebSocketSender,
+        response_result: Result<String, String>,
+    ) {
+        let success;
+        let response = match response_result {
+            Ok(m) => {
+                success = true;
+                m
+            }
+            Err(e) => {
+                success = false;
+                e
+            }
+        };
+        if let Err(e) = socket
+            .send(Message::Text(
+                match serde_json::to_string(&ControllerWebSocketResponse {
+                    response,
+                    // Success is true if there is no error, false if there is an error.
+                    success,
+                }) {
+                    Ok(json) => json,
+                    Err(e) => {
+                        warn!("failed to json encode response: {}", e);
+                        return;
+                    }
+                },
+            ))
+            .await
+        {
+            info!("failed to write data to websocket: {}", e);
+        }
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1204,14 +1204,20 @@ impl ControllerState {
                         } else {
                             self.write_to_socket(
                                 &mut ws_sender,
-                                Err("unrecognized command, see Goose README.md".to_string()),
+                                Err(
+                                    "unrecognized command, see Goose book https://book.goose.rs/controller/websocket.html"
+                                        .to_string(),
+                                ),
                             )
                             .await;
                         }
                     } else {
                         self.write_to_socket(
                             &mut ws_sender,
-                            Err("unable to parse json, see Goose README.md".to_string()),
+                            Err(
+                                "invalid json, see Goose book https://book.goose.rs/controller/websocket.html"
+                                    .to_string(),
+                            ),
                         )
                         .await;
                     }
@@ -1324,7 +1330,7 @@ impl Controller<ControllerWebSocketMessage> for ControllerState {
                         match serde_json::from_str(&request) {
                             Ok(c) => c,
                             Err(_) => {
-                                return Err("unrecognized json request, refer to Goose README.md"
+                                return Err("invalid json, see Goose book https://book.goose.rs/controller/websocket.html"
                                     .to_string())
                             }
                         };

--- a/src/docs/goose-book/src/controller/telnet.md
+++ b/src/docs/goose-book/src/controller/telnet.md
@@ -12,21 +12,26 @@ Connected to localhost.
 Escape character is '^]'.
 goose> ?
 goose 0.16.1 controller commands:
- help (?)           this help
- exit (quit)        exit controller
- start              start an idle load test
- stop               stop a running load test and return to idle state
- shutdown           shutdown running load test (and exit controller)
- host HOST          set host to load test, ie http://localhost/
- users INT          set number of simulated users
- hatchrate FLOAT    set per-second rate users hatch
- startup-time TIME  set time to take starting users
- runtime TIME       set how long to run test, ie 1h30m5s
- config             display load test configuration
- config-json        display load test configuration in json format
- metrics            display metrics for current load test
- metrics-json       display metrics for current load test in json format
-goose>
+help               this help
+exit               exit controller
+
+start              start an idle load test
+stop               stop a running load test and return to idle state
+shutdown           shutdown load test and exit controller
+
+host HOST          set host to load test, ie https://web.site/
+hatchrate FLOAT    set per-second rate users hatch
+startup-time TIME  set total time to take starting users
+users INT          set number of simulated users
+runtime TIME       set how long to run test, ie 1h30m5s
+
+config             display load test configuration
+config-json        display load test configuration in json format
+metrics            display metrics for current load test
+metrics-json       display metrics for current load test in json format
+goose> q
+goodbye!
+goose> Connection closed by foreign host.
 ```
 
 ## Example

--- a/src/docs/goose-book/src/controller/websocket.md
+++ b/src/docs/goose-book/src/controller/websocket.md
@@ -8,38 +8,31 @@ The WebSocket Controller supports the same commands listed in the [telnet contro
 
 Requests must be made in the following format:
 ```json
-{
-  "request": String,
-}
+{"request":String}
 ```
 
 For example, a client should send the follow json to request the current load test metrics:
 ```json
-{
-  "request": "metrics",
-}
+{"request":"metrics"}
 ```
 
 Responses will always be in the following format:
 ```json
-{
-  "response": String,
-  "success": Boolean,
-}
+{"response":String,"success":Boolean}
 ```
 
 For example:
 ```bash
 % websocat ws://127.0.0.1:5117
 foo
-{"response":"unable to parse json, see Goose README.md","success":false}
-{"request": "foo"}
-{"response":"unrecognized command, see Goose README.md","success":false}
-{"request": "config"}
-{"response":"{\"help\":false,\"version\":false,\"list\":false,\"host\":\"http://apache/\",\"users\":5,\"hatch_rate\":\".5\",\"run_time\":\"\",\"log_level\":0,\"goose_log\":\"\",\"verbose\":1,\"running_metrics\":null,\"no_reset_metrics\":false,\"no_metrics\":false,\"no_transaction_metrics\":false,\"no_error_summary\":false,\"report_file\":\"\",\"request_log\":\"\",\"request_format\":\"json\",\"debug_log\":\"\",\"debug_format\":\"json\",\"no_debug_body\":false,\"status_codes\":false,\"no_telnet\":false,\"telnet_host\":\"0.0.0.0\",\"telnet_port\":5116,\"no_websocket\":false,\"websocket_host\":\"0.0.0.0\",\"websocket_port\":5117,\"no_autostart\":true,\"throttle_requests\":0,\"sticky_follow\":false,\"manager\":false,\"expect_workers\":null,\"no_hash_check\":false,\"manager_bind_host\":\"\",\"manager_bind_port\":0,\"worker\":false,\"manager_host\":\"\",\"manager_port\":0}","success":true}
-{"request": "stop"}
+{"response":"invalid json, see Goose book https://book.goose.rs/controller/websocket.html","success":false}
+{"request":"foo"}
+{"response":"unrecognized command, see Goose book https://book.goose.rs/controller/websocket.html","success":false}
+{"request":"config"}
+{"response":"{\"help\":false,\"version\":false,\"list\":false,\"host\":\"\",\"users\":10,\"hatch_rate\":null,\"startup_time\":\"0\",\"run_time\":\"0\",\"goose_log\":\"\",\"log_level\":0,\"quiet\":0,\"verbose\":0,\"running_metrics\":null,\"no_reset_metrics\":false,\"no_metrics\":false,\"no_transaction_metrics\":false,\"no_print_metrics\":false,\"no_error_summary\":false,\"report_file\":\"\",\"no_granular_report\":false,\"request_log\":\"\",\"request_format\":\"Json\",\"request_body\":false,\"transaction_log\":\"\",\"transaction_format\":\"Json\",\"error_log\":\"\",\"error_format\":\"Json\",\"debug_log\":\"\",\"debug_format\":\"Json\",\"no_debug_body\":false,\"no_status_codes\":false,\"test_plan\":null,\"no_telnet\":false,\"telnet_host\":\"0.0.0.0\",\"telnet_port\":5116,\"no_websocket\":false,\"websocket_host\":\"0.0.0.0\",\"websocket_port\":5117,\"no_autostart\":true,\"no_gzip\":false,\"timeout\":null,\"co_mitigation\":\"Disabled\",\"throttle_requests\":0,\"sticky_follow\":false,\"manager\":false,\"expect_workers\":null,\"no_hash_check\":false,\"manager_bind_host\":\"\",\"manager_bind_port\":0,\"worker\":false,\"manager_host\":\"\",\"manager_port\":0}","success":true}
+{"request":"stop"}
 {"response":"load test not running, failed to stop","success":false}
-{"request": "exit"}
-{"response":"goodbye!","success":true}
+{"request":"shutdown"}
+{"response":"load test shut down","success":true}
 ```
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -7,7 +7,7 @@ use tokio_tungstenite::tungstenite::Message;
 
 use goose::config::GooseConfiguration;
 use goose::controller::{
-    GooseControllerCommand, GooseControllerWebSocketRequest, GooseControllerWebSocketResponse,
+    ControllerCommand, ControllerWebSocketRequest, ControllerWebSocketResponse,
 };
 use goose::prelude::*;
 
@@ -41,12 +41,12 @@ enum TestType {
 struct TestState {
     // A buffer for the telnet Controller.
     buf: [u8; 2048],
-    // Track iterations through GooseControllerCommands.
+    // Track iterations through ControllerCommands.
     position: usize,
     // Track the steps within a given iteration.
     step: usize,
     // The Controller command currently being tested.
-    command: GooseControllerCommand,
+    command: ControllerCommand,
     // A TCP socket if testing the telnet Controller.
     telnet_stream: Option<TcpStream>,
     // A TCP socket if testing the WebSocket Controller.
@@ -193,7 +193,7 @@ async fn run_standalone_test(test_type: TestType) {
         loop {
             // Process data received from the client in a loop.
             let response;
-            let websocket_response: GooseControllerWebSocketResponse;
+            let websocket_response: ControllerWebSocketResponse;
             if let Some(stream) = test_state.telnet_stream.as_mut() {
                 let _ = match stream.read(&mut test_state.buf) {
                     Ok(data) => data,
@@ -233,7 +233,7 @@ async fn run_standalone_test(test_type: TestType) {
 
             //println!("{:?}: {}", test_state.command, response);
             match test_state.command {
-                GooseControllerCommand::Exit => {
+                ControllerCommand::Exit => {
                     match test_state.step {
                         // Exit the Controller.
                         0 => {
@@ -251,7 +251,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::Help => {
+                ControllerCommand::Help => {
                     match test_state.step {
                         0 => {
                             // Request the help text.
@@ -273,7 +273,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::Host => {
+                ControllerCommand::Host => {
                     match test_state.step {
                         // Set the host to be load tested.
                         0 => {
@@ -304,7 +304,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::Users => {
+                ControllerCommand::Users => {
                     match test_state.step {
                         // Reconfigure the number of users simulated by the load test.
                         0 => {
@@ -331,7 +331,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::HatchRate => {
+                ControllerCommand::HatchRate => {
                     match test_state.step {
                         // Configure a decimal hatch_rate.
                         0 => {
@@ -373,7 +373,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::StartupTime => {
+                ControllerCommand::StartupTime => {
                     match test_state.step {
                         // Try to configure a decimal StartupTime.
                         0 => {
@@ -412,7 +412,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::RunTime => {
+                ControllerCommand::RunTime => {
                     match test_state.step {
                         // Configure run_time using h:m:s format.
                         0 => {
@@ -470,7 +470,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::Config => {
+                ControllerCommand::Config => {
                     match test_state.step {
                         // Request the configuration.
                         0 => {
@@ -491,7 +491,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::ConfigJson => {
+                ControllerCommand::ConfigJson => {
                     match test_state.step {
                         // Request the configuration in json format.
                         0 => {
@@ -507,7 +507,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::Metrics => {
+                ControllerCommand::Metrics => {
                     match test_state.step {
                         // Request the running metrics.
                         0 => {
@@ -528,7 +528,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::MetricsJson => {
+                ControllerCommand::MetricsJson => {
                     match test_state.step {
                         // Request the running metrics in json format.
                         0 => {
@@ -543,7 +543,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::Start => {
+                ControllerCommand::Start => {
                     match test_state.step {
                         // Try to stop an idle load test.
                         0 => {
@@ -572,7 +572,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::Stop => {
+                ControllerCommand::Stop => {
                     match test_state.step {
                         // Try to configure host on a running load test.
                         0 => {
@@ -621,7 +621,7 @@ async fn run_standalone_test(test_type: TestType) {
                         }
                     }
                 }
-                GooseControllerCommand::Shutdown => {
+                ControllerCommand::Shutdown => {
                     match test_state.step {
                         // Shut down the load test.
                         0 => {
@@ -666,20 +666,20 @@ async fn run_standalone_test(test_type: TestType) {
 fn update_state(test_state: Option<TestState>, test_type: &TestType) -> TestState {
     // The commands being tested, and the order they are tested.
     let commands_to_test = [
-        GooseControllerCommand::Exit,
-        GooseControllerCommand::Help,
-        GooseControllerCommand::Host,
-        GooseControllerCommand::Users,
-        GooseControllerCommand::HatchRate,
-        GooseControllerCommand::StartupTime,
-        GooseControllerCommand::RunTime,
-        GooseControllerCommand::Start,
-        GooseControllerCommand::Config,
-        GooseControllerCommand::ConfigJson,
-        GooseControllerCommand::Metrics,
-        GooseControllerCommand::MetricsJson,
-        GooseControllerCommand::Stop,
-        GooseControllerCommand::Shutdown,
+        ControllerCommand::Exit,
+        ControllerCommand::Help,
+        ControllerCommand::Host,
+        ControllerCommand::Users,
+        ControllerCommand::HatchRate,
+        ControllerCommand::StartupTime,
+        ControllerCommand::RunTime,
+        ControllerCommand::Start,
+        ControllerCommand::Config,
+        ControllerCommand::ConfigJson,
+        ControllerCommand::Metrics,
+        ControllerCommand::MetricsJson,
+        ControllerCommand::Stop,
+        ControllerCommand::Shutdown,
     ];
 
     if let Some(mut state) = test_state {
@@ -741,7 +741,7 @@ fn make_request(test_state: &mut TestState, command: &str) {
     } else if let Some(stream) = test_state.websocket_stream.as_mut() {
         stream
             .write_message(Message::Text(
-                serde_json::to_string(&GooseControllerWebSocketRequest {
+                serde_json::to_string(&ControllerWebSocketRequest {
                     request: command.to_string(),
                 })
                 .unwrap(),


### PR DESCRIPTION
 - introduce `ControllerCommandDetails` which includes `help`, `regex`, `process_response` all defined together
 - drop `Goose` prefix from Controller
 - improve `help` formatting (logically grouping and separating command types)
 - move anything that has to be modified when adding new commands to the top of the source file
 - closes https://github.com/tag1consulting/goose/issues/470