### PR TITLE
Fix GooseBot model deprecation and disable auto-triggers

### DIFF
--- a/.github/scripts/goosebot_review.py
+++ b/.github/scripts/goosebot_review.py
@@ -313,9 +313,12 @@ def call_anthropic_api(prompt: str, token_tracker: TokenUsageTracker, max_tokens
             
         client = anthropic.Anthropic(**client_kwargs)
         
-        # Use Claude Sonnet 3.7 model
+        # Use Claude Sonnet 4 model (configurable via environment variable)
+        model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+        logger.info(f"Using model: {model}")
+        
         response = client.messages.create(
-            model="claude-3-sonnet-20240229",
+            model=model,
             max_tokens=max_tokens,
             system="You are GooseBot, an AI assistant that helps with code reviews for the Goose load testing framework. Be concise and helpful.",
             messages=[

--- a/.github/workflows/goosebot_review.yml
+++ b/.github/workflows/goosebot_review.yml
@@ -1,11 +1,12 @@
 name: GooseBot PR Review
 
 on:
-  # Use pull_request_target instead of pull_request to access secrets
-  # This runs in the context of the base repo instead of the fork
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-  # Manual trigger for testing
+  # Automatic triggers disabled due to model deprecation causing noise on every PR
+  # See: https://github.com/tag1consulting/goose/issues/623
+  # pull_request_target:
+  #   types: [opened, synchronize, reopened]
+  
+  # Manual trigger for optional use
   workflow_dispatch:
     inputs:
       pr_number:
@@ -59,6 +60,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_API_URL: ${{ secrets.ANTHROPIC_API_URL }}
+          ANTHROPIC_MODEL: "claude-sonnet-4-20250514"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Configure file filtering
           PR_REVIEW_WHITELIST: "*.rs,*.md,*.py,*.toml,*.yml,*.yaml"

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -35,7 +35,7 @@ Based on the code analysis, potential next steps for the project may include:
   - Created local testing tool with .env support for faster prompt iteration
   - Added explicit "no issues found" response when PR documentation is adequate
   - Additional review scopes planned for future phases (see [aiCodeReviewPlan.md](./aiCodeReviewPlan.md) for full implementation plan)
-  - Update Claude model before July 2025 deprecation date
+  - ✓ Updated Claude model from deprecated claude-3-sonnet-20240229 to claude-sonnet-4-20250514 (Issue #623)
 
 ## Active Decisions and Considerations
 


### PR DESCRIPTION
## Problem

GooseBot was causing noise on every PR with 404 errors due to using the deprecated Claude model `claude-3-sonnet-20240229`.

## Solution

This PR addresses issue #623 by:

### 1. Disabling Automatic Triggers
- Removed the `pull_request_target` trigger from `.github/workflows/goosebot_review.yml`
- Added explanatory comments referencing the issue
- Preserved the `workflow_dispatch` trigger for manual use when desired

### 2. Updating to Claude Sonnet 4
- Changed model from deprecated `claude-3-sonnet-20240229` to `claude-sonnet-4-20250514`
- Made the model configurable via `ANTHROPIC_MODEL` environment variable
- Updated the workflow to explicitly set the new model

### 3. Documentation Updates
- Updated memory bank to reflect the changes

## Result

✅ **No more automatic noise on every PR**  
✅ **GooseBot preserved for manual use** via GitHub Actions workflow dispatch  
✅ **Uses latest Claude Sonnet 4 model** for better performance  
✅ **Future-proofed** with configurable model selection  

## Manual Usage

GooseBot can still be used manually by:
1. Going to the Actions tab
2. Selecting "GooseBot PR Review" workflow
3. Clicking "Run workflow"
4. Entering the PR number and scope

## Files Changed

- `.github/workflows/goosebot_review.yml` - Disabled auto-triggers, updated model
- `.github/scripts/goosebot_review.py` - Updated to Claude Sonnet 4, made model configurable
- `memory-bank/activeContext.md` - Documented the fix

Fixes #623