### PR TITLE
Fix scenario filtering to use exact matching without wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     o introduces `TransactionName` enum with `TransactionOnly` and `InheritNameByRequests` variants
  - [#656](https://github.com/tag1consulting/goose/pull/656) fix stack overflow when cloning `GooseUser` with session data
     o **breaking**: session data types must now implement `Clone` (add `#[derive(Clone)]` to your session structs)
+ - [#655](https://github.com/tag1consulting/goose/pull/655) fix `--scenarios` to use exact matching instead of substring matching; add `*` wildcard support for pattern matching
  - [#578](https://github.com/tag1consulting/goose/pull/578) add type-safe client builder for cookie configuration, optimize startup with shared clients
  - [#629](https://github.com/tag1consulting/goose/pull/629) add `--pdf-print-html` option to generate printer-friendly HTML optimized for PDF conversion; provides two-step PDF workflow without requiring Chromium dependencies; add `--pdf-timeout` option for configurable Chrome timeout in direct PDF generation (10-300s, default: 60)
  - [#663](https://github.com/tag1consulting/goose/pull/663) add response time breakdowns grouped by HTTP status code in CLI and HTML/markdown reports; breakdowns only appear when a request returns multiple different status codes

--- a/src/config.rs
+++ b/src/config.rs
@@ -235,14 +235,14 @@ impl FromStr for Scenarios {
         for line in lines {
             // Ignore white space an case.
             let scenario = line.trim().to_lowercase();
-            // Valid scenario names are alphanumeric only.
-            if scenario.chars().all(char::is_alphanumeric) {
+            // Valid scenario names are alphanumeric, with optional * wildcards.
+            if scenario.chars().all(|c| c.is_alphanumeric() || c == '*') {
                 active.push(scenario);
             } else {
                 // Logger isn't initialized yet, provide helpful debug output.
                 eprintln!("ERROR: invalid `configuration.scenarios` value: '{line}'");
                 eprintln!("  Expected format: --scenarios \"{{one}},{{two}},{{three}}\"");
-                eprintln!("    {{one}}, {{two}}, {{three}}, etc must be alphanumeric");
+                eprintln!("    {{one}}, {{two}}, {{three}}, etc must be alphanumeric (use * for wildcard matching)");
                 eprintln!("    To view valid scenario names invoke `--scenarios-list`");
                 return Err(GooseError::InvalidOption {
                     option: "`configuration.scenarios".to_string(),

--- a/src/docs/goose-book/src/getting-started/scenarios.md
+++ b/src/docs/goose-book/src/getting-started/scenarios.md
@@ -33,68 +33,29 @@ Scenarios:
 
 ## Running Scenarios By Machine Name
 
-It is now possible to run any subset of the above scenarios by passing a comma separated list of machine names with the `--scenarios` run time option. Goose will match what you have typed against any machine name containing all or some of the typed text, so you do not have to type the full name. For example, to run only the two anonymous Scenarios, you could add `--scenarios anon`:
+It is now possible to run any subset of the above scenarios by passing a comma separated list of machine names with the `--scenarios` run time option. Goose uses **exact matching** by default. To match multiple scenarios with a single pattern, use the `*` wildcard character which matches zero or more characters.
+
+For example, to run only the two anonymous Scenarios, you could add `--scenarios "anon*"`:
 
 ```bash,ignore
-% cargo run --release --example umami -- --hatch-rate 10 --scenarios anon
+% cargo run --release --example umami -- --hatch-rate 10 --scenarios "anon*"
     Finished release [optimized] target(s) in 0.15s
-     Running `target/release/examples/umami --hatch-rate 10 --scenarios anon`
+     Running `target/release/examples/umami --hatch-rate 10 --scenarios 'anon*'`
 05:50:17 [INFO] Output verbosity level: INFO
 05:50:17 [INFO] Logfile verbosity level: WARN
 05:50:17 [INFO] users defaulted to number of CPUs = 10
 05:50:17 [INFO] hatch_rate = 10
 05:50:17 [INFO] iterations = 0
-05:50:17 [INFO] scenarios = Scenarios { active: ["anon"] }
-05:50:17 [INFO] host for Anonymous English user configured: https://drupal-9.ddev.site/
-05:50:17 [INFO] host for Anonymous Spanish user configured: https://drupal-9.ddev.site/
-05:50:17 [INFO] host for Admin user configured: https://drupal-9.ddev.site/
-05:50:17 [INFO] allocating transactions and scenarios with RoundRobin scheduler
-05:50:17 [INFO] initializing 10 user states...
-05:50:17 [INFO] WebSocket controller listening on: 0.0.0.0:5117
-05:50:17 [INFO] Telnet controller listening on: 0.0.0.0:5116
-05:50:17 [INFO] entering GooseAttack phase: Increase
-05:50:17 [INFO] launching user 1 from Anonymous Spanish user...
-05:50:18 [INFO] launching user 2 from Anonymous English user...
-05:50:18 [INFO] launching user 3 from Anonymous Spanish user...
-05:50:18 [INFO] launching user 4 from Anonymous English user...
-05:50:18 [INFO] launching user 5 from Anonymous Spanish user...
-05:50:18 [INFO] launching user 6 from Anonymous English user...
-05:50:18 [INFO] launching user 7 from Anonymous Spanish user...
-^C05:50:18 [WARN] caught ctrl-c, stopping...
+05:50:17 [INFO] scenarios = Scenarios { active: ["anon*"] }
 ```
 
-Or, to run only the "Anonymous Spanish user" and "Admin user" Scenarios, you could add `--senarios "spanish,admin"`:
+Or, to run only the "Anonymous Spanish user" and "Admin user" Scenarios using their exact machine names, you could add `--scenarios "anonymousspanishuser,adminuser"`:
 
 ```bash,ignore
-% cargo run --release --example umami -- --hatch-rate 10 --scenarios "spanish,admin"
-   Compiling goose v0.18.1 (/Users/jandrews/devel/goose)
-    Finished release [optimized] target(s) in 11.79s
-     Running `target/release/examples/umami --hatch-rate 10 --scenarios spanish,admin`
-05:53:45 [INFO] Output verbosity level: INFO
-05:53:45 [INFO] Logfile verbosity level: WARN
-05:53:45 [INFO] users defaulted to number of CPUs = 10
-05:53:45 [INFO] hatch_rate = 10
-05:53:45 [INFO] iterations = 0
-05:53:45 [INFO] scenarios = Scenarios { active: ["spanish", "admin"] }
-05:53:45 [INFO] host for Anonymous English user configured: https://drupal-9.ddev.site/
-05:53:45 [INFO] host for Anonymous Spanish user configured: https://drupal-9.ddev.site/
-05:53:45 [INFO] host for Admin user configured: https://drupal-9.ddev.site/
-05:53:45 [INFO] allocating transactions and scenarios with RoundRobin scheduler
-05:53:45 [INFO] initializing 10 user states...
-05:53:45 [INFO] Telnet controller listening on: 0.0.0.0:5116
-05:53:45 [INFO] WebSocket controller listening on: 0.0.0.0:5117
-05:53:45 [INFO] entering GooseAttack phase: Increase
-05:53:45 [INFO] launching user 1 from Anonymous Spanish user...
-05:53:45 [INFO] launching user 2 from Admin user...
-05:53:45 [INFO] launching user 3 from Anonymous Spanish user...
-05:53:45 [INFO] launching user 4 from Anonymous Spanish user...
-05:53:45 [INFO] launching user 5 from Anonymous Spanish user...
-05:53:45 [INFO] launching user 6 from Anonymous Spanish user...
-05:53:45 [INFO] launching user 7 from Anonymous Spanish user...
-05:53:45 [INFO] launching user 8 from Anonymous Spanish user...
-05:53:45 [INFO] launching user 9 from Anonymous Spanish user...
-05:53:46 [INFO] launching user 10 from Anonymous Spanish user...
-^C05:53:46 [WARN] caught ctrl-c, stopping...
+% cargo run --release --example umami -- --hatch-rate 10 --scenarios "anonymousspanishuser,adminuser"
+05:53:45 [INFO] scenarios = Scenarios { active: ["anonymousspanishuser", "adminuser"] }
 ```
+
+You can also mix exact and wildcard matching: `--scenarios "adminuser,anon*"` would run the exact `adminuser` scenario plus all scenarios starting with `anon`.
 
 When the load test completes, you can refer to the [Scenario metrics](./metrics.html#scenarios) to confirm which Scenarios were enabled, and which were not.


### PR DESCRIPTION
# PR Description: Fix scenario filtering substring matching bug

## Problem
Issue #612: When filtering scenarios, `--scenarios put1024bytes` incorrectly matched both `put1024bytes` and `getput1024bytes` due to substring matching instead of exact matching.

## Root Cause
`scenario_is_active()` method used `scenario_name.contains(&scenario)`, causing substring matches.

## Solution
Replace substring matching with exact matching for non-wildcard patterns:
- **No wildcard**: Exact string comparison only
- **With `*` wildcard**: Pattern matching (maintains backward compatibility)

## Technical Changes
- **src/lib.rs**: Replace `contains()` with `wildcard_match()` helper
- **src/config.rs**: Allow `*` characters in scenario validation
- **tests/scenarios.rs**: Add comprehensive test coverage (14 new tests)
- **Documentation**: Update scenario filtering behavior description

## Behavior Change
**Before**: `--scenarios put1024bytes` matches `put1024bytes`, `getput1024bytes`, `preput1024bytes`
**After**: `--scenarios put1024bytes` matches only `put1024bytes`

**Backward Compatibility**: `--scenarios *` continues to match all scenarios

## Test Coverage
- Exact matching without wildcards
- Wildcard patterns: `*suffix`, `prefix*`, `prefix*suffix`
- Multiple wildcards: `*prefix*middle*suffix*`
- Edge cases and complex patterns

Fixes #612
