### PR TITLE
remove empty if branch

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2546,7 +2546,6 @@ impl GooseMetrics {
             env!("CARGO_PKG_VERSION"),
         )?;
 
-        if self.hosts.len() == 1 {}
         writeln!(
             fmt,
             " ------------------------------------------------------------------------------"


### PR DESCRIPTION
 - Fixes clippy detected issue:
```
error: this `if` branch is empty
Error:     --> src/metrics.rs:2549:9
     |
2549 |         if self.hosts.len() == 1 {}
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `self.hosts.len() == 1;`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_if
     = note: `-D clippy::needless-if` implied by `-D warnings`
```

- Using `git blame` confirmed this was added during [#342](https://github.com/tag1consulting/goose/pull/342)
- This slipped in during that earlier PR, and is not necessary; simply removing