### PR TITLE
Support nids higher than 255 (u32 vs u8)

### DIFF
--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -15,7 +15,7 @@ pub enum ContentType {
 /// Details tracked about individual nodes used to run load test and validate
 /// that pages are being correctly loaded.
 pub struct Node<'a> {
-    pub nid: u8,
+    pub nid: u32,
     pub url_en: &'a str,
     pub url_es: &'a str,
     pub title_en: &'a str,


### PR DESCRIPTION
Ran into this error with nids in the thousands. 

```
error: literal out of range for `u8`                                                   
  --> examples/umami/common.rs:34:26                                                   
   |                                                                                   
34 |                     nid: 34054,                                                   
   |                          ^^^^^                                                    
   |                                                                                   
   = note: the literal `34054` does not fit into the type `u8` whose range is `0..=255`
```

Changed, https://github.com/tag1consulting/goose/blob/d5274ae75d33ab1df20c5d5e0dc995151738ab73/examples/umami/common.rs#L17-L18 from `u8` to `u32` and all is well now. 