### PR TITLE
Update Tokio and related dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,20 +27,18 @@ num_cpus = "1.0"
 num-format = "0.4"
 rand = "0.8"
 regex = "1"
-reqwest = { version = "0.11",  default-features = false, features = [
+reqwest = { version = "0.11", default-features = false, features = [
     "cookies",
     "gzip",
     "json",
 ] }
-serde = { version = "1.0", features = [
-    "derive",
-] }
+serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"
 simplelog = "0.10"
 strum = "0.24"
 strum_macros = "0.24"
-tokio = { version = "~1.15.0", features = [
+tokio = { version = "1", features = [
     "fs",
     "io-util",
     "macros",
@@ -49,8 +47,8 @@ tokio = { version = "~1.15.0", features = [
     "time",
     "sync",
 ] }
-tokio-tungstenite = "0.15"
-tungstenite = "0.15"
+tokio-tungstenite = "0.17"
+tungstenite = "0.17"
 url = "2"
 
 # optional dependencies
@@ -59,7 +57,7 @@ nng = { version = "1.0", optional = true }
 [features]
 default = ["reqwest/default-tls"]
 gaggle = ["nng"]
-rustls-tls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls-tls-webpki-roots"]
 
 [build-dependencies]
 rustc_version = "0.4"


### PR DESCRIPTION
This helps include goose in a Cargo workspace that already has a newer Tokio version selected.