### PR TITLE
Fix redundant help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.16.2-dev
  - [#477](https://github.com/tag1consulting/goose/pull/477) introduce `--iterations` (and `GooseDefault::Iterations`) which configures each GooseUser to run a configurable number of iterations of the assigned Scenario then exit; introduces Scenario metrics which can be disabled with `--no-scenario-metrics` (`GooseDefault::NoScenarioMetrics`); introduces `--scenario-log` and `--scenario-format` (and `GooseDefault::ScenarioLog` and `GooseDefault::ScenarioFormat`)
+ - [#483](https://github.com/tag1consulting/goose/pull/483) remove duplicate help (-h) output
 
 ## 0.16.1 May 12, 2022
  - [#464](https://github.com/tag1consulting/goose/pull/464) add `startuptime` (and `startup_time`) TIME to controllers, setting how long the load test should spend starting configured number of users

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,89 +24,18 @@ const DEFAULT_PORT: &str = "5115";
 /// Custom defaults can be programmatically set for most of these options using the
 /// `GooseDefaults` structure.
 ///
-/// Help is generated for all of these options by passing a `-h` flag to an application
-/// built with the Goose Library. For example, using the following command from within the
-/// Goose source tree to run the included `simple` example:
-///
-/// `cargo run --example simple -- -h`
-///
-/// Goose will generate the following output from the [`GooseConfiguration`] structure:
-///
-/// ```text
-/// Usage: target/debug/examples/simple [OPTIONS]
-///
-/// Runtime options available when launching a Goose load test.
-///
-///
-/// Optional arguments:
-/// -h, --help                  Displays this help
-/// -V, --version               Prints version information
-/// -l, --list                  Lists all transactions and exits
-///
-/// -H, --host HOST             Defines host to load test (ie http://10.21.32.33)
-/// -u, --users USERS           Sets concurrent users (default: number of CPUs)
-/// -r, --hatch-rate RATE       Sets per-second user hatch rate (default: 1)
-/// -s, --startup-time TIME     Starts users for up to (30s, 20m, 3h, 1h30m, etc)
-/// -t, --run-time TIME         Stops load test after (30s, 20m, 3h, 1h30m, etc)
-/// -G, --goose-log NAME        Enables Goose log file and sets name
-/// -g, --log-level             Increases Goose log level (-g, -gg, etc)
-/// -q, --quiet                 Decreases Goose verbosity (-q, -qq, etc)
-/// -v, --verbose               Increases Goose verbosity (-v, -vv, etc)
-///
-/// Metrics:
-/// --running-metrics TIME      How often to optionally print running metrics
-/// --no-reset-metrics          Doesn't reset metrics after all users have started
-/// --no-metrics                Doesn't track metrics
-/// --no-transaction-metrics    Doesn't track transaction metrics
-/// --no-scenario-metrics       Doesn't track scenario metrics
-/// --no-print-metrics          Doesn't display metrics at end of load test
-/// --no-error-summary          Doesn't display an error summary
-/// --report-file NAME          Create an html-formatted report
-/// --no-granular-report        Disable granular graphs in report file
-/// -R, --request-log NAME      Sets request log file name
-/// --request-format FORMAT     Sets request log format (csv, json, raw, pretty)
-/// --request-body              Include the request body in the request log
-/// -T, --transaction-log NAME  Sets transaction log file name
-/// --transaction-format FORMAT Sets log format (csv, json, raw, pretty)
-/// -S, --scenario-log NAME     Sets scenario log file name
-/// --scenario-format FORMAT    Sets log format (csv, json, raw, pretty)
-/// -E, --error-log NAME        Sets error log file name
-/// --error-format FORMAT       Sets error log format (csv, json, raw, pretty)
-/// -D, --debug-log NAME        Sets debug log file name
-/// --debug-format FORMAT       Sets debug log format (csv, json, raw, pretty)
-/// --no-debug-body             Do not include the response body in the debug log
-/// --no-status-codes           Do not track status code metrics
-///
-/// Advanced:
-/// --test-plan "TESTPLAN"      Defines a more complex test plan ("10,60s;0,30s")
-/// --iterations ITERATIONS     Sets how many times to run scenarios then exit
-/// --no-telnet                 Doesn't enable telnet Controller
-/// --telnet-host HOST          Sets telnet Controller host (default: 0.0.0.0)
-/// --telnet-port PORT          Sets telnet Controller TCP port (default: 5116)
-/// --no-websocket              Doesn't enable WebSocket Controller
-/// --websocket-host HOST       Sets WebSocket Controller host (default: 0.0.0.0)
-/// --websocket-port PORT       Sets WebSocket Controller TCP port (default: 5117)
-/// --no-autostart              Doesn't automatically start load test
-/// --no-gzip                   Doesn't set the gzip Accept-Encoding header
-/// --timeout VALUE             Sets per-request timeout, in seconds (default: 60)
-/// --co-mitigation STRATEGY    Sets coordinated omission mitigation strategy
-/// --throttle-requests VALUE   Sets maximum requests per second
-/// --sticky-follow             Follows base_url redirect with subsequent requests
-///
-/// Gaggle:
-/// --manager                   Enables distributed load test Manager mode
-/// --expect-workers VALUE      Sets number of Workers to expect
-/// --no-hash-check             Tells Manager to ignore load test checksum
-/// --manager-bind-host HOST    Sets host Manager listens on (default: 0.0.0.0)
-/// --manager-bind-port PORT    Sets port Manager listens on (default: 5115)
-/// --worker                    Enables distributed load test Worker mode
-/// --manager-host HOST         Sets host Worker connects to (default: 127.0.0.1)
-/// --manager-port PORT         Sets port Worker connects to (default: 5115)
-/// ```
+/// [Help is generated for all of these options](https://book.goose.rs/getting-started/runtime-options.html)
+/// by passing a `-h` flag to an application built with the Goose Library.
 ///
 /// Goose leverages [`gumdrop`](https://docs.rs/gumdrop/) to derive the above help from
 /// the the below structure.
 #[derive(Options, Debug, Clone, Serialize, Deserialize)]
+#[options(
+    help = r#"Goose is a modern, high-performance, distributed HTTP(S) load testing tool,
+written in Rust. Visit https://book.goose.rs/ for more information.
+
+The following runtime options are available when launching a Goose load test:"#
+)]
 pub struct GooseConfiguration {
     /// Displays this help
     #[options(short = "h")]

--- a/src/docs/goose-book/src/getting-started/runtime-options.md
+++ b/src/docs/goose-book/src/getting-started/runtime-options.md
@@ -5,8 +5,10 @@ The `-h` flag will show all run-time configuration options available to Goose lo
 ```ignore
 Usage: target/release/loadtest [OPTIONS]
 
-Runtime options available when launching a Goose load test.
+Goose is a modern, high-performance, distributed HTTP(S) load testing tool,
+written in Rust. Visit https://book.goose.rs/ for more information.
 
+The following runtime options are available when launching a Goose load test:
 
 Optional arguments:
   -h, --help                  Displays this help


### PR DESCRIPTION
 - remove example `-h` output, instead pointing to [the book](https://book.goose.rs/getting-started/runtime-options.html)
 - includes the following description at the top of the help output: 
```
Goose is a modern, high-performance, distributed HTTP(S) load testing tool,
written in Rust. For more information visit https://book.goose.rs/

The following runtime options are available when launching a Goose load test:
```
 - closes https://github.com/tag1consulting/goose/issues/482
 - NOTE: this is built on top of another PR which needs to be merged first to properly see the changes in this PR https://github.com/tag1consulting/goose/pull/477
 - the full help output now looks as follows:

```
% cargo run --release --example simple -- -h
   Compiling goose v0.16.2-dev (~/devel/goose)
    Finished release [optimized] target(s) in 10.56s
     Running `target/release/examples/simple -h`
Usage: target/release/examples/simple [OPTIONS]

Goose is a modern, high-performance, distributed HTTP(S) load testing tool,
written in Rust. For more information visit https://book.goose.rs/

The following runtime options are available when launching a Goose load test:

Optional arguments:
  -h, --help                  Displays this help
  -V, --version               Prints version information
  -l, --list                  Lists all transactions and exits

  -H, --host HOST             Defines host to load test (ie http://10.21.32.33)
  -u, --users USERS           Sets concurrent users (default: number of CPUs)
  -r, --hatch-rate RATE       Sets per-second user hatch rate (default: 1)
  -s, --startup-time TIME     Starts users for up to (30s, 20m, 3h, 1h30m, etc)
  -t, --run-time TIME         Stops load test after (30s, 20m, 3h, 1h30m, etc)
  -G, --goose-log NAME        Enables Goose log file and sets name
  -g, --log-level             Increases Goose log level (-g, -gg, etc)
  -q, --quiet                 Decreases Goose verbosity (-q, -qq, etc)
  -v, --verbose               Increases Goose verbosity (-v, -vv, etc)

Metrics:
  --running-metrics TIME      How often to optionally print running metrics
  --no-reset-metrics          Doesn't reset metrics after all users have started
  --no-metrics                Doesn't track metrics
  --no-transaction-metrics    Doesn't track transaction metrics
  --no-scenario-metrics       Doesn't track scenario metrics
  --no-print-metrics          Doesn't display metrics at end of load test
  --no-error-summary          Doesn't display an error summary
  --report-file NAME          Create an html-formatted report
  --no-granular-report        Disable granular graphs in report file
  -R, --request-log NAME      Sets request log file name
  --request-format FORMAT     Sets request log format (csv, json, raw, pretty)
  --request-body              Include the request body in the request log
  -T, --transaction-log NAME  Sets transaction log file name
  --transaction-format FORMAT Sets log format (csv, json, raw, pretty)
  -S, --scenario-log NAME     Sets scenario log file name
  --scenario-format FORMAT    Sets log format (csv, json, raw, pretty)
  -E, --error-log NAME        Sets error log file name
  --error-format FORMAT       Sets error log format (csv, json, raw, pretty)
  -D, --debug-log NAME        Sets debug log file name
  --debug-format FORMAT       Sets debug log format (csv, json, raw, pretty)
  --no-debug-body             Do not include the response body in the debug log
  --no-status-codes           Do not track status code metrics

Advanced:
  --test-plan "TESTPLAN"      Defines a more complex test plan ("10,60s;0,30s")
  --iterations ITERATIONS     Sets how many times to run scenarios then exit
  --no-telnet                 Doesn't enable telnet Controller
  --telnet-host HOST          Sets telnet Controller host (default: 0.0.0.0)
  --telnet-port PORT          Sets telnet Controller TCP port (default: 5116)
  --no-websocket              Doesn't enable WebSocket Controller
  --websocket-host HOST       Sets WebSocket Controller host (default: 0.0.0.0)
  --websocket-port PORT       Sets WebSocket Controller TCP port (default: 5117)
  --no-autostart              Doesn't automatically start load test
  --no-gzip                   Doesn't set the gzip Accept-Encoding header
  --timeout VALUE             Sets per-request timeout, in seconds (default: 60)
  --co-mitigation STRATEGY    Sets coordinated omission mitigation strategy
  --throttle-requests VALUE   Sets maximum requests per second
  --sticky-follow             Follows base_url redirect with subsequent requests

Gaggle:
  --manager                   Enables distributed load test Manager mode
  --expect-workers VALUE      Sets number of Workers to expect
  --no-hash-check             Tells Manager to ignore load test checksum
  --manager-bind-host HOST    Sets host Manager listens on (default: 0.0.0.0)
  --manager-bind-port PORT    Sets port Manager listens on (default: 5115)
  --worker                    Enables distributed load test Worker mode
  --manager-host HOST         Sets host Worker connects to (default: 127.0.0.1)
  --manager-port PORT         Sets port Worker connects to (default: 5115)
```