### PR TITLE
Issue #531: Fix missing impl for TransactionError

### DIFF
--- a/src/goose.rs
+++ b/src/goose.rs
@@ -433,6 +433,13 @@ impl From<reqwest::Error> for TransactionError {
     }
 }
 
+/// Auto-convert Reqwest errors to boxed TransactionError.
+impl From<reqwest::Error> for Box<TransactionError> {
+    fn from(value: reqwest::Error) -> Self {
+        Box::new(TransactionError::Reqwest(value))
+    }
+}
+
 /// Auto-convert Url errors.
 impl From<url::ParseError> for TransactionError {
     fn from(err: url::ParseError) -> TransactionError {


### PR DESCRIPTION
This PR addressed issue https://github.com/tag1consulting/goose/issues/531.

The original bug report provided a minimum reproducible code, but I think we're able to shrink that even further to:
```rust
async fn test_case(user: &mut GooseUser) -> TransactionResult {
    let goose = user
        .get("my/url")
        .await?;
    let _ = goose.response?;
    Ok(())
}
```

Trying to compile a loadtest with this code should give the following error:
```
the trait `From<reqwest::error::Error>` is not implemented for `Box<TransactionError>`
```

With this PR, it should compile cleanly.