### PR TITLE
run-time option to configure which scenarios run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  - [#498](https://github.com/tag1consulting/goose/issues/498) ignore `GooseDefault::Host` if set to an empty string
  - [#487](https://github.com/tag1consulting/goose/pull/487) add dev-dependency on (nix)[https://docs.rs/nix] to provide test coverage confirming proper shutdown from SIGINT (ctrl-c); capture ctrl-c in a lazy_static wrapped in a RwLock so it can be reset
  - [#489](https://github.com/tag1consulting/goose/pull/489) don't panic when writing report file and shutting down with controller
- - [#505](https://github.com/tag1consulting/goose/pull/505) introduce `--scenarios` (and GooseDefault::Scenarios) so a subset of scnearios can be launched, and `--scenarios-list` to display internal machine names for matching
+ - [#505](https://github.com/tag1consulting/goose/pull/505) introduce `--scenarios` (and `GooseDefault::Scenarios`) so a subset of scnearios can be launched, and `--scenarios-list` to display internal machine names for matching
 
 ## 0.16.2 May 20, 2022
  - [#477](https://github.com/tag1consulting/goose/pull/477) introduce `--iterations` (and `GooseDefault::Iterations`) which configures each GooseUser to run a configurable number of iterations of the assigned Scenario then exit; introduces Scenario metrics which can be disabled with `--no-scenario-metrics` (`GooseDefault::NoScenarioMetrics`); introduces `--scenario-log` and `--scenario-format` (and `GooseDefault::ScenarioLog` and `GooseDefault::ScenarioFormat`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - [#498](https://github.com/tag1consulting/goose/issues/498) ignore `GooseDefault::Host` if set to an empty string
  - [#487](https://github.com/tag1consulting/goose/pull/487) add dev-dependency on (nix)[https://docs.rs/nix] to provide test coverage confirming proper shutdown from SIGINT (ctrl-c); capture ctrl-c in a lazy_static wrapped in a RwLock so it can be reset
  - [#489](https://github.com/tag1consulting/goose/pull/489) don't panic when writing report file and shutting down with controller
+ - [#505](https://github.com/tag1consulting/goose/pull/505) introduce `--list-scenarios` and `--scenarios` so a subset of scenarios can be launched
 
 ## 0.16.2 May 20, 2022
  - [#477](https://github.com/tag1consulting/goose/pull/477) introduce `--iterations` (and `GooseDefault::Iterations`) which configures each GooseUser to run a configurable number of iterations of the assigned Scenario then exit; introduces Scenario metrics which can be disabled with `--no-scenario-metrics` (`GooseDefault::NoScenarioMetrics`); introduces `--scenario-log` and `--scenario-format` (and `GooseDefault::ScenarioLog` and `GooseDefault::ScenarioFormat`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  - [#498](https://github.com/tag1consulting/goose/issues/498) ignore `GooseDefault::Host` if set to an empty string
  - [#487](https://github.com/tag1consulting/goose/pull/487) add dev-dependency on (nix)[https://docs.rs/nix] to provide test coverage confirming proper shutdown from SIGINT (ctrl-c); capture ctrl-c in a lazy_static wrapped in a RwLock so it can be reset
  - [#489](https://github.com/tag1consulting/goose/pull/489) don't panic when writing report file and shutting down with controller
- - [#505](https://github.com/tag1consulting/goose/pull/505) introduce `--scenarios` (and `GooseDefault::Scenarios`) so a subset of scnearios can be launched, and `--scenarios-list` to display internal machine names for matching
+ - [#505](https://github.com/tag1consulting/goose/pull/505) introduce `--scenarios` (and `GooseDefault::Scenarios`) so a subset of scenarios can be launched, and `--scenarios-list` to display internal machine names for matching
 
 ## 0.16.2 May 20, 2022
  - [#477](https://github.com/tag1consulting/goose/pull/477) introduce `--iterations` (and `GooseDefault::Iterations`) which configures each GooseUser to run a configurable number of iterations of the assigned Scenario then exit; introduces Scenario metrics which can be disabled with `--no-scenario-metrics` (`GooseDefault::NoScenarioMetrics`); introduces `--scenario-log` and `--scenario-format` (and `GooseDefault::ScenarioLog` and `GooseDefault::ScenarioFormat`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  - [#498](https://github.com/tag1consulting/goose/issues/498) ignore `GooseDefault::Host` if set to an empty string
  - [#487](https://github.com/tag1consulting/goose/pull/487) add dev-dependency on (nix)[https://docs.rs/nix] to provide test coverage confirming proper shutdown from SIGINT (ctrl-c); capture ctrl-c in a lazy_static wrapped in a RwLock so it can be reset
  - [#489](https://github.com/tag1consulting/goose/pull/489) don't panic when writing report file and shutting down with controller
- - [#505](https://github.com/tag1consulting/goose/pull/505) introduce `--list-scenarios` and `--scenarios` so a subset of scenarios can be launched
+ - [#505](https://github.com/tag1consulting/goose/pull/505) introduce `--scenarios` (and GooseDefault::Scenarios) so a subset of scnearios can be launched, and `--scenarios-list` to display internal machine names for matching
 
 ## 0.16.2 May 20, 2022
  - [#477](https://github.com/tag1consulting/goose/pull/477) introduce `--iterations` (and `GooseDefault::Iterations`) which configures each GooseUser to run a configurable number of iterations of the assigned Scenario then exit; introduces Scenario metrics which can be disabled with `--no-scenario-metrics` (`GooseDefault::NoScenarioMetrics`); introduces `--scenario-log` and `--scenario-format` (and `GooseDefault::ScenarioLog` and `GooseDefault::ScenarioFormat`)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1694,7 +1694,7 @@ impl GooseConfiguration {
                 // Use --scenarios if set.
                 GooseValue {
                     value: Some(self.scenarios.clone()),
-                    filter: false,
+                    filter: self.scenarios.is_empty(),
                     message: "scenarios",
                 },
                 // Use GooseDefault if not already set and not Worker.

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,9 @@ pub struct GooseConfiguration {
     /// Prints version information
     #[options(short = "V")]
     pub version: bool,
+    /// Lists all scenarios and exits
+    #[options(no_short)]
+    pub list_scenarios: bool,
     /// Lists all transactions and exits
     // Add a blank line after this option
     #[options(short = "l", help = "Lists all transactions and exits\n")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,9 +43,6 @@ pub struct GooseConfiguration {
     /// Prints version information
     #[options(short = "V")]
     pub version: bool,
-    /// Lists all scenarios and exits
-    #[options(no_short)]
-    pub list_scenarios: bool,
     /// Lists all transactions and exits
     // Add a blank line after this option
     #[options(short = "l", help = "Lists all transactions and exits\n")]
@@ -158,6 +155,12 @@ pub struct GooseConfiguration {
     /// Sets how many times to run scenarios then exit
     #[options(no_short)]
     pub iterations: usize,
+    /// Displays internal names of scenarios and exits
+    #[options(no_short)]
+    pub list_scenarios: bool,
+    /// Limits load test to only specified scenarios
+    #[options(no_short, meta = "\"SCENARIO\"")]
+    pub scenarios: String,
     /// Doesn't enable telnet Controller
     #[options(no_short)]
     pub no_telnet: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -587,7 +587,6 @@ impl GooseDefaultType<&str> for GooseAttack {
             GooseDefault::ErrorLog => self.defaults.error_log = Some(value.to_string()),
             GooseDefault::GooseLog => self.defaults.goose_log = Some(value.to_string()),
             GooseDefault::HatchRate => self.defaults.hatch_rate = Some(value.to_string()),
-            GooseDefault::Timeout => self.defaults.timeout = Some(value.to_string()),
             GooseDefault::Host => {
                 self.defaults.host = if value.is_empty() {
                     None
@@ -595,15 +594,6 @@ impl GooseDefaultType<&str> for GooseAttack {
                     Some(value.to_string())
                 }
             }
-            GooseDefault::GooseLog => self.defaults.goose_log = Some(value.to_string()),
-            GooseDefault::ReportFile => self.defaults.report_file = Some(value.to_string()),
-            GooseDefault::RequestLog => self.defaults.request_log = Some(value.to_string()),
-            GooseDefault::TransactionLog => self.defaults.transaction_log = Some(value.to_string()),
-            GooseDefault::ScenarioLog => self.defaults.scenario_log = Some(value.to_string()),
-            GooseDefault::ErrorLog => self.defaults.error_log = Some(value.to_string()),
-            GooseDefault::DebugLog => self.defaults.debug_log = Some(value.to_string()),
-            GooseDefault::TelnetHost => self.defaults.telnet_host = Some(value.to_string()),
-            GooseDefault::WebSocketHost => self.defaults.websocket_host = Some(value.to_string()),
             GooseDefault::ManagerBindHost => {
                 self.defaults.manager_bind_host = Some(value.to_string())
             }

--- a/src/docs/goose-book/src/SUMMARY.md
+++ b/src/docs/goose-book/src/SUMMARY.md
@@ -12,6 +12,7 @@
         - [Common Options](getting-started/common.md)
         - [Test Plan](getting-started/test-plan.md)
         - [Throttle](getting-started/throttle.md)
+        - [Limiting Scenarios](getting-started/scenarios.md)
         - [Custom Options](getting-started/custom.md)
     - [Metrics](getting-started/metrics.md)
     - [Tips](getting-started/tips.md)

--- a/src/docs/goose-book/src/getting-started/custom.md
+++ b/src/docs/goose-book/src/getting-started/custom.md
@@ -6,7 +6,7 @@ Instead, you can use environment variables. One example of this can be found in 
 
 Alternatively, you can use this method to set configurable custom defaults. The [earlier example](./custom.md) can be enhanced to use an environment variable to set a custom default hostname:
 
-```rust
+```rust,ignore
 use goose::prelude::*;
 
 async fn loadtest_index(user: &mut GooseUser) -> TransactionResult {

--- a/src/docs/goose-book/src/getting-started/runtime-options.md
+++ b/src/docs/goose-book/src/getting-started/runtime-options.md
@@ -52,6 +52,8 @@ Metrics:
 Advanced:
   --test-plan "TESTPLAN"      Defines a more complex test plan ("10,60s;0,30s")
   --iterations ITERATIONS     Sets how many times to run scenarios then exit
+  --scenarios "SCENARIO"      Limits load test to only specified scenarios
+  --scenarios-list            Lists all scenarios and exits
   --no-telnet                 Doesn't enable telnet Controller
   --telnet-host HOST          Sets telnet Controller host (default: 0.0.0.0)
   --telnet-port PORT          Sets telnet Controller TCP port (default: 5116)

--- a/src/docs/goose-book/src/getting-started/scenarios.md
+++ b/src/docs/goose-book/src/getting-started/scenarios.md
@@ -1,0 +1,100 @@
+# Limiting Which Scenarios Run
+
+It can often be useful to run only a subset of the [Scenarios](../glossary.html#scenario) defined by a load test. Instead of commenting them out in the source code and recompiling, the `--scenarios` run-time option allows you to dynamically control which Scenarios are running.
+
+## Listing Scenarios By Machine Name
+To ensure that each scenario has a unique name, you must use the machine name of the scenario when filtering which are running. For example, using the [Umami example](../example/umami.html) enable the `--scenarios-list` flag:
+
+```bash,ignore
+% cargo run --release --example umami -- --scenarios-list
+    Finished release [optimized] target(s) in 0.15s
+     Running `target/release/examples/umami --scenarios-list`
+05:24:03 [INFO] Output verbosity level: INFO
+05:24:03 [INFO] Logfile verbosity level: WARN
+05:24:03 [INFO] users defaulted to number of CPUs = 10
+05:24:03 [INFO] iterations = 0
+Scenarios:
+ - adminuser: ("Admin user")
+ - anonymousenglishuser: ("Anonymous English user")
+ - anonymousspanishuser: ("Anonymous Spanish user")
+ ```
+
+> **What Is A Machine Name:** It is possible to name your Scenarios pretty much anything you want in your load test, including even using the same identical name for multiple Scenarios. A machine name ensures that you can still identify each Scenario uniquely, and without any special characters that can be difficult or insecure to pass through the command line. A machine name is made up of only the alphanumeric characters found in your Scenario's full name, and optionally with a number appended to differentiate between multiple Scenarios that would otherwise have the same name.
+>
+> In the following example, we have three very similarly named Scenarios. One simply has an extra white space between words. The second has an airplane emoticon in the name. Both the extra space and the airplane symbol are stripped away from the machine name as they are not alphanumerics, and instead `_1` and `_2` are appended to the end to differentiate:
+>
+> ```ignore
+> Scenarios:
+> - loadtesttransactions: ("LoadtestTransactions")
+> - loadtesttransactions_1: ("Loadtest Transactions")
+> - loadtesttransactions_2: ("LoadtestTransactions ✈️")
+>
+> ```
+
+## Running Scenarios By Machine Name
+
+It is now possible to run any subset of the above scenarios by passing a comma separated list of machine names with the `--scenarios` run time option. Goose will match what you have typed against any machine name containing all or some of the typed text, so you do not have to type the full name. For example, to run only the two anonymous Scenarios, you could add `--scenarios anon`:
+
+```bash,ignore
+% cargo run --release --example umami -- --hatch-rate 10 --scenarios anon
+    Finished release [optimized] target(s) in 0.15s
+     Running `target/release/examples/umami --hatch-rate 10 --scenarios anon`
+05:50:17 [INFO] Output verbosity level: INFO
+05:50:17 [INFO] Logfile verbosity level: WARN
+05:50:17 [INFO] users defaulted to number of CPUs = 10
+05:50:17 [INFO] hatch_rate = 10
+05:50:17 [INFO] iterations = 0
+05:50:17 [INFO] scenarios = Scenarios { active: ["anon"] }
+05:50:17 [INFO] host for Anonymous English user configured: https://drupal-9.ddev.site/
+05:50:17 [INFO] host for Anonymous Spanish user configured: https://drupal-9.ddev.site/
+05:50:17 [INFO] host for Admin user configured: https://drupal-9.ddev.site/
+05:50:17 [INFO] allocating transactions and scenarios with RoundRobin scheduler
+05:50:17 [INFO] initializing 10 user states...
+05:50:17 [INFO] WebSocket controller listening on: 0.0.0.0:5117
+05:50:17 [INFO] Telnet controller listening on: 0.0.0.0:5116
+05:50:17 [INFO] entering GooseAttack phase: Increase
+05:50:17 [INFO] launching user 1 from Anonymous Spanish user...
+05:50:18 [INFO] launching user 2 from Anonymous English user...
+05:50:18 [INFO] launching user 3 from Anonymous Spanish user...
+05:50:18 [INFO] launching user 4 from Anonymous English user...
+05:50:18 [INFO] launching user 5 from Anonymous Spanish user...
+05:50:18 [INFO] launching user 6 from Anonymous English user...
+05:50:18 [INFO] launching user 7 from Anonymous Spanish user...
+^C05:50:18 [WARN] caught ctrl-c, stopping...
+```
+
+Or, to run only the "Anonymous Spanish user" and "Admin user" Scenarios, you could add `--senarios "spanish,admin"`:
+
+```bash,ignore
+% cargo run --release --example umami -- --hatch-rate 10 --scenarios "spanish,admin"
+   Compiling goose v0.16.3-dev (/Users/jandrews/devel/goose)
+    Finished release [optimized] target(s) in 11.79s
+     Running `target/release/examples/umami --hatch-rate 10 --scenarios spanish,admin`
+05:53:45 [INFO] Output verbosity level: INFO
+05:53:45 [INFO] Logfile verbosity level: WARN
+05:53:45 [INFO] users defaulted to number of CPUs = 10
+05:53:45 [INFO] hatch_rate = 10
+05:53:45 [INFO] iterations = 0
+05:53:45 [INFO] scenarios = Scenarios { active: ["spanish", "admin"] }
+05:53:45 [INFO] host for Anonymous English user configured: https://drupal-9.ddev.site/
+05:53:45 [INFO] host for Anonymous Spanish user configured: https://drupal-9.ddev.site/
+05:53:45 [INFO] host for Admin user configured: https://drupal-9.ddev.site/
+05:53:45 [INFO] allocating transactions and scenarios with RoundRobin scheduler
+05:53:45 [INFO] initializing 10 user states...
+05:53:45 [INFO] Telnet controller listening on: 0.0.0.0:5116
+05:53:45 [INFO] WebSocket controller listening on: 0.0.0.0:5117
+05:53:45 [INFO] entering GooseAttack phase: Increase
+05:53:45 [INFO] launching user 1 from Anonymous Spanish user...
+05:53:45 [INFO] launching user 2 from Admin user...
+05:53:45 [INFO] launching user 3 from Anonymous Spanish user...
+05:53:45 [INFO] launching user 4 from Anonymous Spanish user...
+05:53:45 [INFO] launching user 5 from Anonymous Spanish user...
+05:53:45 [INFO] launching user 6 from Anonymous Spanish user...
+05:53:45 [INFO] launching user 7 from Anonymous Spanish user...
+05:53:45 [INFO] launching user 8 from Anonymous Spanish user...
+05:53:45 [INFO] launching user 9 from Anonymous Spanish user...
+05:53:46 [INFO] launching user 10 from Anonymous Spanish user...
+^C05:53:46 [WARN] caught ctrl-c, stopping...
+```
+
+When the load test completes, you can refer to the [Scenario metrics](./metrics.html#scenarios) to confirm which Scenarios were enabled, and which were not.

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -527,7 +527,7 @@ impl Scenario {
     }
 
     /// An internal helper to convert a Scenario name to a machine name which is only
-    /// alphanumberics.
+    /// alphanumerics.
     fn get_machine_name(name: &str) -> String {
         // Remove all non-alphanumeric characters.
         let re = Regex::new("[^a-zA-Z0-9]+").unwrap();

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -289,6 +289,7 @@
 
 use downcast_rs::{impl_downcast, Downcast};
 use http::method::Method;
+use regex::Regex;
 use reqwest::{header, Client, ClientBuilder, RequestBuilder, Response};
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
@@ -470,6 +471,8 @@ impl From<flume::SendError<Option<GooseLog>>> for TransactionError {
 pub struct Scenario {
     /// The name of the scenario.
     pub name: String,
+    /// Auto-generated machine name of the scenario.
+    pub machine_name: String,
     /// An integer reflecting where this scenario lives in the internal
     /// [`GooseAttack`](../struct.GooseAttack.html)`.scenarios` vector.
     pub scenarios_index: usize,
@@ -511,6 +514,7 @@ impl Scenario {
         trace!("new scenario: name: {}", &name);
         Scenario {
             name: name.to_string(),
+            machine_name: Scenario::get_machine_name(name),
             scenarios_index: usize::max_value(),
             weight: 1,
             transaction_wait: None,
@@ -520,6 +524,16 @@ impl Scenario {
             weighted_on_stop_transactions: Vec::new(),
             host: None,
         }
+    }
+
+    /// An internal helper to convert a Scenario name to a machine name which is only
+    /// alphanumberics.
+    fn get_machine_name(name: &str) -> String {
+        // Remove all non-alphanumeric characters.
+        let re = Regex::new("[^a-zA-Z0-9]+").unwrap();
+        let alphanumeric = re.replace_all(name, "");
+        // Convert to lower case.
+        alphanumeric.to_lowercase()
     }
 
     /// Registers a [`Transaction`](./struct.Transaction.html) with a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -671,14 +671,11 @@ impl GooseAttack {
             return true;
         }
 
-        if scenario
+        // Returns true or false depending on if the machine name is included in the
+        // configured `--scenarios`.
+        scenario
             .machine_name
             .contains(&self.configuration.scenarios)
-        {
-            true
-        } else {
-            false
-        }
     }
 
     /// Use configured GooseScheduler to build out a properly weighted list of
@@ -690,7 +687,7 @@ impl GooseAttack {
         let mut u: usize = 0;
         let mut v: usize;
         for scenario in &self.scenarios {
-            if self.scenario_is_active(&scenario) {
+            if self.scenario_is_active(scenario) {
                 if u == 0 {
                     u = scenario.weight;
                 } else {
@@ -708,7 +705,7 @@ impl GooseAttack {
         let mut available_scenarios = Vec::with_capacity(self.scenarios.len());
         let mut total_scenarios = 0;
         for (index, scenario) in self.scenarios.iter().enumerate() {
-            if self.scenario_is_active(&scenario) {
+            if self.scenario_is_active(scenario) {
                 // divide by greatest common divisor so vector is as short as possible
                 let weight = scenario.weight / u;
                 trace!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -946,27 +946,6 @@ impl GooseAttack {
             });
         }
 
-        // Display scenarios, then exit.
-        if self.configuration.scenarios_list {
-            self.print_scenarios();
-            std::process::exit(0);
-        }
-
-        // At least one scenario must be active.
-        let mut active_scenario: bool = false;
-        for scenario in &self.scenarios {
-            if self.scenario_is_active(scenario) {
-                active_scenario = true;
-                break;
-            }
-        }
-        if !active_scenario {
-            self.print_scenarios();
-            return Err(GooseError::NoScenarios {
-                detail: "No scenarios are enabled.".to_string(),
-            });
-        }
-
         // Display scenarios and transactions, then exit.
         if self.configuration.list {
             println!("Available transactions:");
@@ -987,6 +966,27 @@ impl GooseAttack {
 
         // Validate GooseConfiguration.
         self.configuration.validate()?;
+
+        // Display scenarios, then exit.
+        if self.configuration.scenarios_list {
+            self.print_scenarios();
+            std::process::exit(0);
+        }
+
+        // At least one scenario must be active.
+        let mut active_scenario: bool = false;
+        for scenario in &self.scenarios {
+            if self.scenario_is_active(scenario) {
+                active_scenario = true;
+                break;
+            }
+        }
+        if !active_scenario {
+            self.print_scenarios();
+            return Err(GooseError::NoScenarios {
+                detail: "No scenarios are enabled.".to_string(),
+            });
+        }
 
         // Build TestPlan.
         self.test_plan = TestPlan::build(&self.configuration);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,7 @@ use lazy_static::lazy_static;
 use nng::Socket;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
-use std::collections::hash_map::DefaultHasher;
-use std::collections::BTreeMap;
-use std::collections::HashSet;
+use std::collections::{hash_map::DefaultHasher, BTreeMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -383,6 +381,8 @@ pub struct GooseAttack {
     test_stop_transaction: Option<Transaction>,
     /// A vector containing one copy of each Scenario defined by this load test.
     scenarios: Vec<Scenario>,
+    /// A set of all registered scenario names.
+    scenario_machine_names: HashSet<String>,
     /// A weighted vector containing a GooseUser object for each GooseUser that will run during this load test.
     weighted_users: Vec<GooseUser>,
     /// A weighted vector containing a lightweight GaggleUser object that is sent to all Workers if running in Gaggle mode.
@@ -426,6 +426,7 @@ impl GooseAttack {
             test_start_transaction: None,
             test_stop_transaction: None,
             scenarios: Vec::new(),
+            scenario_machine_names: HashSet::new(),
             weighted_users: Vec::new(),
             weighted_gaggle_users: Vec::new(),
             defaults: GooseDefaults::default(),
@@ -462,6 +463,7 @@ impl GooseAttack {
             test_start_transaction: None,
             test_stop_transaction: None,
             scenarios: Vec::new(),
+            scenario_machine_names: HashSet::new(),
             weighted_users: Vec::new(),
             weighted_gaggle_users: Vec::new(),
             defaults: GooseDefaults::default(),
@@ -575,6 +577,22 @@ impl GooseAttack {
     /// ```
     pub fn register_scenario(mut self, mut scenario: Scenario) -> Self {
         scenario.scenarios_index = self.scenarios.len();
+        // Machine names must be unique. If this machine name has already been seen, add an
+        // integer at the end to differentiate.
+        let mut conflicts: u32 = 0;
+        let mut machine_name = scenario.machine_name.to_string();
+        // Inserting into the scenario_machine_names hashset will fail if this is name was
+        // already seen.
+        while !self.scenario_machine_names.insert(machine_name) {
+            // For each conflict increase the counter and try again.
+            conflicts += 1;
+            machine_name = format!("{}_{}", scenario.machine_name, conflicts);
+        }
+        // If there was a conflict, also update the scenario itself.
+        if conflicts > 0 {
+            scenario.machine_name = format!("{}_{}", scenario.machine_name, conflicts);
+        }
+        // Finally, register the scenario.
         self.scenarios.push(scenario);
         self
     }
@@ -895,6 +913,20 @@ impl GooseAttack {
             return Err(GooseError::NoScenarios {
                 detail: "No scenarios are defined.".to_string(),
             });
+        }
+
+        // Display scenarios, then exit.
+        if self.configuration.list_scenarios {
+            let mut scenarios = BTreeMap::new();
+            println!("Sorted scenarios:");
+            for scenario in self.scenarios {
+                scenarios.insert(scenario.machine_name.clone(), scenario.clone());
+            }
+            // Display sorted by machine_name.
+            for (key, scenario) in scenarios {
+                println!(r#" - {}: ("{}")"#, key, scenario.name);
+            }
+            std::process::exit(0);
         }
 
         // Display scenarios and transactions, then exit.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -667,14 +667,18 @@ impl GooseAttack {
     /// Internal helper to determine if the scenario is currently active.
     fn scenario_is_active(&self, scenario: &Scenario) -> bool {
         // All scenarios are enabled by default.
-        if self.configuration.scenarios.is_empty() {
+        if self.configuration.scenarios.active.is_empty() {
             true
         // Returns true or false depending on if the machine name is included in the
         // configured `--scenarios`.
         } else {
-            scenario
-                .machine_name
-                .contains(&self.configuration.scenarios)
+            for active in &self.configuration.scenarios.active {
+                if scenario.machine_name.contains(active) {
+                    return true;
+                }
+            }
+            // No matches found, this scenario is not active.
+            false
         }
     }
 

--- a/src/test_plan.rs
+++ b/src/test_plan.rs
@@ -15,7 +15,6 @@ use crate::util;
 use crate::{AttackPhase, GooseAttack, GooseAttackRunState, GooseError};
 
 /// Internal data structure representing a test plan.
-//#[derive(Options, Debug, Clone, Serialize, Deserialize)]
 #[derive(Options, Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct TestPlan {
     // A test plan is a vector of tuples each indicating a # of users and milliseconds.

--- a/tests/cancel.rs
+++ b/tests/cancel.rs
@@ -240,7 +240,7 @@ async fn run_standalone_test(test_type: TestType) {
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(
-        common::build_load_test(configuration.clone(), &get_transactions(), None, None),
+        common::build_load_test(configuration.clone(), vec![get_transactions()], None, None),
         None,
     )
     .await;
@@ -271,7 +271,7 @@ async fn run_gaggle_test(test_type: TestType) {
     let worker_handles = common::launch_gaggle_workers(EXPECT_WORKERS, || {
         common::build_load_test(
             worker_configuration.clone(),
-            &get_transactions(),
+            vec![get_transactions()],
             None,
             None,
         )
@@ -327,7 +327,7 @@ async fn run_gaggle_test(test_type: TestType) {
     // Build the load test for the Manager.
     let manager_goose_attack = common::build_load_test(
         manager_configuration.clone(),
-        &get_transactions(),
+        vec![get_transactions()],
         None,
         None,
     );

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -232,7 +232,7 @@ async fn run_load_test(is_gaggle: bool) {
 
             // Run the Goose Attack.
             let goose_metrics = common::run_load_test(
-                common::build_load_test(configuration.clone(), &build_scenario(), None, None),
+                common::build_load_test(configuration.clone(), vec![build_scenario()], None, None),
                 None,
             )
             .await;
@@ -246,7 +246,12 @@ async fn run_load_test(is_gaggle: bool) {
 
             // Workers launched in own threads, store thread handles.
             let worker_handles = common::launch_gaggle_workers(EXPECT_WORKERS, || {
-                common::build_load_test(worker_configuration.clone(), &build_scenario(), None, None)
+                common::build_load_test(
+                    worker_configuration.clone(),
+                    vec![build_scenario()],
+                    None,
+                    None,
+                )
             });
 
             // Build Manager configuration.
@@ -261,7 +266,7 @@ async fn run_load_test(is_gaggle: bool) {
             let goose_metrics = common::run_load_test(
                 common::build_load_test(
                     manager_configuration.clone(),
-                    &build_scenario(),
+                    vec![build_scenario()],
                     None,
                     None,
                 ),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -85,19 +85,21 @@ pub fn launch_gaggle_workers<F: Fn() -> GooseAttack>(
     worker_handles
 }
 
-// Create a GooseAttack object from the configuration, Scenario, and optional start and
+// Create a GooseAttack object from the configuration, Scenarios, and optional start and
 // stop Transactions.
 #[allow(dead_code)]
 pub fn build_load_test(
     configuration: GooseConfiguration,
-    scenario: &Scenario,
+    scenarios: Vec<Scenario>,
     start_transaction: Option<&Transaction>,
     stop_transaction: Option<&Transaction>,
 ) -> GooseAttack {
     // First set up the common base configuration.
-    let mut goose = crate::GooseAttack::initialize_with_config(configuration)
-        .unwrap()
-        .register_scenario(scenario.clone());
+    let mut goose = crate::GooseAttack::initialize_with_config(configuration).unwrap();
+
+    for scenario in scenarios {
+        goose = goose.register_scenario(scenario.clone());
+    }
 
     if let Some(transaction) = start_transaction {
         goose = goose.test_start(transaction.clone());

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -683,7 +683,7 @@ async fn run_standalone_test(test_type: TestType) {
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(
-        common::build_load_test(configuration.clone(), &get_transactions(), None, None),
+        common::build_load_test(configuration.clone(), vec![get_transactions()], None, None),
         None,
     )
     .await;

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -167,7 +167,7 @@ async fn run_standalone_test(test_type: TestType) {
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(
-        common::build_load_test(configuration.clone(), &get_transactions(), None, None),
+        common::build_load_test(configuration.clone(), vec![get_transactions()], None, None),
         None,
     )
     .await;
@@ -191,7 +191,7 @@ async fn run_gaggle_test(test_type: TestType) {
     let worker_handles = common::launch_gaggle_workers(EXPECT_WORKERS, || {
         common::build_load_test(
             worker_configuration.clone(),
-            &get_transactions(),
+            vec![get_transactions()],
             None,
             None,
         )
@@ -217,7 +217,7 @@ async fn run_gaggle_test(test_type: TestType) {
     // Build the load test for the Manager.
     let manager_goose_attack = common::build_load_test(
         manager_configuration.clone(),
-        &get_transactions(),
+        vec![get_transactions()],
         None,
         None,
     );

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -298,7 +298,7 @@ async fn run_standalone_test(test_type: TestType, format: &str) {
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(
-        common::build_load_test(configuration, &get_transactions(), None, None),
+        common::build_load_test(configuration, vec![get_transactions()], None, None),
         None,
     )
     .await;
@@ -418,7 +418,7 @@ async fn run_gaggle_test(test_type: TestType, format: &str) {
         let worker_configuration = common::build_configuration(&server, worker_configuration_flags);
         let worker_goose_attack = common::build_load_test(
             worker_configuration.clone(),
-            &get_transactions(),
+            vec![get_transactions()],
             None,
             None,
         );
@@ -446,7 +446,7 @@ async fn run_gaggle_test(test_type: TestType, format: &str) {
 
     // Build the load test for the Manager.
     let manager_goose_attack =
-        common::build_load_test(manager_configuration, &get_transactions(), None, None);
+        common::build_load_test(manager_configuration, vec![get_transactions()], None, None);
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles)).await;

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -121,7 +121,7 @@ async fn run_load_test(is_gaggle: bool) {
 
             // Run the Goose Attack.
             common::run_load_test(
-                common::build_load_test(configuration, &get_transactions(), None, None),
+                common::build_load_test(configuration, vec![get_transactions()], None, None),
                 None,
             )
             .await;
@@ -134,7 +134,7 @@ async fn run_load_test(is_gaggle: bool) {
             let worker_handles = common::launch_gaggle_workers(EXPECT_WORKERS, || {
                 common::build_load_test(
                     worker_configuration.clone(),
-                    &get_transactions(),
+                    vec![get_transactions()],
                     None,
                     None,
                 )
@@ -146,7 +146,12 @@ async fn run_load_test(is_gaggle: bool) {
 
             // Run the Goose Attack.
             common::run_load_test(
-                common::build_load_test(manager_configuration, &get_transactions(), None, None),
+                common::build_load_test(
+                    manager_configuration,
+                    vec![get_transactions()],
+                    None,
+                    None,
+                ),
                 Some(worker_handles),
             )
             .await;

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -166,7 +166,7 @@ async fn run_standalone_test(test_type: TestType) {
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(
-        common::build_load_test(configuration.clone(), &get_transactions(), None, None),
+        common::build_load_test(configuration.clone(), vec![get_transactions()], None, None),
         None,
     )
     .await;
@@ -190,7 +190,7 @@ async fn run_gaggle_test(test_type: TestType) {
     let worker_handles = common::launch_gaggle_workers(EXPECT_WORKERS, || {
         common::build_load_test(
             worker_configuration.clone(),
-            &get_transactions(),
+            vec![get_transactions()],
             None,
             None,
         )
@@ -216,7 +216,7 @@ async fn run_gaggle_test(test_type: TestType) {
     // Build the load test for the Manager.
     let manager_goose_attack = common::build_load_test(
         manager_configuration.clone(),
-        &get_transactions(),
+        vec![get_transactions()],
         None,
         None,
     );

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -332,7 +332,12 @@ async fn run_standalone_test(test_type: TestType) {
 
     // Run the Goose Attack.
     common::run_load_test(
-        common::build_load_test(configuration, &get_transactions(&test_type), None, None),
+        common::build_load_test(
+            configuration,
+            vec![get_transactions(&test_type)],
+            None,
+            None,
+        ),
         None,
     )
     .await;
@@ -361,7 +366,7 @@ async fn run_gaggle_test(test_type: TestType) {
     let worker_handles = common::launch_gaggle_workers(EXPECT_WORKERS, || {
         common::build_load_test(
             worker_configuration.clone(),
-            &get_transactions(&test_type),
+            vec![get_transactions(&test_type)],
             None,
             None,
         )
@@ -374,7 +379,7 @@ async fn run_gaggle_test(test_type: TestType) {
     // Build the load test for the Workers.
     let manager_goose_attack = common::build_load_test(
         manager_configuration,
-        &get_transactions(&test_type),
+        vec![get_transactions(&test_type)],
         None,
         None,
     );

--- a/tests/scenarios.rs
+++ b/tests/scenarios.rs
@@ -1,0 +1,312 @@
+/// Validate that Goose only runs the selected Scenario filtered by --scenarios.
+use httpmock::{Method::GET, Mock, MockServer};
+use serial_test::serial;
+
+mod common;
+
+use goose::config::GooseConfiguration;
+use goose::goose::GooseMethod;
+use goose::prelude::*;
+
+// Paths used in load tests performed during these tests.
+const SCENARIOA1: &str = "/path/a/1";
+const SCENARIOA2: &str = "/path/a/2";
+const SCENARIOB1: &str = "/path/b/1";
+const SCENARIOB2: &str = "/path/b/2";
+
+// Indexes to the above paths.
+const SCENARIOA1_KEY: usize = 0;
+const SCENARIOA2_KEY: usize = 1;
+const SCENARIOB1_KEY: usize = 2;
+const SCENARIOB2_KEY: usize = 3;
+
+// Load test configuration.
+const EXPECT_WORKERS: usize = 2;
+
+// There are multiple test variations in this file.
+enum TestType {
+    // Limit scenarios with --scenarios option.
+    ScenariosOption,
+    // Limit scenarios with GooseDefault::Scenarios.
+    ScenariosDefault,
+}
+
+// Test transaction.
+pub async fn get_scenarioa1(user: &mut GooseUser) -> TransactionResult {
+    let _goose = user.get(SCENARIOA1).await?;
+    Ok(())
+}
+
+// Test transaction.
+pub async fn get_scenarioa2(user: &mut GooseUser) -> TransactionResult {
+    let _goose = user.get(SCENARIOA2).await?;
+    Ok(())
+}
+
+// Test transaction.
+pub async fn get_scenariob1(user: &mut GooseUser) -> TransactionResult {
+    let _goose = user.get(SCENARIOB1).await?;
+    Ok(())
+}
+
+// Test transaction.
+pub async fn get_scenariob2(user: &mut GooseUser) -> TransactionResult {
+    let _goose = user.get(SCENARIOB2).await?;
+    Ok(())
+}
+
+// All tests in this file run against a common endpoint.
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+    vec![
+        // SCENARIOA1 is stored in vector at SCENARIOA1_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(SCENARIOA1);
+            then.status(200);
+        }),
+        // SCENARIOA2 is stored in vector at SCENARIOA2_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(SCENARIOA2);
+            then.status(200);
+        }),
+        // SCENARIOB1 is stored in vector at SCENARIOB1_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(SCENARIOB1);
+            then.status(200);
+        }),
+        // SCENARIOB2 is stored in vector at SCENARIOB2_KEY.
+        server.mock(|when, then| {
+            when.method(GET).path(SCENARIOB2);
+            then.status(200);
+        }),
+    ]
+}
+
+// Build appropriate configuration for these tests.
+fn common_build_configuration(server: &MockServer, test_type: &TestType) -> GooseConfiguration {
+    // In all cases throttle requests to allow asserting metrics precisely.
+    let configuration = match test_type {
+        TestType::ScenariosOption => {
+            // Start 10 users in 1 second, then run for 1 more second.
+            vec![
+                "--users",
+                "10",
+                "--hatch-rate",
+                "10",
+                "--run-time",
+                "1",
+                "--no-reset-metrics",
+                // Only run Scenario A1 and Scenario A2
+                "--scenarios",
+                "scenarioa",
+            ]
+        }
+        TestType::ScenariosDefault => {
+            // Start 10 users in 1 second, then run for 1 more second.
+            vec![
+                "--users",
+                "10",
+                "--hatch-rate",
+                "10",
+                "--run-time",
+                "1",
+                "--no-reset-metrics",
+            ]
+        }
+    };
+
+    // Build the resulting configuration.
+    common::build_configuration(server, configuration)
+}
+
+// Helper to confirm all variations generate appropriate results.
+fn validate_loadtest(
+    goose_metrics: &GooseMetrics,
+    mock_endpoints: &[Mock],
+    configuration: &GooseConfiguration,
+    test_type: TestType,
+) {
+    assert!(goose_metrics.total_users == configuration.users.unwrap());
+    assert!(goose_metrics.maximum_users == 10);
+    assert!(goose_metrics.total_users == 10);
+
+    match test_type {
+        TestType::ScenariosOption => {
+            // Get scenarioa1 metrics.
+            let scenarioa1_metrics = goose_metrics
+                .requests
+                .get(&format!("GET {}", SCENARIOA1))
+                .unwrap();
+            // Confirm that the path and method are correct in the statistics.
+            assert!(scenarioa1_metrics.path == SCENARIOA1);
+            assert!(scenarioa1_metrics.method == GooseMethod::Get);
+            // There should not have been any failures during this test.
+            assert!(scenarioa1_metrics.fail_count == 0);
+            // Confirm Goose and the mock endpoint agree on the number of requests made.
+            assert!(mock_endpoints[SCENARIOA1_KEY].hits() <= scenarioa1_metrics.success_count);
+
+            // Get scenarioa2 metrics.
+            let scenarioa2_metrics = goose_metrics
+                .requests
+                .get(&format!("GET {}", SCENARIOA2))
+                .unwrap();
+            // Confirm that the path and method are correct in the statistics.
+            assert!(scenarioa2_metrics.path == SCENARIOA2);
+            assert!(scenarioa2_metrics.method == GooseMethod::Get);
+            // There should not have been any failures during this test.
+            assert!(scenarioa2_metrics.fail_count == 0);
+            // Confirm Goose and the mock endpoint agree on the number of requests made.
+            assert!(mock_endpoints[SCENARIOA2_KEY].hits() <= scenarioa2_metrics.success_count);
+
+            // scenariob1 and scenariob2 should not have been loaded due to `--scenarios scenarioa`.
+            assert!(mock_endpoints[SCENARIOB1_KEY].hits() == 0);
+            assert!(mock_endpoints[SCENARIOB2_KEY].hits() == 0);
+        }
+        TestType::ScenariosDefault => {
+            // scenarioa1 and scenarioa2 should not have been loaded due to `GooseDefault::Scenarios`.
+            assert!(mock_endpoints[SCENARIOA1_KEY].hits() == 0);
+            assert!(mock_endpoints[SCENARIOA2_KEY].hits() == 0);
+            assert!(mock_endpoints[SCENARIOB1_KEY].hits() > 0);
+            assert!(mock_endpoints[SCENARIOB2_KEY].hits() > 0);
+        }
+    }
+}
+
+// Returns the appropriate scenarios needed to build these tests.
+fn get_scenarios() -> Vec<Scenario> {
+    vec![
+        scenario!("Scenario A1").register_transaction(transaction!(get_scenarioa1)),
+        scenario!("Scenario A2").register_transaction(transaction!(get_scenarioa2)),
+        scenario!("Scenario B1").register_transaction(transaction!(get_scenariob1)),
+        scenario!("Scenario B2").register_transaction(transaction!(get_scenariob2)),
+    ]
+}
+
+// Helper to run all standalone tests.
+async fn run_standalone_test(test_type: TestType) {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    // Build common configuration elements.
+    let configuration = common_build_configuration(&server, &test_type);
+
+    let mut goose = common::build_load_test(configuration.clone(), get_scenarios(), None, None);
+
+    // By default, only run scenarios starting with `scenariob`.
+    goose = *goose
+        .set_default(GooseDefault::Scenarios, "scenariob")
+        .unwrap();
+
+    // Run the Goose Attack.
+    let goose_metrics = common::run_load_test(goose, None).await;
+
+    // Confirm that the load test ran correctly.
+    validate_loadtest(&goose_metrics, &mock_endpoints, &configuration, test_type);
+}
+
+// Helper to run all standalone tests.
+async fn run_gaggle_test(test_type: TestType) {
+    // Start the mock server.
+    let server = MockServer::start();
+
+    // Setup the endpoints needed for this test on the mock server.
+    let mock_endpoints = setup_mock_server_endpoints(&server);
+
+    // Each worker has the same identical configuration.
+    let worker_configuration = common::build_configuration(&server, vec!["--worker"]);
+
+    // Workers launched in own threads, store thread handles.
+    let worker_handles = common::launch_gaggle_workers(EXPECT_WORKERS, || {
+        common::build_load_test(worker_configuration.clone(), get_scenarios(), None, None)
+    });
+
+    // Build common configuration elements, adding Manager Gaggle flags.
+    let manager_configuration = match test_type {
+        TestType::ScenariosOption => common::build_configuration(
+            &server,
+            vec![
+                "--manager",
+                "--expect-workers",
+                &EXPECT_WORKERS.to_string(),
+                "--no-reset-metrics",
+                "--users",
+                "10",
+                "--hatch-rate",
+                "10",
+                "--run-time",
+                "1",
+                "--scenarios",
+                "scenarioa",
+            ],
+        ),
+        TestType::ScenariosDefault => common::build_configuration(
+            &server,
+            vec![
+                "--manager",
+                "--expect-workers",
+                &EXPECT_WORKERS.to_string(),
+                "--no-reset-metrics",
+                "--users",
+                "10",
+                "--hatch-rate",
+                "10",
+                "--run-time",
+                "1",
+            ],
+        ),
+    };
+
+    // Build the load test for the Manager.
+    let mut manager_goose_attack =
+        common::build_load_test(manager_configuration.clone(), get_scenarios(), None, None);
+
+    // By default, only run scenarios starting with `scenariob`.
+    manager_goose_attack = *manager_goose_attack
+        .set_default(GooseDefault::Scenarios, "scenariob")
+        .unwrap();
+
+    // Run the Goose Attack.
+    let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles)).await;
+
+    // Confirm that the load test ran correctly.
+    validate_loadtest(
+        &goose_metrics,
+        &mock_endpoints,
+        &manager_configuration,
+        test_type,
+    );
+}
+
+/* With `--scenarios` */
+
+#[tokio::test]
+// Run only half the configured scenarios.
+async fn test_scenarios_option() {
+    run_standalone_test(TestType::ScenariosOption).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+#[serial]
+// Run only half the configured scenarios, in Gaggle mode.
+async fn test_scenarios_option_gaggle() {
+    run_gaggle_test(TestType::ScenariosOption).await;
+}
+
+/* With `GooseDefault::Scenarios` */
+
+#[tokio::test]
+// Run only half the configured scenarios.
+async fn test_scenarios_default() {
+    run_standalone_test(TestType::ScenariosDefault).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[cfg_attr(not(feature = "gaggle"), ignore)]
+#[serial]
+// Run only half the configured scenarios, in Gaggle mode.
+async fn test_scenarios_default_gaggle() {
+    run_gaggle_test(TestType::ScenariosDefault).await;
+}

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -136,15 +136,18 @@ fn build_goose_attack(test_type: &TestType, configuration: GooseConfiguration) -
     let start_transaction = transaction!(setup);
     let stop_transaction = transaction!(teardown);
     match test_type {
-        TestType::Start => {
-            common::build_load_test(configuration, &scenario, Some(&start_transaction), None)
-        }
+        TestType::Start => common::build_load_test(
+            configuration,
+            vec![scenario],
+            Some(&start_transaction),
+            None,
+        ),
         TestType::Stop => {
-            common::build_load_test(configuration, &scenario, None, Some(&stop_transaction))
+            common::build_load_test(configuration, vec![scenario], None, Some(&stop_transaction))
         }
         TestType::StartAndStop => common::build_load_test(
             configuration,
-            &scenario,
+            vec![scenario],
             Some(&start_transaction),
             Some(&stop_transaction),
         ),

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -180,7 +180,7 @@ async fn test_throttle() {
 
     // Run the Goose Attack.
     common::run_load_test(
-        common::build_load_test(configuration, &get_transactions(), None, None),
+        common::build_load_test(configuration, vec![get_transactions()], None, None),
         None,
     )
     .await;
@@ -210,7 +210,7 @@ async fn test_throttle() {
 
     // Run the Goose Attack.
     common::run_load_test(
-        common::build_load_test(configuration, &get_transactions(), None, None),
+        common::build_load_test(configuration, vec![get_transactions()], None, None),
         None,
     )
     .await;
@@ -254,7 +254,7 @@ async fn test_throttle_gaggle() {
         request_logs.push(worker_configuration.request_log.clone());
         let worker_goose_attack = common::build_load_test(
             worker_configuration.clone(),
-            &get_transactions(),
+            vec![get_transactions()],
             None,
             None,
         );
@@ -279,7 +279,7 @@ async fn test_throttle_gaggle() {
     // Build the load test for the Manager.
     let manager_goose_attack = common::build_load_test(
         manager_configuration.clone(),
-        &get_transactions(),
+        vec![get_transactions()],
         None,
         None,
     );
@@ -314,7 +314,7 @@ async fn test_throttle_gaggle() {
         request_logs.push(worker_configuration.request_log.clone());
         let worker_goose_attack = common::build_load_test(
             worker_configuration.clone(),
-            &get_transactions(),
+            vec![get_transactions()],
             None,
             None,
         );
@@ -327,7 +327,7 @@ async fn test_throttle_gaggle() {
 
     // Build the load test for the Manager.
     let manager_goose_attack =
-        common::build_load_test(manager_configuration, &get_transactions(), None, None);
+        common::build_load_test(manager_configuration, vec![get_transactions()], None, None);
 
     // Run the Goose Attack.
     common::run_load_test(manager_goose_attack, Some(worker_handles)).await;


### PR DESCRIPTION
- NOTE: depends on #506 being merged fixed (to address clippy errors) -- I've rebased on top of this PR

 - assign a unique machine name for each scenario
 - introduce `--scenarios` to optionally specify which scenarios run during a load test
 - introduce `--scenarios-list` to list scenarios by machine name
 - introduce `GooseDefault::Scenarios`
 - test coverage
 - update `test/common.rs::build_load_test()` to support multiple scenarios (necessary to test this feature)
 - add book page titled "Limiting Which Scenarios Run" that provides complete details on this new feature
 - closes https://github.com/tag1consulting/goose/issues/479
 - closes https://github.com/tag1consulting/goose/issues/472