### PR TITLE
release 0.17.0 without gaggle support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.17.0
+## 0.17.0 December 9, 2022
  - [#529](https://github.com/tag1consulting/goose/pull/529) **API change** temporaryily removed Gaggle support `gaggle` feature) to allow upgrading Tokio and other dependencies.
    - if you require Gaggle support, use Goose 0.16.4 with Tokio 0.15 for now; Gaggle support is being added back in https://github.com/tag1consulting/goose/pull/509
    - updated Tokio to 1.23, updated tungestenite and tokio-tungstenite to 0.18; updated ctrlc to 3.2; updated num_cpus to 1.14, updated simplelog to 0.12, updated nix to 0.26, updated rustls to 0.20, updates serial_test to 0.9

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.17.0-dev"
+version = "0.17.0"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."


### PR DESCRIPTION
 - release 0.17.0 without gaggle support
 - this release updates goose dependencies, most notably tokio (see https://github.com/tag1consulting/goose/pull/529)
 - if you require Gaggle support, currently you must use the older 0.16.4 release w/ tokio 1.15 (until https://github.com/tag1consulting/goose/pull/509 lands)

Regression testing:
- https://docs.google.com/spreadsheets/d/1w71FEk-y3zaanHIa5NZnhu8UNVD4lhG3aCjUlANgbhE/edit#gid=0
- https://docs.google.com/document/d/16nTv1rKYNmkyMPFOiL4joCyeh2ETqy9TUrH2c6YjFoc/edit?usp=sharing
