### PR TITLE
document --accept-invalid-certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.17.3-dev
+ - [#565](https://github.com/tag1consulting/goose/pull/565) add `--accept-invalid-certs` to skip validation of https certificates
 
 ## 0.17.2 August 28, 2023
  - [#557](https://github.com/tag1consulting/goose/pull/557) speed up user initialization on Linux

--- a/src/docs/goose-book/src/getting-started/runtime-options.md
+++ b/src/docs/goose-book/src/getting-started/runtime-options.md
@@ -66,6 +66,7 @@ Advanced:
   --co-mitigation STRATEGY    Sets coordinated omission mitigation strategy
   --throttle-requests VALUE   Sets maximum requests per second
   --sticky-follow             Follows base_url redirect with subsequent requests
+  --accept-invalid-certs      Disables validation of https certificates
 ```
 
 All of the above configuration options are [defined in the developer documentation](https://docs.rs/goose/*/goose/config/struct.GooseConfiguration.html).


### PR DESCRIPTION
 - update documentation for https://github.com/tag1consulting/goose/pull/565, `--accept-invalid-certs`