### PR TITLE
disable default chrono features, fix potential segfault in the time crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.17.2-dev
  - [#557](https://github.com/tag1consulting/goose/pull/557) speed up user initialization on Linux
+ - [#559](https://github.com/tag1consulting/goose/pull/559) disable unnecessary features in chronos, avoid potential segfault in time crate: https://rustsec.org/advisories/RUSTSEC-2020-0071
 
 ## 0.17.1 August 17, 2023
  - [#543](https://github.com/tag1consulting/goose/pull/543) remove external dependency on num_cpus(), use instead built-in available_parallelism() added in rust 1.59.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 
 [dependencies]
 async-trait = "0.1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ctrlc = "3"
 downcast-rs = "1.2"
 flume = "0.11"


### PR DESCRIPTION
 - fixes https://github.com/tag1consulting/goose/issues/558 
 - only enable required features from `chrono`, addressing https://rustsec.org/advisories/RUSTSEC-2020-0071

> A possible workaround for crates affected through the transitive dependency in chrono, is to avoid using the default oldtime feature dependency of the chrono crate by disabling its default-features and manually specifying the required features instead.

- source of the fix: https://github.com/chronotope/chrono/issues/602#issuecomment-1242149249

This fixes the following issue detailed [at the link above](https://rustsec.org/advisories/RUSTSEC-2020-0071):
> Unix-like operating systems may segfault due to dereferencing a dangling pointer in specific circumstances. This requires an environment variable to be set in a different thread than the affected functions. This may occur without the user's knowledge, notably in a third-party library.