### PR TITLE
Fix error graph in HTML report

### DIFF
--- a/src/metrics/common.rs
+++ b/src/metrics/common.rs
@@ -414,9 +414,9 @@ pub fn prepare_data(options: ReportOptions, metrics: &GooseMetrics) -> ReportDat
         scenario_metrics,
         transaction_metrics,
         status_code_metrics,
-        errors: metrics
+        errors: (!metrics
             .errors
-            .is_empty()
+            .is_empty())
             .then(|| metrics.errors.values().collect::<Vec<_>>()),
     }
 }


### PR DESCRIPTION
Currently, the HTML report does not display an error summary. This is due to an incorrect boolean value in `src/metrics/common.rs`. This PR fixes this, returning the error summary.

Closes: #619