### PR TITLE
document why we're not awaiting

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -987,7 +987,9 @@ pub(crate) async fn controller_main(
 
         // Spawn a new thread to communicate with a client. The returned JoinHandle is
         // ignored as the thread simply runs until the client exits or Goose shuts down.
-        let _ = tokio::spawn(controller_state.accept_connections(stream)).await;
+        // Don't .await the tokio::spawn or Goose can't handle multiple simultaneous
+        // connections.
+        let _ignored_joinhandle = tokio::spawn(controller_state.accept_connections(stream));
     }
 
     Ok(())

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -987,7 +987,7 @@ pub(crate) async fn controller_main(
 
         // Spawn a new thread to communicate with a client. The returned JoinHandle is
         // ignored as the thread simply runs until the client exits or Goose shuts down.
-        let _ = tokio::spawn(controller_state.accept_connections(stream));
+        let _ = tokio::spawn(controller_state.accept_connections(stream)).await;
     }
 
     Ok(())

--- a/tests/cancel.rs
+++ b/tests/cancel.rs
@@ -236,7 +236,7 @@ async fn run_standalone_test(test_type: TestType) {
     let configuration = common_build_configuration(&server, &test_type);
 
     // Start a thread that will send a SIGINT to the running load test.
-    let _ = tokio::spawn(cancel_load_test(Duration::from_secs(3)));
+    let _ = tokio::spawn(cancel_load_test(Duration::from_secs(3))).await;
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(
@@ -333,7 +333,7 @@ async fn run_gaggle_test(test_type: TestType) {
     );
 
     // Start a thread that will send a SIGINT to the running load test.
-    let _ = tokio::spawn(cancel_load_test(Duration::from_secs(3)));
+    let _ = tokio::spawn(cancel_load_test(Duration::from_secs(3))).await;
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles)).await;

--- a/tests/cancel.rs
+++ b/tests/cancel.rs
@@ -236,7 +236,8 @@ async fn run_standalone_test(test_type: TestType) {
     let configuration = common_build_configuration(&server, &test_type);
 
     // Start a thread that will send a SIGINT to the running load test.
-    let _ = tokio::spawn(cancel_load_test(Duration::from_secs(3))).await;
+    // Don't await tokio::spawn, instead run in parallel and continue to start Goose Attakc.
+    let _ignored_joinhandle = tokio::spawn(cancel_load_test(Duration::from_secs(3)));
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(
@@ -333,7 +334,8 @@ async fn run_gaggle_test(test_type: TestType) {
     );
 
     // Start a thread that will send a SIGINT to the running load test.
-    let _ = tokio::spawn(cancel_load_test(Duration::from_secs(3))).await;
+    // Don't await tokio::spawn, instead run in parallel and continue to start Goose Attakc.
+    let _ignored_joinhandle = tokio::spawn(cancel_load_test(Duration::from_secs(3)));
 
     // Run the Goose Attack.
     let goose_metrics = common::run_load_test(manager_goose_attack, Some(worker_handles)).await;

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -277,9 +277,6 @@ async fn test_defaults_gaggle() {
     // Setup the mock endpoints needed for this test.
     let mock_endpoints = setup_mock_server_endpoints(&server);
 
-    const HOST: &str = "127.0.0.1";
-    const PORT: usize = 9988;
-
     let mut configuration = common::build_configuration(&server, vec![]);
 
     // Unset options set in common.rs so set_default() is instead used.


### PR DESCRIPTION
 - address clippy false-positive with https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_future (it suggested we had a missing await, but in this case we don't want to await tokio::spawn as we're intentionally starting a new thread but don't need to do anything with the JoinHandle)
 - remove unused constants (cut and paste cruft)