### PR TITLE
v0.17.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.17.2-dev
+## 0.17.2 August 28, 2023
  - [#557](https://github.com/tag1consulting/goose/pull/557) speed up user initialization on Linux
  - [#559](https://github.com/tag1consulting/goose/pull/559) disable unnecessary features in chronos, avoid potential segfault in time crate: https://rustsec.org/advisories/RUSTSEC-2020-0071
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.17.2-dev"
+version = "0.17.2"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/src/docs/goose-book/src/controller/telnet.md
+++ b/src/docs/goose-book/src/controller/telnet.md
@@ -11,7 +11,7 @@ Trying 127.0.0.1...
 Connected to localhost.
 Escape character is '^]'.
 goose> ?
-goose 0.17.1 controller commands:
+goose 0.17.2 controller commands:
 help               this help
 exit               exit controller
 
@@ -110,6 +110,6 @@ The above commands are also summarized in the metrics overview:
  Canceling:   2022-05-05 07:11:13 - 2022-05-05 07:11:13 (00:00:00, 0 <- 20)
 
  Target host: https://umami.ddev.site/
- goose v0.17.1
+ goose v0.17.2
  ------------------------------------------------------------------------------
 ```

--- a/src/docs/goose-book/src/getting-started/creating.md
+++ b/src/docs/goose-book/src/getting-started/creating.md
@@ -23,9 +23,9 @@ At this point it's possible to compile all dependencies, though the resulting bi
 ```bash
 $ cargo run
     Updating crates.io index
-  Downloaded goose v0.17.1
+  Downloaded goose v0.17.2
       ...
-   Compiling goose v0.17.1
+   Compiling goose v0.17.2
    Compiling loadtest v0.1.0 (/home/jandrews/devel/rust/loadtest)
     Finished dev [unoptimized + debuginfo] target(s) in 52.97s
      Running `target/debug/loadtest`

--- a/src/docs/goose-book/src/getting-started/metrics.md
+++ b/src/docs/goose-book/src/getting-started/metrics.md
@@ -7,7 +7,7 @@ In this case, the [Drupal Umami demo](https://www.drupal.org/docs/umami-drupal-d
 ## ASCII metrics
 ```bash
 % cargo run --release --example umami -- --host http://umami.ddev.site/ -u9 -r3 -t1m --no-reset-metrics --report-file report.html
-   Compiling goose v0.17.1 (~/goose)
+   Compiling goose v0.17.2 (~/goose)
     Finished release [optimized] target(s) in 11.88s
      Running `target/release/examples/umami --host 'http://umami.ddev.site/' -u9 -r3 -t1m --no-reset-metrics --report-file report.html`
 05:09:05 [INFO] Output verbosity level: INFO
@@ -285,7 +285,7 @@ All 9 users hatched.
  Decreasing:  2022-05-17 07:10:08 - 2022-05-17 07:10:08 (00:00:00, 0 <- 9)
 
  Target host: http://umami.ddev.site/
- goose v0.17.1
+ goose v0.17.2
  ------------------------------------------------------------------------------
 ```
 

--- a/src/docs/goose-book/src/getting-started/scenarios.md
+++ b/src/docs/goose-book/src/getting-started/scenarios.md
@@ -67,7 +67,7 @@ Or, to run only the "Anonymous Spanish user" and "Admin user" Scenarios, you cou
 
 ```bash,ignore
 % cargo run --release --example umami -- --hatch-rate 10 --scenarios "spanish,admin"
-   Compiling goose v0.17.1 (/Users/jandrews/devel/goose)
+   Compiling goose v0.17.2 (/Users/jandrews/devel/goose)
     Finished release [optimized] target(s) in 11.79s
      Running `target/release/examples/umami --hatch-rate 10 --scenarios spanish,admin`
 05:53:45 [INFO] Output verbosity level: INFO


### PR DESCRIPTION
## 0.17.2 August 28, 2023
 - [#557](https://github.com/tag1consulting/goose/pull/557) speed up user initialization on Linux
 - [#559](https://github.com/tag1consulting/goose/pull/559) disable unnecessary features in chronos, avoid potential segfault in time crate: https://rustsec.org/advisories/RUSTSEC-2020-0071
