### PR TITLE
Refactor CSV Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.16.4-dev
  - [#512](https://github.com/tag1consulting/goose/pull/512) include proper HTTP method and path in logs and html report when using `GooseRequest::builder()`
  - [#514](https://github.com/tag1consulting/goose/pull/514) fix panic when an empty wait time interval is set
+ - [#516](https://github.com/tag1consulting/goose/pull/516) fix unescaped inner quotes in csv logs
 
 ## 0.16.3 July 17, 2022
  - [#498](https://github.com/tag1consulting/goose/issues/498) ignore `GooseDefault::Host` if set to an empty string

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -166,6 +166,7 @@ pub(crate) type GooseLoggerTx = Option<flume::Sender<Option<GooseLog>>>;
 /// Inner quotes are doubled according to RFC 4180 2.7.
 /// The fields are joined by commas `,`, but *not* terminated with a line ending.
 #[macro_export]
+#[doc(hidden)]
 macro_rules! format_csv_row {
     ($( $field:expr ),+ $(,)?) => {{
         [$( $field.to_string() ),*]

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -741,3 +741,12 @@ async fn test_all_logs_pretty() {
 async fn test_all_logs_pretty_gaggle() {
     run_gaggle_test(TestType::All, "pretty").await;
 }
+
+#[test]
+fn test_csv_row_macro() {
+    let row = goose::logger::format_csv_row!(1, '"', "hello , ");
+    assert_eq!(r#"1,"""","hello , ""#, row);
+
+    let row = goose::logger::format_csv_row!(format!("{:?}", (1, 2)), "你好", "A\nNew Day",);
+    assert_eq!("\"(1, 2)\",你好,\"A\nNew Day\"", row);
+}


### PR DESCRIPTION
To fix #515 I added a macro that properly escapes the values.
I like this approach because it is very lightweight and doesn't add any csv reader functionality as many external dependencies would. On the other hand, this still struggles with nested data and Option<> as well as hard coded headers.

However, currently in order to use the macro in the tests, I use macro_export, but then this leaks into the docs. Does anyone know how to prevent this in Edition 2018? Or is this a case for docs::hidden?

I additionally propose to flatten the GooseRequestMetric.raw into its fields method, url, headers, body for the request log and error log. For GooseDebug, which includes a whole GooseRequestMetric, a similar argument applies.
The Option<> values should further be represented by an empty string when None.
Since those changes potentially break external metric analysis via CSV import, I am reluctant to make these changes without further input.
What do you think? Do you import goose metrics in another program? And via csv or other?