### PR TITLE
confirm Goose shuts down correctly when canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.16.3-dev
+ - [#487](https://github.com/tag1consulting/goose/pull/487) add dev-dependency on (nix)[https://docs.rs/nix] to provide test coverage confirming proper shutdown from SIGINT (ctrl-c); capture ctrl-c in a lazy_static wrapped in a RwLock so it can be reset
 
 ## 0.16.2 May 20, 2022
  - [#477](https://github.com/tag1consulting/goose/pull/477) introduce `--iterations` (and `GooseDefault::Iterations`) which configures each GooseUser to run a configurable number of iterations of the assigned Scenario then exit; introduces Scenario metrics which can be disabled with `--no-scenario-metrics` (`GooseDefault::NoScenarioMetrics`); introduces `--scenario-log` and `--scenario-format` (and `GooseDefault::ScenarioLog` and `GooseDefault::ScenarioFormat`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ rustc_version = "0.4"
 
 [dev-dependencies]
 httpmock = "0.6"
-serial_test = "0.5"
 native-tls = "0.2"
+nix = "0.24"
 rustls = "0.19"
+serial_test = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,8 @@ use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::sync::{
-    atomic::{AtomicBool, AtomicUsize, Ordering},
-    Arc,
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
 };
 use std::time::{self, Duration};
 use std::{fmt, io};
@@ -94,6 +94,7 @@ const DEFAULT_WEBSOCKET_PORT: &str = "5117";
 // WORKER_ID is only used when running a gaggle (a distributed load test).
 lazy_static! {
     static ref WORKER_ID: AtomicUsize = AtomicUsize::new(0);
+    static ref CANCELED: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
 }
 
 /// Internal representation of a weighted transaction list.
@@ -365,9 +366,6 @@ struct GooseAttackRunState {
     users_shutdown: HashSet<usize>,
     /// Boolean flag indicating of Goose should shutdown after stopping a running load test.
     shutdown_after_stop: bool,
-    /// Thread-safe boolean flag indicating if the [`GooseAttack`](./struct.GooseAttack.html)
-    /// has been canceled.
-    canceled: Arc<AtomicBool>,
     /// Whether or not the load test is currently canceling.
     canceling: bool,
     /// Optional socket used to coordinate a distributed Gaggle.
@@ -1323,7 +1321,6 @@ impl GooseAttack {
             users_shutdown: HashSet::new(),
             all_users_spawned: false,
             shutdown_after_stop: !self.configuration.no_autostart,
-            canceled: Arc::new(AtomicBool::new(false)),
             canceling: false,
             socket,
         };
@@ -1332,7 +1329,7 @@ impl GooseAttack {
         trace!("socket: {:?}", &goose_attack_run_state.socket);
 
         // Catch ctrl-c to allow clean shutdown to display metrics.
-        util::setup_ctrlc_handler(&goose_attack_run_state.canceled);
+        util::setup_ctrlc_handler();
 
         Ok(goose_attack_run_state)
     }
@@ -1976,7 +1973,7 @@ impl GooseAttack {
             // Gracefully exit loop if ctrl-c is caught.
             if self.attack_phase != AttackPhase::Shutdown
                 && !goose_attack_run_state.canceling
-                && goose_attack_run_state.canceled.load(Ordering::SeqCst)
+                && *CANCELED.lock().unwrap()
             {
                 // Shutdown after stopping as the load test was canceled.
                 goose_attack_run_state.shutdown_after_stop = true;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -13,7 +13,7 @@ use crate::metrics::{
 };
 use crate::util;
 use crate::worker::GaggleMetrics;
-use crate::{GooseAttack, GooseConfiguration, GooseUserCommand, CANCELED};
+use crate::{GooseAttack, GooseConfiguration, GooseUserCommand, CANCELED, SHUTDOWN_GAGGLE};
 
 /// How long the manager will wait for all workers to stop after the load test ends.
 const GRACEFUL_SHUTDOWN_TIMEOUT: usize = 30;
@@ -404,7 +404,7 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                     false
                 };
                 // Test ran to completion or was canceled with ctrl-c.
-                if timer_expired || *CANCELED.lock().unwrap() {
+                if timer_expired || *SHUTDOWN_GAGGLE.read().unwrap() || *CANCELED.read().unwrap() {
                     info!(
                         "stopping after {} seconds...",
                         goose_attack.started.unwrap().elapsed().as_secs()
@@ -432,7 +432,7 @@ pub(crate) async fn manager_main(mut goose_attack: GooseAttack) -> GooseAttack {
                     goose_attack.metrics.print_running();
                 }
             }
-        } else if *CANCELED.lock().unwrap() {
+        } else if *CANCELED.read().unwrap() {
             info!("load test canceled, exiting");
             std::process::exit(1);
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,7 +15,10 @@ use crate::report;
 use crate::test_plan::{TestPlanHistory, TestPlanStepAction};
 use crate::util;
 #[cfg(feature = "gaggle")]
-use crate::{CANCELED, worker::{self, GaggleMetrics}};
+use crate::{
+    worker::{self, GaggleMetrics},
+    CANCELED,
+};
 use crate::{AttackMode, GooseAttack, GooseAttackRunState, GooseConfiguration, GooseError};
 use chrono::prelude::*;
 use http::StatusCode;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -17,7 +17,7 @@ use crate::util;
 #[cfg(feature = "gaggle")]
 use crate::{
     worker::{self, GaggleMetrics},
-    CANCELED,
+    SHUTDOWN_GAGGLE,
 };
 use crate::{AttackMode, GooseAttack, GooseAttackRunState, GooseConfiguration, GooseError};
 use chrono::prelude::*;
@@ -2687,9 +2687,9 @@ impl GooseAttack {
                         ],
                         true,
                     ) {
-                        // GooseUserCommand::Exit received, cancel.
-                        let mut canceled = CANCELED.lock().unwrap();
-                        *canceled = true;
+                        // GooseUserCommand::Exit received, shutdown the Gaggle.
+                        let mut shutdown_gaggle = SHUTDOWN_GAGGLE.write().unwrap();
+                        *shutdown_gaggle = true;
                     }
                     // The manager has all our metrics, reset locally.
                     self.metrics.requests = HashMap::new();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,7 +15,7 @@ use crate::report;
 use crate::test_plan::{TestPlanHistory, TestPlanStepAction};
 use crate::util;
 #[cfg(feature = "gaggle")]
-use crate::worker::{self, GaggleMetrics};
+use crate::{CANCELED, worker::{self, GaggleMetrics}};
 use crate::{AttackMode, GooseAttack, GooseAttackRunState, GooseConfiguration, GooseError};
 use chrono::prelude::*;
 use http::StatusCode;
@@ -2685,9 +2685,8 @@ impl GooseAttack {
                         true,
                     ) {
                         // GooseUserCommand::Exit received, cancel.
-                        goose_attack_run_state
-                            .canceled
-                            .store(true, std::sync::atomic::Ordering::SeqCst);
+                        let mut canceled = CANCELED.lock().unwrap();
+                        *canceled = true;
                     }
                     // The manager has all our metrics, reset locally.
                     self.metrics.requests = HashMap::new();

--- a/tests/cancel.rs
+++ b/tests/cancel.rs
@@ -1,0 +1,329 @@
+/// Validate that Goose properly shuts down when it receives SIGINT (control-c).
+use httpmock::{Method::GET, Mock, MockServer};
+use nix::sys::signal::{kill, SIGINT};
+use nix::unistd::getpid;
+use serial_test::serial;
+use tokio::time::{sleep, Duration};
+
+mod common;
+
+use goose::config::GooseConfiguration;
+use goose::goose::GooseMethod;
+use goose::prelude::*;
+
+// Paths used in load tests performed during these tests.
+const INDEX_PATH: &str = "/";
+
+// Indexes to the above paths.
+const INDEX_KEY: usize = 0;
+
+// Load test configuration.
+const EXPECT_WORKERS: usize = 2;
+
+// There are multiple test variations in this file.
+enum TestType {
+    // Runs until canceled.
+    NoRunTime,
+    // Runs a set amount of time (with --run-time) then exits.
+    RunTime,
+    // Run time is optionally configured through a test plan.
+    TestPlan,
+    // Runs a set number of iterations (with --iterations) then exits.
+    Iterations,
+}
+
+// Test transaction.
+pub async fn get_index(user: &mut GooseUser) -> TransactionResult {
+    let _goose = user.get(INDEX_PATH).await?;
+    Ok(())
+}
+
+// All tests in this file run against a common endpoint.
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+    vec![
+        // This load test only requests INDEX_PATH, which we store in vector at INDEX_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(INDEX_PATH);
+            then.status(200);
+        }),
+    ]
+}
+
+// Build appropriate configuration for these tests.
+fn common_build_configuration(
+    server: &MockServer,
+    test_type: &TestType,
+    custom: &mut Vec<&str>,
+) -> GooseConfiguration {
+    // In all cases throttle requests to allow asserting metrics precisely.
+    let mut configuration = match test_type {
+        TestType::RunTime => {
+            // Hatch 3 users a second for 2 seconds, then run for 2 more seconds.
+            vec![
+                "--throttle-requests",
+                "5",
+                "--users",
+                "6",
+                "--hatch-rate",
+                "3",
+                "--run-time",
+                "10",
+            ]
+        }
+        TestType::NoRunTime => {
+            // Hatch 3 users a second for 2 seconds, then run until canceled.
+            vec![
+                "--throttle-requests",
+                "5",
+                "--users",
+                "6",
+                "--hatch-rate",
+                "3",
+            ]
+        }
+        TestType::TestPlan => {
+            // Common configuration is the throttle, test-plan defined through `custom`.
+            vec!["--throttle-requests", "5"]
+        }
+        TestType::Iterations => {
+            // Hatch 3 users a second for 2 seconds, runing each for 5 iterations complete iterations then cancel.
+            vec![
+                "--throttle-requests",
+                "5",
+                "--users",
+                "6",
+                "--hatch-rate",
+                "3",
+                "iterations",
+                "5",
+            ]
+        }
+    };
+
+    // Custom elements in some tests.
+    configuration.append(custom);
+
+    // Return the resulting configuration.
+    common::build_configuration(server, configuration)
+}
+
+// Helper to confirm all variations generate appropriate results.
+fn validate_one_scenario(
+    goose_metrics: &GooseMetrics,
+    mock_endpoints: &[Mock],
+    configuration: &GooseConfiguration,
+    test_type: TestType,
+    is_gaggle: bool,
+) {
+    // Confirm that we loaded the mock endpoints.
+    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
+
+    // Get index and about out of goose metrics.
+    let index_metrics = goose_metrics
+        .requests
+        .get(&format!("GET {}", INDEX_PATH))
+        .unwrap();
+
+    // Confirm that the path and method are correct in the statistics.
+    assert!(index_metrics.path == INDEX_PATH);
+    assert!(index_metrics.method == GooseMethod::Get);
+
+    // There should not have been any failures during this test.
+    assert!(index_metrics.fail_count == 0);
+
+    match test_type {
+        TestType::RunTime => {
+            assert!(goose_metrics.total_users == configuration.users.unwrap());
+            if !is_gaggle {
+                assert!(goose_metrics.history.len() == 4);
+            }
+        }
+        TestType::NoRunTime => {
+            assert!(goose_metrics.total_users == configuration.users.unwrap());
+            if !is_gaggle {
+                assert!(goose_metrics.history.len() == 4);
+            }
+        }
+        TestType::TestPlan => {}
+        TestType::Iterations => {}
+    }
+}
+
+// Returns the appropriate scenario needed to build these tests.
+fn get_transactions() -> Scenario {
+    scenario!("LoadTest").register_transaction(transaction!(get_index).set_weight(9).unwrap())
+}
+
+async fn cancel_load_test(duration: Duration) {
+    sleep(duration).await;
+    kill(getpid(), SIGINT).expect("failed to send SIGNINT");
+}
+
+// Helper to run all standalone tests.
+async fn run_standalone_test(test_type: TestType) {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    let mut configuration_flags = match test_type {
+        TestType::RunTime => vec!["--no-reset-metrics"],
+        TestType::NoRunTime => vec!["--no-reset-metrics"],
+        TestType::TestPlan => vec![],
+        TestType::Iterations => vec![],
+    };
+
+    // Build common configuration elements.
+    let configuration = common_build_configuration(&server, &test_type, &mut configuration_flags);
+
+    let cancel_delay = match test_type {
+        TestType::RunTime => Duration::from_secs(3),
+        TestType::NoRunTime => Duration::from_secs(2),
+        TestType::TestPlan => Duration::from_secs(2),
+        TestType::Iterations => Duration::from_secs(2),
+    };
+
+    // Start a thread that will send a SIGINT to the running load test.
+    let _ = tokio::spawn(cancel_load_test(cancel_delay));
+
+    // Run the Goose Attack.
+    let goose_metrics = common::run_load_test(
+        common::build_load_test(configuration.clone(), &get_transactions(), None, None),
+        None,
+    )
+    .await;
+
+    // Confirm that the load test ran correctly.
+    validate_one_scenario(
+        &goose_metrics,
+        &mock_endpoints,
+        &configuration,
+        test_type,
+        false,
+    );
+}
+
+// Helper to run all standalone tests.
+async fn run_gaggle_test(test_type: TestType) {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    // Each worker has the same identical configuration.
+    let worker_configuration =
+        common::build_configuration(&server, vec!["--worker", "--throttle-requests", "5"]);
+
+    // Workers launched in own threads, store thread handles.
+    let worker_handles = common::launch_gaggle_workers(EXPECT_WORKERS, || {
+        common::build_load_test(
+            worker_configuration.clone(),
+            &get_transactions(),
+            None,
+            None,
+        )
+    });
+
+    // Build common configuration elements, adding Manager Gaggle flags.
+    let manager_configuration = match test_type {
+        TestType::RunTime => common::build_configuration(
+            &server,
+            vec![
+                "--manager",
+                "--expect-workers",
+                &EXPECT_WORKERS.to_string(),
+                "--no-reset-metrics",
+                "--users",
+                "6",
+                "--hatch-rate",
+                "3",
+                "--run-time",
+                "10",
+            ],
+        ),
+        TestType::NoRunTime => common::build_configuration(
+            &server,
+            vec![
+                "--manager",
+                "--expect-workers",
+                &EXPECT_WORKERS.to_string(),
+                "--no-reset-metrics",
+                "--users",
+                "6",
+                "--hatch-rate",
+                "3",
+            ],
+        ),
+        TestType::Iterations => common::build_configuration(
+            &server,
+            vec!["--manager", "--expect-workers", &EXPECT_WORKERS.to_string()],
+        ),
+        TestType::TestPlan => panic!("test plan configuration not supported in gaggle mode"),
+    };
+
+    // Build the load test for the Manager.
+    let manager_goose_attack = common::build_load_test(
+        manager_configuration.clone(),
+        &get_transactions(),
+        None,
+        None,
+    );
+
+    let cancel_delay = match test_type {
+        TestType::RunTime => Duration::from_secs(3),
+        TestType::NoRunTime => Duration::from_secs(2),
+        TestType::TestPlan => Duration::from_secs(2),
+        TestType::Iterations => Duration::from_secs(2),
+    };
+
+    // Start a thread that will send a SIGINT to the running load test.
+    let _ = tokio::spawn(cancel_load_test(cancel_delay));
+
+    // Run the Goose Attack.
+    let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
+
+    // Confirm that the load test ran correctly.
+    validate_one_scenario(
+        &goose_metrics,
+        &mock_endpoints,
+        &manager_configuration,
+        test_type,
+        true,
+    );
+}
+
+/* With --run-time */
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[serial]
+// Cancel a scenario with --run-time configured before it times out.
+async fn test_cancel_runtime() {
+    run_standalone_test(TestType::RunTime).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+#[serial]
+// Cancel a scenario with --run-time configured before it times out, in Gaggle mode.
+async fn test_cancel_runtime_gaggle() {
+    run_gaggle_test(TestType::RunTime).await;
+}
+
+/* Without --run-time */
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[serial]
+// Cancel a scenario without --run-time configured.
+async fn test_cancel_noruntime() {
+    run_standalone_test(TestType::NoRunTime).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+#[serial]
+// Cancel a scenario without --run-time configured, in Gaggle mode.
+async fn test_cancel_noruntime_gaggle() {
+    run_gaggle_test(TestType::NoRunTime).await;
+}

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -1,4 +1,5 @@
 use httpmock::{Method::GET, Mock, MockServer};
+use serial_test::serial;
 
 mod common;
 
@@ -155,6 +156,7 @@ fn get_transactions() -> Scenario {
 }
 
 #[tokio::test]
+#[serial]
 // Enable throttle to confirm it limits the number of request per second.
 // Increase the throttle and confirm it increases the number of requests
 // per second.
@@ -224,6 +226,7 @@ async fn test_throttle() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[cfg_attr(not(feature = "gaggle"), ignore)]
+#[serial]
 // Enable throttle to confirm it limits the number of request per second, in
 // Gaggle mode. Increase the throttle and confirm it increases the number of
 // requests per second, in Gaggle mode.


### PR DESCRIPTION
 - move CANCELED flag into a global lazy_static so it can be reset and re-used on multiple tests
 - move Gaggle-shutdown handling to new SHUTDOWN_GAGGLE flag (also a global lazy_static) so that a Gaggle test shutting down at the same time as a non-Gaggle test is running won't cause both to be shut down
 - test coverage with `--run-time` configured
 - test coverage without `--run-time` configured (ie, run forever until canceled)
 - test coverage with `--iterations` configured
 - test coverage with `--test-plan` including canceling while the test is Increasing, Maintaining, and Decreasing
 - adds dev-dependency on [`nix`](https://docs.rs/nix) in order to access `kill` for sending `SIGINT`