### PR TITLE
Don't panic when shutting down with controller and writing report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.16.3-dev
  - [#487](https://github.com/tag1consulting/goose/pull/487) add dev-dependency on (nix)[https://docs.rs/nix] to provide test coverage confirming proper shutdown from SIGINT (ctrl-c); capture ctrl-c in a lazy_static wrapped in a RwLock so it can be reset
+ - [#489](https://github.com/tag1consulting/goose/pull/489) don't panic when writing report file and shutting down with controller
 
 ## 0.16.2 May 20, 2022
  - [#477](https://github.com/tag1consulting/goose/pull/477) introduce `--iterations` (and `GooseDefault::Iterations`) which configures each GooseUser to run a configurable number of iterations of the assigned Scenario then exit; introduces Scenario metrics which can be disabled with `--no-scenario-metrics` (`GooseDefault::NoScenarioMetrics`); introduces `--scenario-log` and `--scenario-format` (and `GooseDefault::ScenarioLog` and `GooseDefault::ScenarioFormat`)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1668,6 +1668,9 @@ impl GooseAttack {
                 if !self.configuration.no_metrics {
                     println!("{}", self.metrics);
                 }
+                // Write an html report, if enabled.
+                self.write_html_report().await?;
+                // Return to an Idle state.
                 self.set_attack_phase(goose_attack_run_state, AttackPhase::Idle);
             }
         // If this is not the last step of the load test and sufficient users decreased, move to next step.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,8 +347,6 @@ struct GooseAttackRunState {
     parent_to_throttle_tx: Option<flume::Sender<bool>>,
     /// Optional channel allowing controller thread to make requests, if not disabled.
     controller_channel_rx: Option<flume::Receiver<ControllerRequest>>,
-    /// Optional unbuffered writer for html-formatted report file, if enabled.
-    report_file: Option<File>,
     /// A flag tracking whether or not the header has been written when the metrics
     /// log is enabled.
     metrics_header_displayed: bool,
@@ -991,6 +989,9 @@ impl GooseAttack {
                 self.metrics.duration
             );
             print!("{}", self.metrics);
+
+            // Write an html report, if enabled.
+            self.write_html_report().await?;
         }
 
         Ok(self.metrics)
@@ -1316,7 +1317,6 @@ impl GooseAttack {
             throttle_threads_tx: None,
             parent_to_throttle_tx: None,
             controller_channel_rx,
-            report_file: None,
             metrics_header_displayed: false,
             idle_status_displayed: false,
             users: Vec::new(),
@@ -1660,8 +1660,6 @@ impl GooseAttack {
             self.metrics
                 .history
                 .push(TestPlanHistory::step(TestPlanStepAction::Finished, 0));
-            // Write an html report, if enabled.
-            self.write_html_report(goose_attack_run_state).await?;
             // Shutdown Goose or go into an idle waiting state.
             if goose_attack_run_state.shutdown_after_stop {
                 self.set_attack_phase(goose_attack_run_state, AttackPhase::Shutdown);
@@ -1852,8 +1850,8 @@ impl GooseAttack {
         goose_attack_run_state.throttle_threads_tx = throttle_threads_tx;
         goose_attack_run_state.parent_to_throttle_tx = parent_to_throttle_tx;
 
-        // If enabled, create an report file and confirm access.
-        goose_attack_run_state.report_file = match self.prepare_report_file().await {
+        // If enabled, try to create the report file to confirm access.
+        let _report_file = match self.prepare_report_file().await {
             Ok(f) => f,
             Err(e) => {
                 return Err(GooseError::InvalidOption {

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -174,7 +174,12 @@ async fn run_standalone_test(test_type: TestType) {
 
     let mut configuration_flags = match &test_type {
         TestType::WebSocket => vec!["--no-telnet"],
-        TestType::Telnet => vec!["--no-websocket"],
+        // Also test writing a report-file when stopping load test through controller.
+        TestType::Telnet => vec![
+            "--no-websocket",
+            "--report-file",
+            "controller-test-report.html",
+        ],
     };
 
     // Keep a copy for validation.
@@ -681,6 +686,8 @@ async fn run_standalone_test(test_type: TestType) {
         &configuration,
         validate_test_type,
     );
+
+    // @TODO: clean up report file.
 }
 
 // Update (or create) the current testing state. A simple state maching for


### PR DESCRIPTION
 - write report file in the same place that we display final metrics
 - don't store open file for duration of load test -- instead, test creation at test-start, then re-open to write report at end of test
 - closes https://github.com/tag1consulting/goose/issues/474
 - adds test coverage, writing a report file when using the controller
 - validate report file is properly created and not-empty
 -  cleanup report file at end of successful test

As part of this change, the last thing Goose reports now is where the report file has been written, immediately following the ASCII metrics:

```bash
 === OVERVIEW ===
 ------------------------------------------------------------------------------
 Action       Started               Stopped             Elapsed    Users
 ------------------------------------------------------------------------------
 Increasing:  2022-05-24 09:02:17 - 2022-05-24 09:02:19 (00:00:02, 0 -> 1)
 Increasing:  2022-05-24 09:02:19 - 2022-05-24 09:02:24 (00:00:05, 1 -> 5)
 Maintaining: 2022-05-24 09:02:24 - 2022-05-24 09:02:34 (00:00:10, 5)
 Increasing:  2022-05-24 09:02:34 - 2022-05-24 09:02:35 (00:00:01, 5 -> 20)
 Maintaining: 2022-05-24 09:02:35 - 2022-05-24 09:02:39 (00:00:04, 20)
 Decreasing:  2022-05-24 09:02:39 - 2022-05-24 09:02:45 (00:00:06, 1 <- 20)
 Increasing:  2022-05-24 09:02:45 - 2022-05-24 09:02:50 (00:00:05, 1 -> 20)
 Decreasing:  2022-05-24 09:02:50 - 2022-05-24 09:02:52 (00:00:02, 7 <- 20)
 Decreasing:  2022-05-24 09:02:52 - 2022-05-24 09:02:53 (00:00:01, 4 <- 7)
 Increasing:  2022-05-24 09:02:53 - 2022-05-24 09:02:59 (00:00:06, 4 -> 25)
 Decreasing:  2022-05-24 09:02:59 - 2022-05-24 09:03:36 (00:00:37, 0 <- 25)

 Target host: http://apache.fosciana/
 goose v0.16.3-dev
 ------------------------------------------------------------------------------
07:03:36 [INFO] html report file written to: report.html
```