### PR TITLE
Eliminate clippy pedantic warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub fn trigger_killswitch(reason: &str) {
     match CANCELED.write() {
         Ok(mut canceled) => {
             if !*canceled {
-                info!("Killswitch triggered: {}", reason);
+                info!("Killswitch triggered: {reason}");
             }
             *canceled = true;
         }
@@ -113,7 +113,7 @@ pub fn trigger_killswitch(reason: &str) {
             // If the lock is poisoned, we can still write to it
             let mut canceled = poisoned.into_inner();
             if !*canceled {
-                info!("Killswitch triggered: {}", reason);
+                info!("Killswitch triggered: {reason}");
             }
             *canceled = true;
         }

--- a/src/report/pdf.rs
+++ b/src/report/pdf.rs
@@ -120,7 +120,7 @@ impl ChromeSession {
         let process_id = browser.get_process_id();
 
         if let Some(pid) = process_id {
-            debug!("Chrome browser launched with process ID: {}", pid);
+            debug!("Chrome browser launched with process ID: {pid}");
         } else {
             debug!("Chrome browser launched (process ID not available)");
         }
@@ -151,9 +151,9 @@ impl Drop for ChromeSession {
         let elapsed = self.start_time.elapsed();
 
         if let Some(pid) = self.process_id {
-            debug!("Cleaning up Chrome process {} (ran for {:?})", pid, elapsed);
+            debug!("Cleaning up Chrome process {pid} (ran for {elapsed:?})");
         } else {
-            debug!("Cleaning up Chrome browser session (ran for {:?})", elapsed);
+            debug!("Cleaning up Chrome browser session (ran for {elapsed:?})");
         }
 
         // The Browser's Drop trait handles the actual process termination


### PR DESCRIPTION
# Fix clippy uninlined_format_args violations

Fixes #649

## Changes Made

This PR addresses the 5 clippy `uninlined_format_args` violations identified in issue #649 by updating old format string syntax to modern inline format syntax.

### Files Modified

**src/report/pdf.rs** (3 violations fixed):
- Line 123: `debug!("Chrome browser launched with process ID: {}", pid)` → `debug!("Chrome browser launched with process ID: {pid}")`
- Line 154: `debug!("Cleaning up Chrome process {} (ran for {:?})", pid, elapsed)` → `debug!("Cleaning up Chrome process {pid} (ran for {elapsed:?})")`
- Line 156: `debug!("Cleaning up Chrome browser session (ran for {:?})", elapsed)` → `debug!("Cleaning up Chrome browser session (ran for {elapsed:?})")`

**src/lib.rs** (2 violations fixed):
- Line 108: `info!("Killswitch triggered: {}", reason)` → `info!("Killswitch triggered: {reason}")`
- Line 116: `info!("Killswitch triggered: {}", reason)` → `info!("Killswitch triggered: {reason}")`

## Validation

- ✅ `cargo clippy --all-features -- -D warnings` passes without warnings
- ✅ `cargo check` compiles successfully  
- ✅ Core library tests pass (42/42 unit tests)
- ✅ No functional changes or regressions introduced

## Impact

These changes are purely cosmetic code style improvements that:
- Modernize format string syntax to current Rust standards
- Eliminate clippy pedantic warnings
- Improve code consistency across the codebase
- Maintain full backward compatibility

The changes align with modern Rust formatting conventions and resolve the specific lint violations mentioned in the issue without affecting any functionality.
