### PR TITLE
Speed up user initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -750,6 +750,8 @@ impl GooseAttack {
             "initializing {} user states...",
             self.test_plan.total_users()
         );
+
+        let reqwest_client = goose::create_reqwest_client(&self.configuration)?;
         let mut weighted_users = Vec::new();
         let mut user_count = 0;
         loop {
@@ -770,6 +772,7 @@ impl GooseAttack {
                     base_url,
                     &self.configuration,
                     self.metrics.hash,
+                    Some(reqwest_client.clone()),
                 )?);
                 user_count += 1;
                 if user_count == total_users {


### PR DESCRIPTION
When running goose tests with large amounts of goose users on my machine, it takes roughly 1 minute to initialize 1000 goose users. It appears that building each reqwest client for each goose user is an expensive operation. If we change the behavior to build only 1 reqwest client, and clone the object when creating the goose users, we can significantly increase initialization performance. With this change, I can create a few million goose users and only takes a couple of seconds to complete the initialization phase on my machine.