### PR TITLE
Fix panic when a empty wait time interval is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.16.4-dev
  - [#512](https://github.com/tag1consulting/goose/pull/512) include proper HTTP method and path in logs and html report when using `GooseRequest::builder()`
+ - [#514](https://github.com/tag1consulting/goose/pull/514) fix panic when an empty wait time interval is set
 
 ## 0.16.3 July 17, 2022
  - [#498](https://github.com/tag1consulting/goose/issues/498) ignore `GooseDefault::Host` if set to an empty string

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -59,14 +59,14 @@
 //! scenario, the user will pause for a random number of milliseconds inclusively between
 //! the low and high wait times. In the following example, users loading `foo` transactions will
 //! sleep 0 to 2.5 seconds after each transaction completes, and users loading `bar` transactions will
-//! sleep 5 to 10 seconds after each transaction completes.
+//! always sleep 5 seconds after each transaction completes.
 //!
 //! ```rust
 //! use goose::prelude::*;
 //! use std::time::Duration;
 //!
 //! let mut foo_transactions = scenario!("FooTransactions").set_wait_time(Duration::from_secs(0), Duration::from_millis(2500)).unwrap();
-//! let mut bar_transactions = scenario!("BarTransactions").set_wait_time(Duration::from_secs(5), Duration::from_secs(10)).unwrap();
+//! let mut bar_transactions = scenario!("BarTransactions").set_wait_time(Duration::from_secs(5), Duration::from_secs(5)).unwrap();
 //! ```
 //! ## Creating Transactions
 //!

--- a/src/user.rs
+++ b/src/user.rs
@@ -83,7 +83,7 @@ pub(crate) async fn user_main(
                 // If the transaction_wait is defined, wait for a random time between transaction.
                 if let Some((min, max)) = thread_scenario.transaction_wait {
                     // Total time left to wait before running the next transaction.
-                    let mut wait_time = rand::thread_rng().gen_range(min..max).as_millis();
+                    let mut wait_time = rand::thread_rng().gen_range(min..=max).as_millis();
                     // Track the time slept for Coordinated Omission Mitigation.
                     let sleep_timer = time::Instant::now();
                     // Never sleep more than 500 milliseconds, allowing a sleeping transaction to shut


### PR DESCRIPTION
Previously, despite what the [documentation](https://docs.rs/goose/0.16.3/goose/goose/index.html#scenario-wait-time) says ("inclusively between the low and high"), the wait time was generated with the upper bound exclusive. This lead to the problem that a constant wait time (the same upper and lower limit) would panic because there is no valid value for rand to return.
`thread 'tokio-runtime-worker' panicked at 'cannot sample empty range', [left out for privacy]\rand-0.8.5\src\rng.rs:134:9`


This PR fixes this by this by using a closed range to generate the wait time. Additionally, a example in the documentation now reflects this usecase.