### PR TITLE
update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - [#543](https://github.com/tag1consulting/goose/pull/543) remove external dependency on num_cpus(), use instead built-in available_parallelism() added in rust 1.59.0
  - [#552](https://github.com/tag1consulting/goose/pull/552) add `scenario_index`, `scenario_name`, `transaction_index` and `transaction_name` to the request log
  - [#553](https://github.com/tag1consulting/goose/pull/553) remove `serde_cbor` dependency no longer required due to [#529]
+ - [#554](https://github.com/tag1consulting/goose/pull/554) update `flume`, `itertools`, `strum`, `strum_macros`, `tokio-tungstenite`, and `tungestenite` dependencies to latest versions
 
 ## 0.17.0 December 9, 2022
  - [#529](https://github.com/tag1consulting/goose/pull/529) **API change** temporaryily removed Gaggle support `gaggle` feature) to allow upgrading Tokio and other dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ license = "Apache-2.0"
 [dependencies]
 async-trait = "0.1"
 chrono = "0.4"
-ctrlc = "3.2"
+ctrlc = "3"
 downcast-rs = "1.2"
-flume = "0.10"
+flume = "0.11"
 futures = "0.3"
 gumdrop = "0.8"
 http = "0.2"
-itertools = "0.10"
+itertools = "0.11"
 lazy_static = "1.4"
 log = "0.4"
 num-format = "0.4"
@@ -36,9 +36,9 @@ serde = { version = "1.0", features = [
 ] }
 serde_json = "1.0"
 simplelog = "0.12"
-strum = "0.24"
-strum_macros = "0.24"
-tokio = { version = "1.23", features = [
+strum = "0.25"
+strum_macros = "0.25"
+tokio = { version = "1", features = [
     "fs",
     "io-util",
     "macros",
@@ -47,8 +47,8 @@ tokio = { version = "1.23", features = [
     "time",
     "sync",
 ] }
-tokio-tungstenite = "0.18"
-tungstenite = "0.18"
+tokio-tungstenite = "0.20"
+tungstenite = "0.20"
 url = "2"
 
 [features]


### PR DESCRIPTION
- update `flume`, `itertools`, `strum`, `strum_macros`, `tokio-tungstenite`, and `tungestenite` dependencies to latest versions