### PR TITLE
document using env variables for custom options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.16.3-dev
+ - [#498](https://github.com/tag1consulting/goose/issues/498) ignore `GooseDefault::Host` if set to an empty string
  - [#487](https://github.com/tag1consulting/goose/pull/487) add dev-dependency on (nix)[https://docs.rs/nix] to provide test coverage confirming proper shutdown from SIGINT (ctrl-c); capture ctrl-c in a lazy_static wrapped in a RwLock so it can be reset
  - [#489](https://github.com/tag1consulting/goose/pull/489) don't panic when writing report file and shutting down with controller
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -574,7 +574,13 @@ impl GooseDefaultType<&str> for GooseAttack {
             // Set valid defaults.
             GooseDefault::HatchRate => self.defaults.hatch_rate = Some(value.to_string()),
             GooseDefault::Timeout => self.defaults.timeout = Some(value.to_string()),
-            GooseDefault::Host => self.defaults.host = Some(value.to_string()),
+            GooseDefault::Host => {
+                self.defaults.host = if value.is_empty() {
+                    None
+                } else {
+                    Some(value.to_string())
+                }
+            }
             GooseDefault::GooseLog => self.defaults.goose_log = Some(value.to_string()),
             GooseDefault::ReportFile => self.defaults.report_file = Some(value.to_string()),
             GooseDefault::RequestLog => self.defaults.request_log = Some(value.to_string()),

--- a/src/docs/goose-book/src/SUMMARY.md
+++ b/src/docs/goose-book/src/SUMMARY.md
@@ -12,6 +12,7 @@
         - [Common Options](getting-started/common.md)
         - [Test Plan](getting-started/test-plan.md)
         - [Throttle](getting-started/throttle.md)
+        - [Custom Options](getting-started/custom.md)
     - [Metrics](getting-started/metrics.md)
     - [Tips](getting-started/tips.md)
 

--- a/src/docs/goose-book/src/getting-started/custom.md
+++ b/src/docs/goose-book/src/getting-started/custom.md
@@ -1,0 +1,74 @@
+# Custom Run Time Options
+
+It can sometimes be necessary to add custom run time options to your load test. As Goose "owns" the command line, you can't simply add another option with [gumpdrop](https://docs.rs/gumdrop) (used by Goose) or another command line parser, as Goose will throw an error if it receives an unexpected command line option.
+
+Instead, you can use environment variables. One example of this can be found in the [Umami example](../example/umami.html) which [uses environment variables to allow the configuration of a custom username and password](https://github.com/tag1consulting/goose/blob/main/examples/umami/admin.rs#L9).
+
+Alternatively, you can use this method to set configurable custom defaults. The [earlier example](./custom.md) can be enhanced to use an environment variable to set a custom default hostname:
+
+```rust
+use goose::prelude::*;
+
+async fn loadtest_index(user: &mut GooseUser) -> TransactionResult {
+    let _goose_metrics = user.get("").await?;
+
+    Ok(())
+}
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
+    // Get optional custom default hostname from `HOST` environment variable.
+    let custom_host = match std::env::var("HOST") {
+        Ok(host) => host,
+        Err(_) => "".to_string(),
+    };
+
+    GooseAttack::initialize()?
+        .register_scenario(scenario!("LoadtestTransactions")
+            .register_transaction(transaction!(loadtest_index))
+        )
+        // Set optional custom default hostname.
+        .set_default(GooseDefault::Host, custom_host.as_str())?
+        .execute()
+        .await?;
+
+    Ok(())
+}
+```
+
+This can now be used to set a custom default for the scenario, in this example with no `--host` set Goose will execute a load test against the hostname defined in `HOST`:
+
+```bash,ignore
+% HOST="https://local.dev/" cargo run --release                  
+    Finished release [optimized] target(s) in 0.07s
+     Running `target/release/loadtest`
+07:28:20 [INFO] Output verbosity level: INFO
+07:28:20 [INFO] Logfile verbosity level: WARN
+07:28:20 [INFO] users defaulted to number of CPUs = 10
+07:28:20 [INFO] iterations = 0
+07:28:20 [INFO] host for LoadtestTransactions configured: https://local.dev/
+```
+
+It's still possible to override this custom default from the command line with standard Goose options, for example here the load test will run against the hostname configured by the `--host` option:
+
+```bash,ignore
+% HOST="http://local.dev/" cargo run --release -- --host https://example.com/
+    Finished release [optimized] target(s) in 0.07s
+     Running `target/release/loadtest --host 'https://example.com/'`
+07:32:36 [INFO] Output verbosity level: INFO
+07:32:36 [INFO] Logfile verbosity level: WARN
+07:32:36 [INFO] users defaulted to number of CPUs = 10
+07:32:36 [INFO] iterations = 0
+07:32:36 [INFO] global host configured: https://example.com/
+```
+
+If the `HOST` variable and the `--host` option are not set, Goose will display the expected error:
+
+```bash,ignore
+% cargo run --release
+     Running `target/release/loadtest`
+07:07:45 [INFO] Output verbosity level: INFO
+07:07:45 [INFO] Logfile verbosity level: WARN
+07:07:45 [INFO] users defaulted to number of CPUs = 10
+07:07:45 [INFO] iterations = 0
+Error: InvalidOption { option: "--host", value: "", detail: "A host must be defined via the --host option, the GooseAttack.set_default() function, or the Scenario.set_host() function (no host defined for LoadtestTransactions)." }
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,15 +931,14 @@ impl GooseAttack {
         };
 
         // Confirm there's either a global host, or each scenario has a host defined.
-        if let Err(e) = self.validate_host() {
-            if self.configuration.no_autostart {
-                info!("host must be configured via Controller before starting load test");
-            } else {
-                // If auto-starting, host must be valid.
-                return Err(e);
-            }
+        if self.configuration.no_autostart && self.validate_host().is_err() {
+            info!("host must be configured via Controller before starting load test");
         } else {
-            info!("global host configured: {}", self.configuration.host);
+            // If configuration.host is empty, then it will fall back to per-scenario
+            // defaults if set.
+            if !self.configuration.host.is_empty() {
+                info!("global host configured: {}", self.configuration.host);
+            }
             self.prepare_load_test()?;
         }
 


### PR DESCRIPTION
 - add new book page to document how you can use environment variables for custom run-time configuration
 - ignore `GooseDefault::Host` if set to an empty string (otherwise this results in confusing example our new example)
 - closes https://github.com/tag1consulting/goose/issues/498