### PR TITLE
update: add utf-8 meta charset tag to html report

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -498,6 +498,7 @@ pub(crate) fn build_report(
         r#"<!DOCTYPE html>
 <html>
 <head>
+    <meta charset="utf-8">
     <title>Goose Attack Report</title>
     <style>
         .container {{


### PR DESCRIPTION
fixes the report bottom erros, since they can be from OS current lang