### PR TITLE
docs: clarify that Goose measures TTFB only, not complete response time

### DIFF
--- a/src/docs/goose-book/src/getting-started/metrics.md
+++ b/src/docs/goose-book/src/getting-started/metrics.md
@@ -325,7 +325,15 @@ Below the graph is a table that shows per-request details, only partially includ
 ![Request metrics](metrics-requests.jpg)
 
 #### Response times
-The next graph shows the response times measured for each request made. In the following graph, it's apparent that POST requests had the slowest responses, which is logical as they are not cached. As before, it's possible to click on the request names at the top of the graph to hide/show details about specific requests.
+The next graph shows the response times measured for each request made. Goose measures **Time to First Byte (TTFB)** - the time from when a request starts until the first byte of the response is received. This includes network latency and server processing time, but does not include the time to download the complete response body.
+
+**Why TTFB only?** Goose focuses on TTFB because:
+- **Server performance focus**: TTFB measures server processing time and network latency, which are the primary concerns for load testing
+- **Consistent measurement**: Load test scenarios may not consume complete response bodies, making total download time inconsistent and potentially misleading
+- **Resource efficiency**: Not downloading complete responses allows Goose to generate more load with fewer resources
+- **Real-world relevance**: Many applications stream responses or use chunked encoding where TTFB is the critical performance metric
+
+In the following graph, it's apparent that POST requests had the slowest responses, which is logical as they are not cached. As before, it's possible to click on the request names at the top of the graph to hide/show details about specific requests.
 
 Below the graph is a table that shows per-request details:
 ![Response time metrics](metrics-response-time.jpg)

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -1825,6 +1825,8 @@ impl GooseUser {
 
         // Make the actual request.
         let response = self.client.execute(built_request).await;
+        // Record Time to First Byte (TTFB): client.execute() returns when response headers
+        // are received, not when the complete response body is downloaded.
         request_metric.set_response_time(started.elapsed().as_millis());
 
         // Determine if the request suceeded or failed.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -367,7 +367,7 @@ pub struct GooseRequestMetric {
     pub final_url: String,
     /// Whether or not the request was redirected.
     pub redirected: bool,
-    /// How many milliseconds the request took.
+    /// How many milliseconds the request took (Time to First Byte).
     pub response_time: u64,
     /// The HTTP response code (optional).
     pub status_code: u16,


### PR DESCRIPTION
# PR Description - Issue #614 TTFB Documentation Fix

## Summary
Corrects documentation to accurately reflect that Goose measures Time to First Byte (TTFB) only, not complete response delivery time. The initial response in issue #614 was incorrect.

## Changes
- Update `metrics.md` to clarify TTFB measurement
- Add "Why TTFB only?" section explaining technical rationale
- Update inline code comments for accuracy

## Technical Details
Goose measures TTFB: time from request start until first response byte is received. Does not measure complete response body download time.

**Why TTFB only:**
- Server performance focus (processing + network latency)
- Consistent measurement (load tests may not consume full responses)
- Resource efficiency (enables higher load generation)
- Real-world relevance (streaming/chunked encoding patterns)

## Issue Resolution
Addresses all three timing questions from #614:
1. Request metrics: TTFB measurement
2. Response metrics: Statistical aggregations of TTFB
3. Transaction metrics: Function execution time including TTFB plus overhead

Closes #614
