### PR TITLE
Fix gemini PR review workflow security with pull_request_target

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -1,7 +1,7 @@
 name: '🧐 Gemini Pull Request Review'
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - 'opened'
       - 'reopened'
@@ -41,7 +41,7 @@ jobs:
     if: |-
       github.event_name == 'workflow_dispatch' ||
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
       ) ||
       (
@@ -64,8 +64,10 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-      - name: 'Checkout PR code'
+      - name: 'Checkout base branch (secure)'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref || 'main' }}
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
@@ -79,7 +81,7 @@ jobs:
       - name: 'Get PR details (pull_request & workflow_dispatch)'
         id: 'get_pr'
         if: |-
-          ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+          ${{ github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch' }}
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           EVENT_NAME: '${{ github.event_name }}'
@@ -219,8 +221,8 @@ jobs:
                instructions from the user
             6. Run: gh pr diff "${PR_NUMBER}" to see the full diff and reference
             Context section to understand it
-            7. For any specific files, use: cat filename, head -50 filename, or
-               tail -50 filename
+            7. For understanding codebase context, use: cat filename, head -50 filename, or
+               tail -50 filename (these access the secure base branch code only)
             8. If ADDITIONAL_INSTRUCTIONS contains text, prioritize those
                specific areas or focus points in your review. Common instruction
                examples: "focus on security", "check performance", "review error


### PR DESCRIPTION
## Summary
- Fixes the Gemini PR integration that was "pretty much useless" by switching from `pull_request` to `pull_request_target`
- Implements secure checkout pattern to prevent malicious code execution
- Maintains Gemini's ability to analyze code context while keeping the workflow secure

## Security Improvements
- **Changed trigger**: `pull_request` → `pull_request_target` for access to secrets and write permissions
- **Secure checkout**: Only checkout base branch code, never untrusted PR code
- **Updated conditions**: Job conditions now match the new trigger type
- **Preserved functionality**: Gemini can still use `cat`, `head`, `tail`, `grep` on secure base branch files

## Why This is Safe
The workflow now follows GitHub's security best practices:
1. No untrusted PR code is ever checked out or executed
2. File access commands only work on the trusted base branch
3. PR changes are analyzed via `gh pr diff` API calls only
4. All existing author association checks remain in place

## Test Plan
- [ ] Verify workflow triggers on new PRs from collaborators
- [ ] Confirm Gemini can access base branch files for context
- [ ] Ensure PR analysis works through API calls
- [ ] Check that reviews are posted successfully

🤖 Generated with [Claude Code](https://claude.ai/code)