### PR TITLE
Issue 429: Implement ItemsPerSecond

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -23,28 +23,40 @@ impl ItemsPerSecond {
         ItemsPerSecond(Default::default())
     }
 
+    #[inline(always)]
     fn initialize_or_increment(&mut self, key: &str, second: usize, value: u32) -> u32 {
-        if !self.0.contains_key(key) {
-            self.0.insert(key.to_string(), TimeSeries::new());
+        if !self.contains_key(key) {
+            self.insert(key, TimeSeries::new());
         }
         let data = self.0.get_mut(key).unwrap();
         data.increase_value(second, value);
         data.get(second)
     }
 
+    #[inline(always)]
+    fn contains_key(&mut self, key: &str) -> bool {
+        self.0.contains_key(key)
+    }
+
+    #[inline(always)]
     #[allow(dead_code)]
     fn insert(&mut self, key: &str, time_series: TimeSeries<u32, u32>) {
         self.0.insert(key.to_string(), time_series);
     }
 
+    #[inline(always)]
+    #[allow(dead_code)]
     fn len(&self) -> usize {
         self.0.len()
     }
 
+    #[inline(always)]
+    #[allow(dead_code)]
     fn get(&self, key: &str) -> Option<TimeSeries<u32, u32>> {
         self.0.get(key).cloned()
     }
 
+    #[inline(always)]
     fn get_map(&self) -> HashMap<String, TimeSeries<u32, u32>> {
         self.0.clone()
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -39,7 +39,6 @@ impl ItemsPerSecond {
     }
 
     #[inline(always)]
-    #[allow(dead_code)]
     fn insert(&mut self, key: &str, time_series: TimeSeries<u32, u32>) {
         self.0.insert(key.to_string(), time_series);
     }


### PR DESCRIPTION
Solves this issue: https://github.com/tag1consulting/goose/issues/429

This PR creates a new struct `ItemsPerSecond` and some accompanying methods that encapsulate the logic of the underlying hash map.

**Note:**
I had to use `#[allow(dead_code)]` because for some reason the compiler would complain about dead code, even though the code is being used.