### PR TITLE
release 0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.16.3-dev
+## 0.16.3 July 17, 2022
  - [#498](https://github.com/tag1consulting/goose/issues/498) ignore `GooseDefault::Host` if set to an empty string
  - [#487](https://github.com/tag1consulting/goose/pull/487) add dev-dependency on (nix)[https://docs.rs/nix] to provide test coverage confirming proper shutdown from SIGINT (ctrl-c); capture ctrl-c in a lazy_static wrapped in a RwLock so it can be reset
  - [#489](https://github.com/tag1consulting/goose/pull/489) don't panic when writing report file and shutting down with controller

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.16.3-dev"
+version = "0.16.3"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/src/docs/goose-book/src/controller/telnet.md
+++ b/src/docs/goose-book/src/controller/telnet.md
@@ -11,7 +11,7 @@ Trying 127.0.0.1...
 Connected to localhost.
 Escape character is '^]'.
 goose> ?
-goose 0.16.1 controller commands:
+goose 0.16.3 controller commands:
 help               this help
 exit               exit controller
 
@@ -110,6 +110,6 @@ The above commands are also summarized in the metrics overview:
  Canceling:   2022-05-05 07:11:13 - 2022-05-05 07:11:13 (00:00:00, 0 <- 20)
 
  Target host: https://umami.ddev.site/
- goose v0.16.1
+ goose v0.16.3
  ------------------------------------------------------------------------------
 ```

--- a/src/docs/goose-book/src/getting-started/creating.md
+++ b/src/docs/goose-book/src/getting-started/creating.md
@@ -23,9 +23,9 @@ At this point it's possible to compile all dependencies, though the resulting bi
 ```bash
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.16.2
+  Downloaded goose v0.16.3
       ...
-   Compiling goose v0.16.2
+   Compiling goose v0.16.3
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`

--- a/src/docs/goose-book/src/getting-started/metrics.md
+++ b/src/docs/goose-book/src/getting-started/metrics.md
@@ -7,7 +7,7 @@ In this case, the [Drupal Umami demo](https://www.drupal.org/docs/umami-drupal-d
 ## ASCII metrics
 ```bash
 % cargo run --release --example umami -- --host http://umami.ddev.site/ -u9 -r3 -t1m --no-reset-metrics --report-file report.html
-   Compiling goose v0.16.2 (~/goose)
+   Compiling goose v0.16.3 (~/goose)
     Finished release [optimized] target(s) in 11.88s
      Running `target/release/examples/umami --host 'http://umami.ddev.site/' -u9 -r3 -t1m --no-reset-metrics --report-file report.html`
 05:09:05 [INFO] Output verbosity level: INFO
@@ -285,7 +285,7 @@ All 9 users hatched.
  Decreasing:  2022-05-17 07:10:08 - 2022-05-17 07:10:08 (00:00:00, 0 <- 9)
 
  Target host: http://umami.ddev.site/
- goose v0.16.2
+ goose v0.16.3
  ------------------------------------------------------------------------------
 ```
 


### PR DESCRIPTION
## 0.16.3 July 17, 2022
 - [#498](https://github.com/tag1consulting/goose/issues/498) ignore `GooseDefault::Host` if set to an empty string
 - [#487](https://github.com/tag1consulting/goose/pull/487) add dev-dependency on (nix)[https://docs.rs/nix] to provide test coverage confirming proper shutdown from SIGINT (ctrl-c); capture ctrl-c in a lazy_static wrapped in a RwLock so it can be reset
 - [#489](https://github.com/tag1consulting/goose/pull/489) don't panic when writing report file and shutting down with controller
 - [#505](https://github.com/tag1consulting/goose/pull/505) introduce `--scenarios` (and `GooseDefault::Scenarios`) so a subset of scenarios can be launched, and `--scenarios-list` to display internal machine names for matching
