### PR TITLE
Add PDF report generation using headless Chrome 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - [#574](https://github.com/tag1consulting/goose/pull/574) update [`http`](https://docs.rs/http), [`itertools`](https://docs.rs/itertools) [`nix`](https://docs.rs/nix), [`rustls`](https://docs.rs/rustls/), and [`serial_test`](https://docs.rs/serial_test)
  - [#575](https://github.com/tag1consulting/goose/pull/575) add test coverage for sessions and cookies, revert [#557](https://github.com/tag1consulting/goose/pull/557) to avoid sharing the CookieJar between all users
  - [#600](https://github.com/tag1consulting/goose/pull/600) Refactor reports/metrics, add JSON and markdown report
+ - add optional PDF report generation with `pdf-reports` feature flag; supports configurable page size, margins, scale, and compression via `--pdf-page-size`, `--pdf-margin`, `--pdf-scale`, and `--pdf-no-compress` options
 
 ## 0.17.2 August 28, 2023
  - [#557](https://github.com/tag1consulting/goose/pull/557) speed up user initialization on Linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,12 @@ tokio = { version = "1", features = [
 tokio-tungstenite = "0.26"
 tungstenite = "0.26"
 url = "2"
+headless_chrome = { version = "1.0", features = ["fetch"], optional = true }
+urlencoding = { version = "2.1", optional = true }
 
 [features]
 default = ["reqwest/default-tls"]
+pdf-reports = ["headless_chrome", "urlencoding"]
 rustls-tls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls"]
 gaggle = []
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -198,6 +198,22 @@ pub struct GooseConfiguration {
     /// Disables validation of https certificates
     #[options(no_short)]
     pub accept_invalid_certs: bool,
+    /// Sets PDF page size (a4, letter, legal, a3)
+    #[cfg(feature = "pdf-reports")]
+    #[options(no_short, meta = "SIZE", default = "a4")]
+    pub pdf_page_size: String,
+    /// Sets PDF margins in inches
+    #[cfg(feature = "pdf-reports")]
+    #[options(no_short, meta = "INCHES", default = "0.4")]
+    pub pdf_margin: f64,
+    /// Sets PDF scale factor (0.1-2.0)
+    #[cfg(feature = "pdf-reports")]
+    #[options(no_short, meta = "SCALE", default = "0.8")]
+    pub pdf_scale: f64,
+    /// Disable PDF compression
+    #[cfg(feature = "pdf-reports")]
+    #[options(no_short)]
+    pub pdf_no_compress: bool,
 }
 
 /// Optionally defines a subset of active Scenarios to run during a load test.
@@ -236,6 +252,30 @@ impl FromStr for Scenarios {
         // The listed scenarios are only valid if the logic gets this far.
         Ok(Scenarios { active })
     }
+}
+
+/// Defines PDF page size options for PDF report generation.
+#[cfg(feature = "pdf-reports")]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum PdfPageSize {
+    A4,
+    Letter,
+    Legal,
+    A3,
+    Custom { width: f64, height: f64 },
+}
+
+/// PDF-specific configuration options for report generation.
+#[cfg(feature = "pdf-reports")]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PdfOptions {
+    pub page_size: PdfPageSize,
+    pub margin_top: f64,
+    pub margin_bottom: f64,
+    pub margin_left: f64,
+    pub margin_right: f64,
+    pub compress: bool,
+    pub scale: f64,
 }
 
 /// Optional default values for Goose run-time options.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3039,6 +3039,21 @@ impl GooseAttack {
                         self.write_markdown_report(file).await?;
                     }
                 }
+                #[cfg(feature = "pdf-reports")]
+                Some("pdf") => {
+                    let file = create(path).await?;
+                    if write {
+                        self.write_pdf_report(file, report).await?;
+                    }
+                }
+                #[cfg(not(feature = "pdf-reports"))]
+                Some("pdf") => {
+                    return Err(GooseError::InvalidOption {
+                        option: "--report-file".to_string(),
+                        value: report.clone(),
+                        detail: "PDF reports require the 'pdf-reports' feature. Rebuild with --features pdf-reports".to_string(),
+                    });
+                }
                 None => {
                     return Err(GooseError::InvalidOption {
                         option: "--report-file".to_string(),
@@ -3332,6 +3347,277 @@ impl GooseAttack {
         info!("html report file written to: {path}");
 
         Ok(())
+    }
+
+    /// Write a PDF report.
+    #[cfg(feature = "pdf-reports")]
+    pub(crate) async fn write_pdf_report(
+        &self,
+        _report_file: File,
+        path: &str,
+    ) -> Result<(), GooseError> {
+        use crate::report::pdf::{add_print_css, generate_pdf_from_html};
+        use std::path::Path;
+
+        // Generate HTML report first
+        let test_start_time = self.metrics.history.first().unwrap().timestamp;
+
+        // Prepare report summary variables.
+        let users = self.metrics.maximum_users.to_string();
+
+        let mut steps_overview = String::new();
+        for step in self.metrics.history.windows(2) {
+            let (seconds, minutes, hours) = self
+                .metrics
+                .get_seconds_minutes_hours(&step[0].timestamp, &step[1].timestamp);
+            let started = Local
+                .timestamp_opt(step[0].timestamp.timestamp(), 0)
+                // @TODO: error handling
+                .unwrap()
+                .format("%y-%m-%d %H:%M:%S");
+            let stopped = Local
+                .timestamp_opt(step[1].timestamp.timestamp(), 0)
+                // @TODO: error handling
+                .unwrap()
+                .format("%y-%m-%d %H:%M:%S");
+            match &step[0].action {
+                // For maintaining just show the current number of users.
+                TestPlanStepAction::Maintaining => {
+                    let _ = write!(steps_overview,
+                            "<tr><td>{:?}</td><td>{}</td><td>{}</td><td>{:02}:{:02}:{:02}</td><td>{}</td></tr>",
+                            step[0].action,
+                            started,
+                            stopped,
+                            hours,
+                            minutes,
+                            seconds,
+                            step[0].users,
+                        );
+                }
+                // For increasing show the current number of users to the new number of users.
+                TestPlanStepAction::Increasing => {
+                    let _ = write!(steps_overview,
+                            "<tr><td>{:?}</td><td>{}</td><td>{}</td><td>{:02}:{:02}:{:02}</td><td>{} &rarr; {}</td></tr>",
+                            step[0].action,
+                            started,
+                            stopped,
+                            hours,
+                            minutes,
+                            seconds,
+                            step[0].users,
+                            step[1].users,
+                        );
+                }
+                // For decreasing show the new number of users from the current number of users.
+                TestPlanStepAction::Decreasing | TestPlanStepAction::Canceling => {
+                    let _ = write!(steps_overview,
+                            "<tr><td>{:?}</td><td>{}</td><td>{}</td><td>{:02}:{:02}:{:02}</td><td>{} &larr; {}</td></tr>",
+                            step[0].action,
+                            started,
+                            stopped,
+                            hours,
+                            minutes,
+                            seconds,
+                            step[1].users,
+                            step[0].users,
+                        );
+                }
+                TestPlanStepAction::Finished => {
+                    unreachable!("there shouldn't be a step after finished");
+                }
+            }
+        }
+
+        // Build a comma separated list of hosts.
+        let hosts = &self.metrics.hosts.clone().into_iter().join(", ");
+
+        let ReportData {
+            raw_metrics: _,
+            raw_request_metrics,
+            raw_response_metrics,
+            co_request_metrics,
+            co_response_metrics,
+            scenario_metrics,
+            transaction_metrics,
+            errors,
+            status_code_metrics,
+        } = common::prepare_data(
+            ReportOptions {
+                no_transaction_metrics: self.configuration.no_transaction_metrics,
+                no_scenario_metrics: self.configuration.no_scenario_metrics,
+                no_status_codes: self.configuration.no_status_codes,
+            },
+            &self.metrics,
+        );
+
+        // Compile the request metrics template.
+        let mut raw_requests_rows = Vec::new();
+        for metric in raw_request_metrics {
+            raw_requests_rows.push(report::raw_request_metrics_row(metric));
+        }
+
+        // Compile the response metrics template.
+        let mut raw_responses_rows = Vec::new();
+        for metric in raw_response_metrics {
+            raw_responses_rows.push(report::response_metrics_row(metric));
+        }
+
+        let co_requests_template = co_request_metrics
+            .map(|co_request_metrics| {
+                let co_request_rows = co_request_metrics
+                    .into_iter()
+                    .map(report::coordinated_omission_request_metrics_row)
+                    .join("\n");
+
+                report::coordinated_omission_request_metrics_template(&co_request_rows)
+            })
+            .unwrap_or_default();
+
+        let co_responses_template = co_response_metrics
+            .map(|co_response_metrics| {
+                let co_response_rows = co_response_metrics
+                    .into_iter()
+                    .map(report::coordinated_omission_response_metrics_row)
+                    .join("\n");
+
+                report::coordinated_omission_response_metrics_template(&co_response_rows)
+            })
+            .unwrap_or_default();
+
+        let scenarios_template = scenario_metrics
+            .map(|scenario_metric| {
+                let scenarios_rows = scenario_metric
+                    .into_iter()
+                    .map(report::scenario_metrics_row)
+                    .join("\n");
+
+                report::scenario_metrics_template(
+                    &scenarios_rows,
+                    self.graph_data
+                        .get_scenarios_per_second_graph(!self.configuration.no_granular_report)
+                        .get_markup(&self.metrics.history, test_start_time),
+                )
+            })
+            .unwrap_or_default();
+
+        let transactions_template = transaction_metrics
+            .map(|transaction_metrics| {
+                let transactions_rows = transaction_metrics
+                    .into_iter()
+                    .map(report::transaction_metrics_row)
+                    .join("\n");
+
+                report::transaction_metrics_template(
+                    &transactions_rows,
+                    self.graph_data
+                        .get_transactions_per_second_graph(!self.configuration.no_granular_report)
+                        .get_markup(&self.metrics.history, test_start_time),
+                )
+            })
+            .unwrap_or_default();
+
+        let errors_template = errors
+            .map(|errors| {
+                let error_rows = errors.into_iter().map(report::error_row).join("\n");
+
+                report::errors_template(
+                    &error_rows,
+                    self.graph_data
+                        .get_errors_per_second_graph(!self.configuration.no_granular_report)
+                        .get_markup(&self.metrics.history, test_start_time),
+                )
+            })
+            .unwrap_or_default();
+
+        let status_code_template = status_code_metrics
+            .map(|status_code_metrics| {
+                // Compile the status_code metrics rows.
+                let mut status_code_rows = Vec::new();
+                for metric in status_code_metrics {
+                    status_code_rows.push(report::status_code_metrics_row(metric));
+                }
+
+                // Compile the status_code metrics template.
+                report::status_code_metrics_template(&status_code_rows.join("\n"))
+            })
+            .unwrap_or_default();
+
+        // Compile the HTML report template.
+        let html_report = report::build_report(
+            &users,
+            &steps_overview,
+            hosts,
+            report::GooseReportTemplates {
+                raw_requests_template: &raw_requests_rows.join("\n"),
+                raw_responses_template: &raw_responses_rows.join("\n"),
+                co_requests_template: &co_requests_template,
+                co_responses_template: &co_responses_template,
+                transactions_template: &transactions_template,
+                scenarios_template: &scenarios_template,
+                status_codes_template: &status_code_template,
+                errors_template: &errors_template,
+                graph_rps_template: &self
+                    .graph_data
+                    .get_requests_per_second_graph(!self.configuration.no_granular_report)
+                    .get_markup(&self.metrics.history, test_start_time),
+                graph_average_response_time_template: &self
+                    .graph_data
+                    .get_average_response_time_graph(!self.configuration.no_granular_report)
+                    .get_markup(&self.metrics.history, test_start_time),
+                graph_users_per_second: &self
+                    .graph_data
+                    .get_active_users_graph(!self.configuration.no_granular_report)
+                    .get_markup(&self.metrics.history, test_start_time),
+            },
+        );
+
+        // Add print-optimized CSS for better PDF output
+        let print_optimized_html = add_print_css(&html_report);
+
+        // Create PDF options from configuration
+        #[cfg(feature = "pdf-reports")]
+        let pdf_options = {
+            use crate::config::{PdfOptions, PdfPageSize};
+
+            let page_size = match self.configuration.pdf_page_size.as_str() {
+                "letter" => PdfPageSize::Letter,
+                "legal" => PdfPageSize::Legal,
+                "a3" => PdfPageSize::A3,
+                _ => PdfPageSize::A4, // default
+            };
+
+            PdfOptions {
+                page_size,
+                margin_top: self.configuration.pdf_margin,
+                margin_bottom: self.configuration.pdf_margin,
+                margin_left: self.configuration.pdf_margin,
+                margin_right: self.configuration.pdf_margin,
+                compress: !self.configuration.pdf_no_compress,
+                scale: self.configuration.pdf_scale,
+            }
+        };
+
+        // Generate PDF from HTML using the PDF configuration
+        generate_pdf_from_html(&print_optimized_html, Path::new(path), &pdf_options)?;
+
+        info!("pdf report file written to: {path}");
+
+        Ok(())
+    }
+
+    /// Write a PDF report (feature not enabled).
+    #[cfg(not(feature = "pdf-reports"))]
+    #[allow(dead_code)]
+    pub(crate) async fn write_pdf_report(
+        &self,
+        _report_file: File,
+        path: &str,
+    ) -> Result<(), GooseError> {
+        Err(GooseError::InvalidOption {
+            option: "--report-file".to_string(),
+            value: path.to_string(),
+            detail: "PDF reports require compiling with the 'pdf-reports' feature flag".to_string(),
+        })
     }
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -2,6 +2,9 @@
 mod common;
 mod markdown;
 
+#[cfg(feature = "pdf-reports")]
+pub mod pdf;
+
 pub(crate) use markdown::write_markdown_report;
 
 use crate::{

--- a/src/report/pdf.rs
+++ b/src/report/pdf.rs
@@ -1,0 +1,314 @@
+//! PDF report generation functionality
+//!
+//! This module provides PDF report generation by converting existing HTML reports
+//! to PDF format using headless Chrome. It leverages the HTML report generation
+//! and converts it to PDF with configurable options.
+
+#[cfg(feature = "pdf-reports")]
+use crate::{
+    config::{PdfOptions, PdfPageSize},
+    GooseError,
+};
+
+#[cfg(feature = "pdf-reports")]
+use headless_chrome::{Browser, LaunchOptions};
+
+#[cfg(feature = "pdf-reports")]
+use std::{fs, path::Path};
+
+/// Generate a PDF report from HTML content using headless Chrome
+#[cfg(feature = "pdf-reports")]
+pub(crate) fn generate_pdf_from_html(
+    html_content: &str,
+    output_path: &Path,
+    pdf_options: &PdfOptions,
+) -> Result<(), GooseError> {
+    // Launch headless Chrome
+    let launch_options = LaunchOptions::default_builder()
+        .headless(true)
+        .build()
+        .map_err(|e| GooseError::InvalidOption {
+            option: "--pdf".to_string(),
+            value: format!("Failed to configure Chrome: {e}"),
+            detail: "Unable to launch headless Chrome for PDF generation".to_string(),
+        })?;
+
+    let browser = Browser::new(launch_options).map_err(|e| GooseError::InvalidOption {
+        option: "--pdf".to_string(),
+        value: format!("Failed to launch Chrome: {e}"),
+        detail: "Unable to start headless Chrome browser".to_string(),
+    })?;
+
+    // Create a new tab
+    let tab = browser.new_tab().map_err(|e| GooseError::InvalidOption {
+        option: "--pdf".to_string(),
+        value: format!("Failed to create browser tab: {e}"),
+        detail: "Unable to create new browser tab".to_string(),
+    })?;
+
+    // Create a data URL from the HTML content
+    let encoded_html = urlencoding::encode(html_content);
+    let data_url = format!("data:text/html;charset=utf-8,{encoded_html}");
+
+    // Navigate to the data URL
+    tab.navigate_to(&data_url)
+        .map_err(|e| GooseError::InvalidOption {
+            option: "--pdf".to_string(),
+            value: format!("Failed to load HTML: {e}"),
+            detail: "Unable to load HTML content in browser".to_string(),
+        })?;
+
+    // Wait for the page to load
+    tab.wait_until_navigated()
+        .map_err(|e| GooseError::InvalidOption {
+            option: "--pdf".to_string(),
+            value: format!("Failed to wait for page load: {e}"),
+            detail: "Page failed to load completely".to_string(),
+        })?;
+
+    // Configure PDF options
+    let (width, height) = match pdf_options.page_size {
+        PdfPageSize::A4 => (8.27, 11.7),    // A4 in inches
+        PdfPageSize::Letter => (8.5, 11.0), // US Letter in inches
+        PdfPageSize::Legal => (8.5, 14.0),  // US Legal in inches
+        PdfPageSize::A3 => (11.7, 16.5),    // A3 in inches
+        PdfPageSize::Custom { width, height } => (width, height), // Custom size in inches
+    };
+
+    // Generate PDF
+    let pdf_data = tab
+        .print_to_pdf(Some(headless_chrome::types::PrintToPdfOptions {
+            landscape: Some(false),
+            display_header_footer: Some(false),
+            print_background: Some(true),
+            scale: Some(pdf_options.scale),
+            paper_width: Some(width),
+            paper_height: Some(height),
+            margin_top: Some(pdf_options.margin_top),
+            margin_bottom: Some(pdf_options.margin_bottom),
+            margin_left: Some(pdf_options.margin_left),
+            margin_right: Some(pdf_options.margin_right),
+            page_ranges: None,
+            ignore_invalid_page_ranges: Some(false),
+            header_template: None,
+            footer_template: None,
+            prefer_css_page_size: Some(false),
+            transfer_mode: None,
+            generate_document_outline: Some(false),
+            generate_tagged_pdf: Some(false),
+        }))
+        .map_err(|e| GooseError::InvalidOption {
+            option: "--pdf".to_string(),
+            value: format!("Failed to generate PDF: {e}"),
+            detail: "PDF generation failed".to_string(),
+        })?;
+
+    // Write PDF to file
+    fs::write(output_path, pdf_data).map_err(|e| GooseError::InvalidOption {
+        option: "--pdf".to_string(),
+        value: format!("Failed to write PDF file: {e}"),
+        detail: format!("Unable to write PDF to {}", output_path.display()),
+    })?;
+
+    Ok(())
+}
+
+/// Add print-optimized CSS styles to HTML content for better PDF output
+#[cfg(feature = "pdf-reports")]
+pub(crate) fn add_print_css(html_content: &str) -> String {
+    let print_css = r#"
+        <style media="print">
+            @page {
+                margin: 0.5in;
+                size: auto;
+            }
+            
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                font-size: 12px;
+                line-height: 1.4;
+                color: #333;
+                background: white !important;
+            }
+            
+            .goose-logo, .goose-header img {
+                max-width: 200px !important;
+                height: auto !important;
+            }
+            
+            table {
+                page-break-inside: avoid;
+                border-collapse: collapse;
+                width: 100% !important;
+                font-size: 11px;
+            }
+            
+            th, td {
+                border: 1px solid #ddd !important;
+                padding: 4px 8px !important;
+                text-align: left;
+            }
+            
+            th {
+                background-color: #f5f5f5 !important;
+                font-weight: bold;
+            }
+            
+            .goose-graph {
+                max-width: 100% !important;
+                height: auto !important;
+                page-break-inside: avoid;
+                margin: 10px 0;
+            }
+            
+            h1, h2, h3 {
+                page-break-after: avoid;
+                color: #333 !important;
+            }
+            
+            h1 {
+                font-size: 18px;
+                margin: 20px 0 10px 0;
+            }
+            
+            h2 {
+                font-size: 16px;
+                margin: 15px 0 8px 0;
+                border-bottom: 1px solid #ddd;
+                padding-bottom: 3px;
+            }
+            
+            h3 {
+                font-size: 14px;
+                margin: 12px 0 6px 0;
+            }
+            
+            .goose-metrics-summary {
+                page-break-inside: avoid;
+                margin: 15px 0;
+            }
+            
+            .goose-requests-table,
+            .goose-transactions-table,
+            .goose-scenarios-table {
+                page-break-inside: avoid;
+                margin: 10px 0;
+            }
+            
+            /* Ensure charts and graphs don't break */
+            canvas, svg {
+                max-width: 100% !important;
+                height: auto !important;
+            }
+            
+            /* Hide interactive elements that don't make sense in PDF */
+            button, input[type="button"], input[type="submit"] {
+                display: none !important;
+            }
+            
+            /* Improve readability of small text */
+            .small-text, .footnote {
+                font-size: 10px;
+                color: #666;
+            }
+        </style>
+    "#;
+
+    // Insert the print CSS before the closing </head> tag
+    if let Some(head_end) = html_content.find("</head>") {
+        let mut result = String::with_capacity(html_content.len() + print_css.len());
+        result.push_str(&html_content[..head_end]);
+        result.push_str(print_css);
+        result.push_str(&html_content[head_end..]);
+        result
+    } else {
+        // If no </head> tag found, just prepend the CSS
+        format!("{print_css}\n{html_content}")
+    }
+}
+
+#[cfg(not(feature = "pdf-reports"))]
+pub(crate) fn generate_pdf_from_html(
+    _html_content: &str,
+    _output_path: &std::path::Path,
+    _pdf_options: &crate::config::PdfOptions,
+) -> Result<(), crate::GooseError> {
+    Err(crate::GooseError::InvalidOption {
+        option: "--pdf".to_string(),
+        value: "disabled".to_string(),
+        detail: "PDF reports require compiling with the 'pdf-reports' feature flag".to_string(),
+    })
+}
+
+#[cfg(not(feature = "pdf-reports"))]
+pub(crate) fn add_print_css(html_content: &str) -> String {
+    html_content.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_print_css_with_head_tag() {
+        let html = r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>Test</title>
+</head>
+<body>
+    <h1>Test Content</h1>
+</body>
+</html>"#;
+
+        let result = add_print_css(html);
+
+        // Should contain the original content
+        assert!(result.contains("Test Content"));
+        assert!(result.contains("<title>Test</title>"));
+
+        // Should contain the print CSS
+        assert!(result.contains("@page"));
+        assert!(result.contains("font-family"));
+        assert!(result.contains("page-break-inside: avoid"));
+
+        // CSS should be inserted before </head>
+        let head_end = result.find("</head>").unwrap();
+        let css_start = result.find("<style media=\"print\">").unwrap();
+        assert!(css_start < head_end);
+    }
+
+    #[test]
+    fn test_add_print_css_without_head_tag() {
+        let html = "<h1>Simple HTML</h1>";
+        let result = add_print_css(html);
+
+        // Should contain original content
+        assert!(result.contains("Simple HTML"));
+
+        // Should contain the print CSS (prepended)
+        assert!(result.contains("<style media=\"print\">"));
+        assert!(result.starts_with("<style media=\"print\">"));
+    }
+
+    #[cfg(not(feature = "pdf-reports"))]
+    #[test]
+    fn test_generate_pdf_without_feature() {
+        use crate::config::{PdfOptions, PdfPageSize};
+        use std::path::Path;
+
+        let options = PdfOptions {
+            page_size: PdfPageSize::A4,
+            margin: 0.5,
+            scale: 1.0,
+            compress: true,
+        };
+
+        let result = generate_pdf_from_html("test", Path::new("test.pdf"), &options);
+        assert!(result.is_err());
+
+        if let Err(GooseError::InvalidOption { detail, .. }) = result {
+            assert!(detail.contains("pdf-reports"));
+        }
+    }
+}


### PR DESCRIPTION
## Add optional PDF report generation

This PR adds optional PDF report generation to Goose using headless Chrome. PDF reports have the same content as HTML reports but with print-optimized styling.

### Features

- __Optional feature flag__: `pdf-reports` - zero impact when disabled
- __Automatic conversion__: Uses existing HTML report generation, converts to PDF
- __Print-optimized CSS__: Better formatting for PDF output
- __Configurable options__: Page size, margins, scale, and compression

### Configuration

__Build with PDF support:__

```bash
cargo build --features pdf-reports
```

__Generate PDF reports:__

```bash
./your_app --report-file report.pdf
```

__Configuration options:__

- `--pdf-page-size <SIZE>`: Page size (a4, letter, legal, a3) - default: a4
- `--pdf-margin <INCHES>`: Page margins in inches - default: 0.5
- `--pdf-scale <FACTOR>`: Scale factor (0.1-2.0) - default: 1.0
- `--pdf-no-compress`: Disable PDF compression

__Example:__

```bash
./your_app --report-file report.pdf --pdf-page-size letter --pdf-margin 0.75 --pdf-scale 0.8
```

### Implementation

- Uses headless Chrome via `headless_chrome` crate
- Graceful error handling when feature is disabled
- Full test coverage for both enabled/disabled states
- Updated changelog for v0.18.0