### PR TITLE
Fix clippy warnings for latest Rust version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.18.1-dev
+
 ## 0.18.0
  - update all dependencies
  - [#565](https://github.com/tag1consulting/goose/pull/565) add `--accept-invalid-certs` to skip validation of https certificates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose"
-version = "0.18.0"
+version = "0.18.1-dev"
 authors = ["Jeremy Andrews <jeremy@tag1consulting.com>"]
 edition = "2018"
 description = "A load testing framework inspired by Locust."

--- a/examples/umami/common.rs
+++ b/examples/umami/common.rs
@@ -30,7 +30,7 @@ pub struct Term<'a> {
 }
 
 /// Returns a vector of all nodes of a specified content type.
-pub fn get_nodes(content_type: &ContentType) -> Vec<Node> {
+pub fn get_nodes(content_type: &ContentType) -> Vec<Node<'_>> {
     match content_type {
         ContentType::Article => {
             vec![

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -204,7 +204,7 @@ impl ControllerCommand {
     ///    (and optionally to grab a value being set).
     ///  - `process_response` contains a boxed closure that receives the parent process
     ///    response to the command and responds to the controller appropriately.
-    fn details(&self) -> ControllerCommandDetails {
+    fn details(&self) -> ControllerCommandDetails<'_> {
         match self {
             ControllerCommand::Config => ControllerCommandDetails {
                 help: ControllerHelp {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -157,7 +157,7 @@ impl GraphData {
     }
 
     /// Generate active users graph.
-    pub(crate) fn get_active_users_graph(&self, granular_data: bool) -> Graph<usize, usize> {
+    pub(crate) fn get_active_users_graph(&self, granular_data: bool) -> Graph<'_, usize, usize> {
         self.create_graph_from_single_data(
             "graph-active-users",
             "Active users #",
@@ -167,7 +167,7 @@ impl GraphData {
     }
 
     /// Generate requests per second graph.
-    pub(crate) fn get_requests_per_second_graph(&self, granular_data: bool) -> Graph<u32, u32> {
+    pub(crate) fn get_requests_per_second_graph(&self, granular_data: bool) -> Graph<'_, u32, u32> {
         self.create_graph_from_data(
             "graph-rps",
             "Requests #",
@@ -180,7 +180,7 @@ impl GraphData {
     pub(crate) fn get_average_response_time_graph(
         &self,
         granular_data: bool,
-    ) -> Graph<MovingAverage, f32> {
+    ) -> Graph<'_, MovingAverage, f32> {
         self.create_graph_from_data(
             "graph-avg-response-time",
             "Response time [ms]",
@@ -193,7 +193,7 @@ impl GraphData {
     pub(crate) fn get_transactions_per_second_graph(
         &self,
         granular_data: bool,
-    ) -> Graph<usize, usize> {
+    ) -> Graph<'_, usize, usize> {
         self.create_graph_from_single_data(
             "graph-tps",
             "Transactions #",
@@ -206,7 +206,7 @@ impl GraphData {
     pub(crate) fn get_scenarios_per_second_graph(
         &self,
         granular_data: bool,
-    ) -> Graph<usize, usize> {
+    ) -> Graph<'_, usize, usize> {
         self.create_graph_from_single_data(
             "graph-sps",
             "Scenarios #",
@@ -216,7 +216,7 @@ impl GraphData {
     }
 
     /// Generate errors per second graph.
-    pub(crate) fn get_errors_per_second_graph(&self, granular_data: bool) -> Graph<u32, u32> {
+    pub(crate) fn get_errors_per_second_graph(&self, granular_data: bool) -> Graph<'_, u32, u32> {
         self.create_graph_from_data(
             "graph-eps",
             "Errors #",

--- a/src/metrics/common.rs
+++ b/src/metrics/common.rs
@@ -38,7 +38,7 @@ pub struct ReportOptions {
     pub no_status_codes: bool,
 }
 
-pub fn prepare_data(options: ReportOptions, metrics: &GooseMetrics) -> ReportData {
+pub fn prepare_data(options: ReportOptions, metrics: &GooseMetrics) -> ReportData<'_> {
     // Prepare requests and responses variables.
     let mut raw_request_metrics = Vec::new();
     let mut co_request_metrics = Vec::new();

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -141,7 +141,7 @@ pub async fn delete_nobuilder(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First set up GET_PATH, store in vector at GET_KEY.
         server.mock(|when, then| {

--- a/tests/cancel.rs
+++ b/tests/cancel.rs
@@ -43,7 +43,7 @@ pub async fn get_index(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against a common endpoint.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // This load test only requests INDEX_PATH, which we store in vector at INDEX_KEY.
         server.mock(|when, then| {

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -51,7 +51,7 @@ fn configure_mock_endpoints<'a>() -> Vec<LoadtestEndpoint<'a>> {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     // Get common configuration for building endpoints and the load test itself.
     let test_endpoints = configure_mock_endpoints();
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -151,7 +151,7 @@ pub fn cleanup_files(files: Vec<&str>) {
 
 /// Configure mock server to trigger CO events predictably.
 #[allow(dead_code)]
-pub fn setup_co_triggering_server(server: &MockServer) -> httpmock::Mock {
+pub fn setup_co_triggering_server(server: &MockServer) -> httpmock::Mock<'_> {
     use httpmock::Method::GET;
     use std::time::Duration;
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -78,7 +78,7 @@ pub async fn get_about(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against the following common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First set up INDEX_PATH, store in vector at INDEX_KEY.
         server.mock(|when, then| {

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -64,7 +64,7 @@ pub async fn get_about(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First, set up INDEX_PATH, store in vector at INDEX_KEY.
         server.mock(|when, then| {

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -40,7 +40,7 @@ pub async fn get_404_path(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First set up INDEX_PATH, store in vector at INDEX_KEY.
         server.mock(|when, then| {

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -83,7 +83,7 @@ pub async fn get_error(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First, set up INDEX_PATH, store in vector at INDEX_KEY.
         server.mock(|when, then| {

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -35,7 +35,7 @@ pub async fn logout(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First set up LOGIN_PATH, store in vector at LOGIN_KEY.
         server.mock(|when, then| {

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -40,7 +40,7 @@ pub async fn get_about(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First set up INDEX_PATH, store in vector at INDEX_KEY.
         server.mock(|when, then| {

--- a/tests/scenarios.rs
+++ b/tests/scenarios.rs
@@ -56,7 +56,7 @@ pub async fn get_scenariob2(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against a common endpoint.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // SCENARIOA1 is stored in vector at SCENARIOA1_KEY.
         server.mock(|when, then| {

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -85,7 +85,7 @@ pub async fn stop_one(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First set up ONE_PATH, store in vector at ONE_KEY.
         server.mock(|when, then| {

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -78,7 +78,7 @@ pub async fn stop_one(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First set up ONE_PATH, store in vector at ONE_KEY.
         server.mock(|when, then| {

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -125,7 +125,7 @@ pub async fn validate_cookie(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     let cookie_path_0 = format!("{COOKIE_PATH}0");
     let cookie_path_1 = format!("{COOKIE_PATH}1");
     let cookie_path_2 = format!("{COOKIE_PATH}2");

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -55,7 +55,7 @@ pub async fn get_index(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First set up INDEX_PATH, store in vector at INDEX_KEY.
         server.mock(|when, then| {

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -34,7 +34,7 @@ pub async fn get_about(user: &mut GooseUser) -> TransactionResult {
 }
 
 // All tests in this file run against common endpoints.
-fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock> {
+fn setup_mock_server_endpoints(server: &MockServer) -> Vec<Mock<'_>> {
     vec![
         // First set up INDEX_PATH, store in vector at INDEX_KEY.
         server.mock(|when, then| {


### PR DESCRIPTION
## Summary

This PR fixes all clippy warnings that appear with the latest Rust version. These warnings are related to the new `mismatched-lifetime-syntaxes` lint that was introduced in recent Rust versions.

## Changes Made

- Updated function signatures to use explicit lifetime annotations where needed
- Changed `Vec<Mock>` to `Vec<Mock<'_>>` in test files for consistent lifetime syntax
- Changed `Vec<Node>` to `Vec<Node<'_>>` in the umami example
- All changes maintain backward compatibility and functionality
- Updated version (as we're working toward a new release)

## Files Modified

- 16 test files in `tests/` directory
- 1 example file in `examples/umami/common.rs`
- Various other files with minor clippy fixes

## Testing

- All clippy warnings have been resolved
- `cargo clippy --all-targets --all-features -- -D warnings` now passes without errors
- No functional changes were made, only lifetime annotation improvements

## Context

This is a routine maintenance update that happens whenever a new version of Rust introduces stricter clippy rules. The changes ensure the codebase continues to follow Rust best practices and passes CI checks with the latest toolchain.
