### PR TITLE
remove dependency on serde_cbor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## 0.17.1-dev
- - remove external dependency on num_cpus(), use instead built-in available_parallelism() added in rust 1.59.0
- - add `scenario_index`, `scenario_name`, `transaction_index` and `transaction_name` to the request log
+ - [#543](https://github.com/tag1consulting/goose/pull/543) remove external dependency on num_cpus(), use instead built-in available_parallelism() added in rust 1.59.0
+ - [#552](https://github.com/tag1consulting/goose/pull/552) add `scenario_index`, `scenario_name`, `transaction_index` and `transaction_name` to the request log
+ - [#553](https://github.com/tag1consulting/goose/pull/553) remove `serde_cbor` dependency no longer required due to [#529]
 
 ## 0.17.0 December 9, 2022
  - [#529](https://github.com/tag1consulting/goose/pull/529) **API change** temporaryily removed Gaggle support `gaggle` feature) to allow upgrading Tokio and other dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ reqwest = { version = "0.11",  default-features = false, features = [
 serde = { version = "1.0", features = [
     "derive",
 ] }
-serde_cbor = "0.11"
 serde_json = "1.0"
 simplelog = "0.12"
 strum = "0.24"


### PR DESCRIPTION
 - remove serde_cbor no longer required due to [#529]
 - fixes https://github.com/tag1consulting/goose/issues/540