### PR TITLE
Update Dependencies and Fix Clippy Warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## 0.17.3-dev
+## 0.18.0
+ - update all dependencies
  - [#565](https://github.com/tag1consulting/goose/pull/565) add `--accept-invalid-certs` to skip validation of https certificates
  - [#568](https://github.com/tag1consulting/goose/pull/568) don't panic when truncating non utf-8 string
  - [#574](https://github.com/tag1consulting/goose/pull/574) update [`http`](https://docs.rs/http), [`itertools`](https://docs.rs/itertools) [`nix`](https://docs.rs/nix), [`rustls`](https://docs.rs/rustls/), and [`serial_test`](https://docs.rs/serial_test)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ctrlc = "3"
-downcast-rs = "1.2"
+downcast-rs = "2.0"
 flume = "0.11"
 futures = "0.3"
 gumdrop = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ itertools = "0.14"
 lazy_static = "1.4"
 log = "0.4"
 num-format = "0.4"
-rand = "0.8"
+rand = "0.9"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = [
     "cookies",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,4 @@ httpmock = "0.7"
 native-tls = "0.2"
 nix = { version = "0.29", features = ["signal"] }
 rustls = "0.22"
-serial_test = "2.0"
+serial_test = "3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.18.0-dev"
+version = "0.18.0"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ reqwest = { version = "0.12", default-features = false, features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
-strum = "0.26"
-strum_macros = "0.26"
+strum = "0.27"
+strum_macros = "0.27"
 tokio = { version = "1", features = [
     "fs",
     "io-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ tokio = { version = "1", features = [
     "time",
     "sync",
 ] }
-tokio-tungstenite = "0.21"
-tungstenite = "0.21"
+tokio-tungstenite = "0.26"
+tungstenite = "0.26"
 url = "2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,5 @@ gaggle = []
 httpmock = "0.7"
 native-tls = "0.2"
 nix = { version = "0.29", features = ["signal"] }
-rustls = "0.22"
+rustls = "0.23"
 serial_test = "3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.17.3-dev"
+version = "0.18.0-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."
@@ -20,7 +20,7 @@ flume = "0.11"
 futures = "0.3"
 gumdrop = "0.8"
 http = "1.1"
-itertools = "0.12"
+itertools = "0.14"
 lazy_static = "1.4"
 log = "0.4"
 num-format = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,6 @@ gaggle = []
 [dev-dependencies]
 httpmock = "0.7"
 native-tls = "0.2"
-nix = { version = "0.27", features = ["signal"] }
+nix = { version = "0.29", features = ["signal"] }
 rustls = "0.22"
 serial_test = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ rustls-tls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls"]
 gaggle = []
 
 [dev-dependencies]
-httpmock = "0.6"
+httpmock = "0.7"
 native-tls = "0.2"
 nix = { version = "0.27", features = ["signal"] }
 rustls = "0.22"

--- a/examples/drupal_memcache.rs
+++ b/examples/drupal_memcache.rs
@@ -135,7 +135,7 @@ async fn drupal_memcache_front_page(user: &mut GooseUser) -> TransactionResult {
 
 /// View a node from 1 to 10,000, created by preptest.sh.
 async fn drupal_memcache_node_page(user: &mut GooseUser) -> TransactionResult {
-    let nid = rand::thread_rng().gen_range(1..10_000);
+    let nid = rand::rng().random_range(1..10_000);
     let _goose = user.get(format!("/node/{}", &nid).as_str()).await?;
 
     Ok(())
@@ -143,7 +143,7 @@ async fn drupal_memcache_node_page(user: &mut GooseUser) -> TransactionResult {
 
 /// View a profile from 2 to 5,001, created by preptest.sh.
 async fn drupal_memcache_profile_page(user: &mut GooseUser) -> TransactionResult {
-    let uid = rand::thread_rng().gen_range(2..5_001);
+    let uid = rand::rng().random_range(2..5_001);
     let _goose = user.get(format!("/user/{}", &uid).as_str()).await?;
 
     Ok(())
@@ -175,7 +175,7 @@ async fn drupal_memcache_login(user: &mut GooseUser) -> TransactionResult {
                     };
 
                     // Log the user in.
-                    let uid: usize = rand::thread_rng().gen_range(3..5_002);
+                    let uid: usize = rand::rng().random_range(3..5_002);
                     let username = format!("user{}", uid);
                     let params = [
                         ("name", username.as_str()),
@@ -217,7 +217,7 @@ async fn drupal_memcache_login(user: &mut GooseUser) -> TransactionResult {
 
 /// Post a comment.
 async fn drupal_memcache_post_comment(user: &mut GooseUser) -> TransactionResult {
-    let nid: i32 = rand::thread_rng().gen_range(1..10_000);
+    let nid: i32 = rand::rng().random_range(1..10_000);
     let node_path = format!("node/{}", &nid);
     let comment_path = format!("/comment/reply/{}", &nid);
 

--- a/examples/umami/admin.rs
+++ b/examples/umami/admin.rs
@@ -2,7 +2,7 @@ use goose::prelude::*;
 
 use crate::common;
 
-use rand::seq::SliceRandom;
+use rand::prelude::*;
 use std::env;
 
 /// Log into the website.
@@ -110,7 +110,7 @@ pub async fn log_in(user: &mut GooseUser) -> TransactionResult {
 pub async fn edit_article(user: &mut GooseUser) -> TransactionResult {
     // First, load a random article.
     let nodes = common::get_nodes(&common::ContentType::Article);
-    let article = nodes.choose(&mut rand::thread_rng());
+    let article = nodes.choose(&mut rand::rng());
     let goose = user.get(article.unwrap().url_en).await?;
     common::validate_and_load_static_assets(user, goose, article.unwrap().title_en).await?;
 

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -1,8 +1,7 @@
 use goose::goose::GooseResponse;
 use goose::prelude::*;
 
-use rand::prelude::IteratorRandom;
-use rand::seq::SliceRandom;
+use rand::prelude::*;
 use regex::Regex;
 
 /// The Umami website defines three content types.
@@ -392,10 +391,10 @@ pub fn random_words(count: usize, english: bool) -> Vec<String> {
             ContentType::Recipe,
             ContentType::Recipe,
         ];
-        let content_type = content_types.choose(&mut rand::thread_rng());
+        let content_type = content_types.choose(&mut rand::rng());
         // Then randomly select a node of this content type.
         let nodes = get_nodes(content_type.unwrap());
-        let page = nodes.choose(&mut rand::thread_rng());
+        let page = nodes.choose(&mut rand::rng());
         // Randomly select a word from the title to use in our search.
         let title = if english {
             page.unwrap().title_en
@@ -403,7 +402,7 @@ pub fn random_words(count: usize, english: bool) -> Vec<String> {
             page.unwrap().title_es
         };
         let words = title.split_whitespace();
-        let word = words.choose(&mut rand::thread_rng()).unwrap();
+        let word = words.choose(&mut rand::rng()).unwrap();
         // Remove ' to avoid encoding/decoding issues when validating later.
         let cleaned_word = word.replace("&#039;", "");
         random_words.push(cleaned_word.to_string());

--- a/examples/umami/english.rs
+++ b/examples/umami/english.rs
@@ -2,7 +2,7 @@ use goose::prelude::*;
 
 use crate::common;
 
-use rand::seq::SliceRandom;
+use rand::prelude::*;
 
 /// Load the front page in English and all static assets found on the page.
 pub async fn front_page_en(user: &mut GooseUser) -> TransactionResult {
@@ -23,7 +23,7 @@ pub async fn recipe_listing_en(user: &mut GooseUser) -> TransactionResult {
 /// Load a random recipe in English and all static assets found on the page.
 pub async fn recipe_en(user: &mut GooseUser) -> TransactionResult {
     let nodes = common::get_nodes(&common::ContentType::Recipe);
-    let recipe = nodes.choose(&mut rand::thread_rng());
+    let recipe = nodes.choose(&mut rand::rng());
     let goose = user.get(recipe.unwrap().url_en).await?;
     common::validate_and_load_static_assets(user, goose, recipe.unwrap().title_en).await?;
 
@@ -41,7 +41,7 @@ pub async fn article_listing_en(user: &mut GooseUser) -> TransactionResult {
 /// Load a random article in English and all static assets found on the page.
 pub async fn article_en(user: &mut GooseUser) -> TransactionResult {
     let nodes = common::get_nodes(&common::ContentType::Article);
-    let article = nodes.choose(&mut rand::thread_rng());
+    let article = nodes.choose(&mut rand::rng());
     let goose = user.get(article.unwrap().url_en).await?;
     common::validate_and_load_static_assets(user, goose, article.unwrap().title_en).await?;
 
@@ -51,7 +51,7 @@ pub async fn article_en(user: &mut GooseUser) -> TransactionResult {
 /// Load a random basic page in English and all static assets found on the page.
 pub async fn basic_page_en(user: &mut GooseUser) -> TransactionResult {
     let nodes = common::get_nodes(&common::ContentType::BasicPage);
-    let page = nodes.choose(&mut rand::thread_rng());
+    let page = nodes.choose(&mut rand::rng());
     let goose = user.get(page.unwrap().url_en).await?;
     common::validate_and_load_static_assets(user, goose, page.unwrap().title_en).await?;
 
@@ -66,10 +66,10 @@ pub async fn page_by_nid(user: &mut GooseUser) -> TransactionResult {
         common::ContentType::BasicPage,
         common::ContentType::Recipe,
     ];
-    let content_type = content_types.choose(&mut rand::thread_rng());
+    let content_type = content_types.choose(&mut rand::rng());
     // Then randomly select a node of this content type.
     let nodes = common::get_nodes(content_type.unwrap());
-    let page = nodes.choose(&mut rand::thread_rng());
+    let page = nodes.choose(&mut rand::rng());
     // Load the page by nid instead of by URL.
     let goose = user
         .get(&("/node/".to_string() + &page.unwrap().nid.to_string()))
@@ -96,7 +96,7 @@ pub async fn search_en(user: &mut GooseUser) -> TransactionResult {
 /// Load category listing by a random term in English and all static assets found on the page.
 pub async fn term_listing_en(user: &mut GooseUser) -> TransactionResult {
     let terms = common::get_terms();
-    let term = terms.choose(&mut rand::thread_rng());
+    let term = terms.choose(&mut rand::rng());
     let goose = user.get(term.unwrap().url_en).await?;
     common::validate_and_load_static_assets(user, goose, term.unwrap().title_en).await?;
 

--- a/examples/umami/spanish.rs
+++ b/examples/umami/spanish.rs
@@ -2,7 +2,7 @@ use goose::prelude::*;
 
 use crate::common;
 
-use rand::seq::SliceRandom;
+use rand::prelude::*;
 
 /// Load the front page in Spanish and all static assets found on the page.
 pub async fn front_page_es(user: &mut GooseUser) -> TransactionResult {
@@ -23,7 +23,7 @@ pub async fn recipe_listing_es(user: &mut GooseUser) -> TransactionResult {
 /// Load a random recipe in Spanish and all static assets found on the page.
 pub async fn recipe_es(user: &mut GooseUser) -> TransactionResult {
     let nodes = common::get_nodes(&common::ContentType::Recipe);
-    let recipe = nodes.choose(&mut rand::thread_rng());
+    let recipe = nodes.choose(&mut rand::rng());
     let goose = user.get(recipe.unwrap().url_es).await?;
     common::validate_and_load_static_assets(user, goose, recipe.unwrap().title_es).await?;
 
@@ -41,7 +41,7 @@ pub async fn article_listing_es(user: &mut GooseUser) -> TransactionResult {
 /// Load a random article in Spanish and all static assets found on the page.
 pub async fn article_es(user: &mut GooseUser) -> TransactionResult {
     let nodes = common::get_nodes(&common::ContentType::Article);
-    let article = nodes.choose(&mut rand::thread_rng());
+    let article = nodes.choose(&mut rand::rng());
     let goose = user.get(article.unwrap().url_es).await?;
     common::validate_and_load_static_assets(user, goose, article.unwrap().title_es).await?;
 
@@ -51,7 +51,7 @@ pub async fn article_es(user: &mut GooseUser) -> TransactionResult {
 /// Load a basic page in Spanish and all static assets found on the page.
 pub async fn basic_page_es(user: &mut GooseUser) -> TransactionResult {
     let nodes = common::get_nodes(&common::ContentType::BasicPage);
-    let page = nodes.choose(&mut rand::thread_rng());
+    let page = nodes.choose(&mut rand::rng());
     let goose = user.get(page.unwrap().url_es).await?;
     common::validate_and_load_static_assets(user, goose, page.unwrap().title_es).await?;
 
@@ -75,7 +75,7 @@ pub async fn search_es(user: &mut GooseUser) -> TransactionResult {
 /// Load category listing by a random term in Spanish and all static assets found on the page.
 pub async fn term_listing_es(user: &mut GooseUser) -> TransactionResult {
     let terms = common::get_terms();
-    let term = terms.choose(&mut rand::thread_rng());
+    let term = terms.choose(&mut rand::rng());
     let goose = user.get(term.unwrap().url_es).await?;
     common::validate_and_load_static_assets(user, goose, term.unwrap().title_es).await?;
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1465,6 +1465,7 @@ trait ControllerExecuteCommand<T> {
     // if the request was successful or not.
     async fn write_to_socket(&self, socket: &mut T, response_message: Result<String, String>);
 }
+
 #[async_trait]
 impl ControllerExecuteCommand<tokio::net::TcpStream> for ControllerState {
     // Run the command received from a telnet Controller request.
@@ -1527,6 +1528,7 @@ impl ControllerExecuteCommand<tokio::net::TcpStream> for ControllerState {
         };
     }
 }
+
 #[async_trait]
 impl ControllerExecuteCommand<ControllerWebSocketSender> for ControllerState {
     // Run the command received from a WebSocket Controller request.
@@ -1546,7 +1548,7 @@ impl ControllerExecuteCommand<ControllerWebSocketSender> for ControllerState {
                 && socket
                     .send(Message::Close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
                         code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Normal,
-                        reason: std::borrow::Cow::Borrowed("exit"),
+                        reason: "exit".into(),
                     })))
                     .await
                     .is_err()
@@ -1588,7 +1590,7 @@ impl ControllerExecuteCommand<ControllerWebSocketSender> for ControllerState {
             && socket
                 .send(Message::Close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
                     code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Normal,
-                    reason: std::borrow::Cow::Borrowed("shutdown"),
+                    reason: "shutdown".into(),
                 })))
                 .await
                 .is_err()
@@ -1624,7 +1626,7 @@ impl ControllerExecuteCommand<ControllerWebSocketSender> for ControllerState {
                     // Success is true if there is no error, false if there is an error.
                     success,
                 }) {
-                    Ok(json) => json,
+                    Ok(json) => json.into(),
                     Err(e) => {
                         warn!("failed to json encode response: {}", e);
                         return;

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1545,7 +1545,7 @@ impl GooseUser {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn request<'a>(
+    pub async fn request(
         &mut self,
         mut request: GooseRequest<'_>,
     ) -> Result<GooseResponse, Box<TransactionError>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,7 @@ pub mod util;
 
 use gumdrop::Options;
 use lazy_static::lazy_static;
-use rand::seq::SliceRandom;
-use rand::thread_rng;
+use rand::prelude::*;
 use std::collections::{hash_map::DefaultHasher, BTreeMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::{atomic::AtomicUsize, Arc, RwLock};
@@ -730,7 +729,7 @@ impl GooseAttack {
             GooseScheduler::Random => {
                 // Allocate scenarios randomly.
                 loop {
-                    let scenario = available_scenarios.choose_mut(&mut rand::thread_rng());
+                    let scenario = available_scenarios.choose_mut(&mut rand::rng());
                     match scenario {
                         Some(set) => {
                             if let Some(s) = set.pop() {
@@ -2137,7 +2136,7 @@ fn schedule_unsequenced_transactions(
 
                 let mut transactions_clone = transactions.clone();
                 if scheduler == &GooseScheduler::Random {
-                    transactions_clone.shuffle(&mut thread_rng());
+                    transactions_clone.shuffle(&mut rand::rng());
                 }
                 weighted_transactions.append(&mut transactions_clone);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1164,46 +1164,36 @@ impl GooseAttack {
     // Invoke `test_start` transactions if existing.
     async fn run_test_start(&self) -> Result<(), GooseError> {
         // First run global test_start_transaction, if defined.
-        match &self.test_start_transaction {
-            Some(t) => {
-                info!("running test_start_transaction");
-                // Create a one-time-use User to run the test_start_transaction.
-                let base_url = goose::get_base_url(
-                    self.get_configuration_host(),
-                    None,
-                    self.defaults.host.clone(),
-                )?;
-                let mut user = GooseUser::single(base_url, &self.configuration)?;
-                let function = &t.function;
-                let _ = function(&mut user).await;
-            }
-            // No test_start_transaction defined, nothing to do.
-            None => (),
+        if let Some(t) = &self.test_start_transaction {
+            info!("running test_start_transaction");
+            // Create a one-time-use User to run the test_start_transaction.
+            let base_url = goose::get_base_url(
+                self.get_configuration_host(),
+                None,
+                self.defaults.host.clone(),
+            )?;
+            let mut user = GooseUser::single(base_url, &self.configuration)?;
+            let function = &t.function;
+            let _ = function(&mut user).await;
         }
-
         Ok(())
     }
 
     // Invoke `test_stop` transactions if existing.
     async fn run_test_stop(&self) -> Result<(), GooseError> {
         // First run global test_stop_transaction, if defined.
-        match &self.test_stop_transaction {
-            Some(t) => {
-                info!("running test_stop_transaction");
-                // Create a one-time-use User to run the test_stop_transaction.
-                let base_url = goose::get_base_url(
-                    self.get_configuration_host(),
-                    None,
-                    self.defaults.host.clone(),
-                )?;
-                let mut user = GooseUser::single(base_url, &self.configuration)?;
-                let function = &t.function;
-                let _ = function(&mut user).await;
-            }
-            // No test_stop_transaction defined, nothing to do.
-            None => (),
+        if let Some(t) = &self.test_stop_transaction {
+            info!("running test_stop_transaction");
+            // Create a one-time-use User to run the test_stop_transaction.
+            let base_url = goose::get_base_url(
+                self.get_configuration_host(),
+                None,
+                self.defaults.host.clone(),
+            )?;
+            let mut user = GooseUser::single(base_url, &self.configuration)?;
+            let function = &t.function;
+            let _ = function(&mut user).await;
         }
-
         Ok(())
     }
 

--- a/src/report/markdown.rs
+++ b/src/report/markdown.rs
@@ -22,7 +22,7 @@ pub(crate) fn write_markdown_report<W: Write>(
     Markdown { w, data }.write()
 }
 
-impl<'m, 'w, W: Write> Markdown<'m, 'w, W> {
+impl<W: Write> Markdown<'_, '_, W> {
     pub fn write(mut self) -> Result<(), GooseError> {
         self.write_header()?;
         self.write_plan_overview()?;

--- a/src/user.rs
+++ b/src/user.rs
@@ -72,7 +72,7 @@ pub(crate) async fn user_main(
                 // If the transaction_wait is defined, wait for a random time between transaction.
                 if let Some((min, max)) = thread_scenario.transaction_wait {
                     // Total time left to wait before running the next transaction.
-                    let mut wait_time = rand::thread_rng().gen_range(min..=max).as_millis();
+                    let mut wait_time = rand::rng().random_range(min..=max).as_millis();
                     // Track the time slept for Coordinated Omission Mitigation.
                     let sleep_timer = time::Instant::now();
                     // Never sleep more than 500 milliseconds, allowing a sleeping transaction to shut

--- a/src/util.rs
+++ b/src/util.rs
@@ -354,11 +354,7 @@ pub fn ms_timer_expired(started: time::Instant, elapsed: usize) -> bool {
 /// assert_eq!(util::get_hatch_rate(None), 1.0);
 /// ```
 pub fn get_hatch_rate(hatch_rate: Option<String>) -> f32 {
-    if let Some(value) = get_float_from_string(hatch_rate) {
-        value
-    } else {
-        1.0
-    }
+    get_float_from_string(hatch_rate).unwrap_or(1.0)
 }
 
 /// Convert optional string to f32, otherwise return None.

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -12,7 +12,7 @@ type WorkerHandles = Vec<tokio::task::JoinHandle<GooseMetrics>>;
 
 /// Not all functions are used by all tests, so we enable allow(dead_code) to avoid
 /// compiler warnings during testing.
-
+///
 /// The following options are configured by default, if not set to a custom value
 /// and if not building a Worker configuration:
 ///  --host <mock-server>

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -791,7 +791,8 @@ async fn make_request(test_state: &mut TestState, command: &str) {
                 serde_json::to_string(&ControllerWebSocketRequest {
                     request: command.to_string(),
                 })
-                .unwrap(),
+                .unwrap()
+                .into(),
             ))
             .await
             .unwrap()


### PR DESCRIPTION
This PR updates several key dependencies to their latest versions and addresses Clippy warnings to improve code quality.

## Dependency Updates
- Updated rustls to 0.23
- Updated tungsteniteto 0.26
- Updated serial_test to 3.2
- Updated httpmock to 0.7
- Updated rand to 0.9
- Updated itertools to 0.14
- Updated strum to 0.27
- Updated nix to 0.29
- Updated downcast-rs to 2.0

Fixes https://github.com/tag1consulting/goose/issues/591