### PR TITLE
allow to skip cert validation for internal test situations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -195,7 +195,7 @@ pub struct GooseConfiguration {
     /// Follows base_url redirect with subsequent requests
     #[options(no_short)]
     pub sticky_follow: bool,
-    /// Allows to test internally when https validation is not required
+    /// Disables validation of https certificates
     #[options(no_short)]
     pub accept_invalid_certs: bool,
 }
@@ -335,7 +335,7 @@ pub(crate) struct GooseDefaults {
     pub websocket_host: Option<String>,
     /// An optional default for port WebSocket Controller listens on.
     pub websocket_port: Option<u16>,
-    /// Allow for internal testing when no certificates are available but still using https
+    /// An optional default for not validating https certificates.
     pub accept_invalid_certs: Option<bool>,
 }
 
@@ -437,6 +437,7 @@ pub enum GooseDefault {
     WebSocketHost,
     /// An optional default for port WebSocket Controller listens on.
     WebSocketPort,
+    /// An optional default for not validating https certificates.
     AcceptInvalidCerts,
 }
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -2318,6 +2318,7 @@ pub(crate) fn create_reqwest_client(
         .timeout(Duration::from_millis(timeout))
         // Enable gzip unless `--no-gzip` flag is enabled.
         .gzip(!configuration.no_gzip)
+        .danger_accept_invalid_certs(configuration.accept_invalid_certs)
         .build()
 }
 

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -2318,6 +2318,7 @@ pub(crate) fn create_reqwest_client(
         .timeout(Duration::from_millis(timeout))
         // Enable gzip unless `--no-gzip` flag is enabled.
         .gzip(!configuration.no_gzip)
+        // Validate https certificates unless `--accept_invalid_certs` is enabled.
         .danger_accept_invalid_certs(configuration.accept_invalid_certs)
         .build()
 }

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -2318,7 +2318,7 @@ pub(crate) fn create_reqwest_client(
         .timeout(Duration::from_millis(timeout))
         // Enable gzip unless `--no-gzip` flag is enabled.
         .gzip(!configuration.no_gzip)
-        // Validate https certificates unless `--accept_invalid_certs` is enabled.
+        // Validate https certificates unless `--accept-invalid-certs` is enabled.
         .danger_accept_invalid_certs(configuration.accept_invalid_certs)
         .build()
 }


### PR DESCRIPTION
Adding the possibility to setup Reqwest client with ignore certificate mode.

This feature is used in cases https is used for non terminated proxies, but when testing internal infrastructure setups eg. when self signed or dev certificates are being used.

This is what I currently need to be able to use goose in the setup I have to load test.