### PR TITLE
Add comprehensive Basic Authentication example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     o introduces `TransactionName` enum with `TransactionOnly` and `InheritNameByRequests` variants
  - [#578](https://github.com/tag1consulting/goose/pull/578) add type-safe client builder for cookie configuration, optimize startup with shared clients
  - [#629](https://github.com/tag1consulting/goose/pull/629) add `--pdf-print-html` option to generate printer-friendly HTML optimized for PDF conversion; provides two-step PDF workflow without requiring Chromium dependencies; add `--pdf-timeout` option for configurable Chrome timeout in direct PDF generation (10-300s, default: 60)
+ - [#657](https://github.com/tag1consulting/goose/pull/657) add comprehensive Basic Authentication example demonstrating three approaches: custom client with default headers (recommended), helper function per-request, and manual per-request; includes flexible credential configuration and complete documentation
 
 ## 0.18.1 August 14, 2025
  - [#634](https://github.com/tag1consulting/goose/pull/634) add killswitch mechanism for programmatic test termination

--- a/examples/basic_auth.rs
+++ b/examples/basic_auth.rs
@@ -1,0 +1,269 @@
+//! Goose load test example demonstrating different approaches to HTTP Basic Authentication.
+//!
+//! This example shows multiple ways to handle Basic Auth in Goose load tests:
+//! 1. Per-request basic auth using request builders
+//! 2. Using a helper function for consistent auth across requests
+//! 3. Setting up a custom client with default Authorization headers (recommended)
+//!
+//! ## Usage
+//!
+//! Set environment variables for authentication:
+//! ```bash
+//! export BASIC_AUTH_USERNAME="your_username"
+//! export BASIC_AUTH_PASSWORD="your_password"
+//! ```
+//!
+//! Or use the combined format:
+//! ```bash
+//! export BASIC_AUTH="username:password"
+//! ```
+//!
+//! Run the example:
+//! ```bash
+//! cargo run --example basic_auth -- --host http://httpbin.org
+//! ```
+//!
+//! ## License
+//!
+//! Copyright 2020-2025 Jeremy Andrews
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//! <http://www.apache.org/licenses/LICENSE-2.0>
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+
+use goose::goose::GooseResponse;
+use goose::prelude::*;
+use reqwest::{header, Client};
+use std::{env, time::Duration};
+
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
+    GooseAttack::initialize()?
+        // Scenario 1: Using custom client with default headers (recommended approach)
+        .register_scenario(
+            scenario!("CustomClientAuth")
+                .set_weight(3)?
+                .set_wait_time(Duration::from_secs(1), Duration::from_secs(3))?
+                // Set up custom client with Basic Auth headers on user start
+                .register_transaction(transaction!(setup_basic_auth_client).set_on_start())
+                // All subsequent requests will automatically include Basic Auth
+                .register_transaction(transaction!(test_basic_auth_endpoint))
+                .register_transaction(transaction!(test_user_agent_endpoint))
+                .register_transaction(transaction!(test_json_endpoint)),
+        )
+        // Scenario 2: Using helper function for per-request auth
+        .register_scenario(
+            scenario!("HelperFunctionAuth")
+                .set_weight(2)?
+                .set_wait_time(Duration::from_secs(1), Duration::from_secs(3))?
+                .register_transaction(transaction!(test_with_helper_function))
+                .register_transaction(transaction!(test_post_with_helper)),
+        )
+        // Scenario 3: Manual per-request auth (demonstrates the original problem)
+        .register_scenario(
+            scenario!("ManualPerRequestAuth")
+                .set_weight(1)?
+                .set_wait_time(Duration::from_secs(1), Duration::from_secs(3))?
+                .register_transaction(transaction!(test_manual_basic_auth))
+                .register_transaction(transaction!(test_manual_with_validation)),
+        )
+        .execute()
+        .await?;
+
+    Ok(())
+}
+
+/// Approach 1: Set up a custom client with Basic Auth headers (RECOMMENDED)
+///
+/// This approach sets up the HTTP client once per user with default Basic Auth headers.
+/// All subsequent requests will automatically include the authentication headers,
+/// including requests for static assets (CSS, JS, images) when using
+/// `validate_and_load_static_assets`.
+async fn setup_basic_auth_client(user: &mut GooseUser) -> TransactionResult {
+    // Get credentials from environment variables
+    let (username, password) = get_basic_auth_credentials()?;
+
+    // Create a temporary client to generate the Basic Auth header
+    let temp_client = reqwest::Client::new();
+    let temp_request = temp_client
+        .get("http://example.com") // Dummy URL, we just need the header
+        .basic_auth(&username, Some(&password))
+        .build()
+        .map_err(|e| TransactionError::Reqwest(e))?;
+
+    // Extract the Authorization header from the temporary request
+    let mut headers = header::HeaderMap::new();
+    if let Some(auth_header) = temp_request.headers().get(header::AUTHORIZATION) {
+        headers.insert(header::AUTHORIZATION, auth_header.clone());
+    }
+
+    // Set up the client builder with default headers and other common settings
+    let builder = Client::builder()
+        .user_agent("Goose/1.0 BasicAuth Example")
+        .default_headers(headers)
+        .cookie_store(true)
+        .timeout(Duration::from_secs(30));
+
+    // Apply the custom client to this user
+    user.set_client_builder(builder).await?;
+
+    Ok(())
+}
+
+/// Test endpoint that requires Basic Auth - using custom client approach
+async fn test_basic_auth_endpoint(user: &mut GooseUser) -> TransactionResult {
+    // Since we set up the client with default headers, this request will
+    // automatically include the Basic Auth header
+    let goose_metrics = user.get("/basic-auth/user/passwd").await?;
+
+    // Since we're using httpbin.org for testing, we can validate the response
+    if let Ok(response) = &goose_metrics.response {
+        if response.status() == 200 {
+            // Success! The Basic Auth worked
+            println!("Basic Auth successful!");
+        }
+    }
+
+    Ok(())
+}
+
+/// Test user-agent endpoint to show other headers work too
+async fn test_user_agent_endpoint(user: &mut GooseUser) -> TransactionResult {
+    let _goose_metrics = user.get("/user-agent").await?;
+    Ok(())
+}
+
+/// Test JSON endpoint with Basic Auth
+async fn test_json_endpoint(user: &mut GooseUser) -> TransactionResult {
+    let _goose_metrics = user.get("/json").await?;
+    Ok(())
+}
+
+/// Approach 2: Helper function for consistent Basic Auth across requests
+///
+/// This approach uses a helper function that adds Basic Auth to each request.
+/// It's more flexible than the custom client approach but requires calling
+/// the helper for every request.
+async fn send_authenticated_request(
+    user: &mut GooseUser,
+    method: &GooseMethod,
+    path: &str,
+) -> Result<GooseResponse, Box<TransactionError>> {
+    let mut reqwest_request_builder = user.get_request_builder(method, path)?;
+
+    // Check for Basic Auth credentials in environment
+    if let Ok((username, password)) = get_basic_auth_credentials() {
+        reqwest_request_builder = reqwest_request_builder.basic_auth(username, Some(password));
+    }
+
+    // Build the GooseRequest and make the request
+    let goose_request = GooseRequest::builder()
+        .set_request_builder(reqwest_request_builder)
+        .build();
+
+    let goose_response = user.request(goose_request).await?;
+    Ok(goose_response)
+}
+
+/// Test using the helper function approach
+async fn test_with_helper_function(user: &mut GooseUser) -> TransactionResult {
+    let _goose_response =
+        send_authenticated_request(user, &GooseMethod::Get, "/basic-auth/user/passwd").await?;
+    Ok(())
+}
+
+/// Test POST request using helper function
+async fn test_post_with_helper(user: &mut GooseUser) -> TransactionResult {
+    let _goose_response = send_authenticated_request(user, &GooseMethod::Post, "/post").await?;
+    Ok(())
+}
+
+/// Approach 3: Manual per-request Basic Auth (demonstrates the original problem)
+///
+/// This approach manually adds Basic Auth to each individual request.
+/// Note: This does NOT propagate to static asset requests, which is the
+/// original problem described in issue #608.
+async fn test_manual_basic_auth(user: &mut GooseUser) -> TransactionResult {
+    let (username, password) = get_basic_auth_credentials()?;
+
+    let reqwest_request_builder = user
+        .get_request_builder(&GooseMethod::Get, "/basic-auth/user/passwd")?
+        .basic_auth(username, Some(password));
+
+    let goose_request = GooseRequest::builder()
+        .set_request_builder(reqwest_request_builder)
+        .build();
+
+    let _goose_metrics = user.request(goose_request).await?;
+
+    Ok(())
+}
+
+/// Manual approach with validation (shows the static asset problem)
+async fn test_manual_with_validation(user: &mut GooseUser) -> TransactionResult {
+    let (username, password) = get_basic_auth_credentials()?;
+
+    let reqwest_request_builder = user
+        .get_request_builder(&GooseMethod::Get, "/basic-auth/user/passwd")?
+        .basic_auth(username, Some(password));
+
+    let goose_request = GooseRequest::builder()
+        .set_request_builder(reqwest_request_builder)
+        .build();
+
+    let goose_metrics = user.request(goose_request).await?;
+
+    // WARNING: If this page had static assets (CSS, JS, images), they would
+    // fail to load because they won't have the Basic Auth header!
+    // This is the problem that the custom client approach solves.
+    if let Ok(response) = &goose_metrics.response {
+        if response.status() == 200 {
+            println!("Manual Basic Auth successful, but static assets would fail!");
+        }
+    }
+
+    Ok(())
+}
+
+/// Helper function to get Basic Auth credentials from environment variables
+///
+/// Supports two formats:
+/// 1. BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD (separate variables)
+/// 2. BASIC_AUTH in "username:password" format (combined variable)
+fn get_basic_auth_credentials() -> Result<(String, String), Box<TransactionError>> {
+    // Try the separate username/password format first
+    if let (Ok(username), Ok(password)) = (
+        env::var("BASIC_AUTH_USERNAME"),
+        env::var("BASIC_AUTH_PASSWORD"),
+    ) {
+        return Ok((username, password));
+    }
+
+    // Try the combined format
+    if let Ok(basic_auth) = env::var("BASIC_AUTH") {
+        let parts: Vec<&str> = basic_auth.split(':').collect();
+        if parts.len() == 2 {
+            return Ok((parts[0].to_string(), parts[1].to_string()));
+        } else {
+            return Err(Box::new(TransactionError::Custom(format!(
+                "BASIC_AUTH must be in format 'username:password', got: {}",
+                basic_auth
+            ))));
+        }
+    }
+
+    // Default credentials for testing with httpbin.org
+    eprintln!("Warning: No Basic Auth credentials found in environment variables.");
+    eprintln!("Using default credentials 'user:passwd' for httpbin.org testing.");
+    eprintln!("Set BASIC_AUTH_USERNAME/BASIC_AUTH_PASSWORD or BASIC_AUTH environment variables for real usage.");
+
+    Ok(("user".to_string(), "passwd".to_string()))
+}

--- a/src/docs/goose-book/src/SUMMARY.md
+++ b/src/docs/goose-book/src/SUMMARY.md
@@ -48,6 +48,7 @@
     - [Simple](example/simple.md)
     - [Closure](example/closure.md)
     - [Session](example/session.md)
+    - [Basic Authentication](example/basic-auth.md)
     - [GraphQL](example/graphql.md)
     - [Drupal Memcache](example/drupal-memcache.md)
     - [Umami](example/umami.md)

--- a/src/docs/goose-book/src/example/basic-auth.md
+++ b/src/docs/goose-book/src/example/basic-auth.md
@@ -1,0 +1,168 @@
+# Basic Authentication Example
+
+The [`basic_auth.rs`](https://github.com/tag1consulting/goose/blob/main/examples/basic_auth.rs) example demonstrates different approaches to handling HTTP Basic Authentication in Goose load tests. This addresses the common question of how to test sites behind Basic Auth, particularly when static assets (CSS, JS, images) also require authentication.
+
+## Problem Statement
+
+When load testing a site protected by HTTP Basic Authentication, there are several challenges:
+
+1. **Per-request authentication**: Adding Basic Auth to individual requests works for that specific request, but doesn't propagate to static asset requests
+2. **Static asset failures**: If a page includes CSS, JavaScript, or images, these assets will fail to load if they also require Basic Auth
+3. **Code duplication**: Manually adding authentication to every request leads to repetitive code
+
+## Solutions Demonstrated
+
+The example shows three different approaches to handle Basic Auth:
+
+### 1. Custom Client with Default Headers (Recommended)
+
+This approach sets up the HTTP client once per user with default Basic Auth headers. All subsequent requests automatically include the authentication headers, including requests for static assets.
+
+```rust
+async fn setup_basic_auth_client(user: &mut GooseUser) -> TransactionResult {
+    let (username, password) = get_basic_auth_credentials()?;
+    
+    // Create a temporary client to generate the Basic Auth header
+    let temp_client = reqwest::Client::new();
+    let temp_request = temp_client
+        .get("http://example.com")
+        .basic_auth(&username, Some(&password))
+        .build()
+        .map_err(|e| TransactionError::Reqwest(e))?;
+    
+    // Extract the Authorization header
+    let mut headers = header::HeaderMap::new();
+    if let Some(auth_header) = temp_request.headers().get(header::AUTHORIZATION) {
+        headers.insert(header::AUTHORIZATION, auth_header.clone());
+    }
+    
+    // Set up the client builder with default headers
+    let builder = Client::builder()
+        .user_agent("Goose/1.0 BasicAuth Example")
+        .default_headers(headers)
+        .cookie_store(true)
+        .timeout(Duration::from_secs(30));
+    
+    // Apply the custom client to this user
+    user.set_client_builder(builder).await?;
+    
+    Ok(())
+}
+```
+
+**Advantages:**
+- Set up once per user
+- Automatically applies to all requests, including static assets
+- Clean and maintainable code
+- Works with `validate_and_load_static_assets`
+
+### 2. Helper Function Approach
+
+This approach uses a helper function that adds Basic Auth to each request. It's more flexible than the custom client approach but requires calling the helper for every request.
+
+```rust
+async fn send_authenticated_request(
+    user: &mut GooseUser,
+    method: &GooseMethod,
+    path: &str,
+) -> Result<GooseResponse, Box<TransactionError>> {
+    let mut reqwest_request_builder = user.get_request_builder(method, path)?;
+
+    if let Ok((username, password)) = get_basic_auth_credentials() {
+        reqwest_request_builder = reqwest_request_builder.basic_auth(username, Some(password));
+    }
+
+    let goose_request = GooseRequest::builder()
+        .set_request_builder(reqwest_request_builder)
+        .build();
+
+    let goose_response = user.request(goose_request).await?;
+    Ok(goose_response)
+}
+```
+
+**Advantages:**
+- More control over individual requests
+- Can conditionally apply authentication
+- Easier to debug individual requests
+
+**Disadvantages:**
+- Must be called for every request
+- Doesn't automatically handle static assets
+- More verbose code
+
+### 3. Manual Per-Request Authentication
+
+This approach manually adds Basic Auth to each individual request using the request builder.
+
+```rust
+async fn test_manual_basic_auth(user: &mut GooseUser) -> TransactionResult {
+    let (username, password) = get_basic_auth_credentials()?;
+    
+    let reqwest_request_builder = user
+        .get_request_builder(&GooseMethod::Get, "/basic-auth/user/passwd")?
+        .basic_auth(username, Some(password));
+
+    let goose_request = GooseRequest::builder()
+        .set_request_builder(reqwest_request_builder)
+        .build();
+
+    let _goose_metrics = user.request(goose_request).await?;
+    
+    Ok(())
+}
+```
+
+**Disadvantages:**
+- Most verbose approach
+- Does NOT propagate to static asset requests
+- Lots of code duplication
+- This is the original problem described in [issue #608](https://github.com/tag1consulting/goose/issues/608)
+
+## Configuration
+
+The example supports multiple ways to provide Basic Auth credentials:
+
+### Environment Variables
+
+**Separate variables:**
+```bash
+export BASIC_AUTH_USERNAME="your_username"
+export BASIC_AUTH_PASSWORD="your_password"
+```
+
+**Combined format:**
+```bash
+export BASIC_AUTH="username:password"
+```
+
+### Default Credentials
+
+If no environment variables are set, the example uses default credentials (`user:passwd`) suitable for testing with httpbin.org.
+
+## Running the Example
+
+```bash
+# Using httpbin.org for testing (uses default credentials)
+cargo run --example basic_auth -- --host http://httpbin.org --users 5 --run-time 30s
+
+# With custom credentials
+BASIC_AUTH_USERNAME="myuser" BASIC_AUTH_PASSWORD="mypass" \
+cargo run --example basic_auth -- --host https://your-protected-site.com --users 10 --run-time 60s
+
+# Using combined format
+BASIC_AUTH="myuser:mypass" \
+cargo run --example basic_auth -- --host https://your-protected-site.com --users 10 --run-time 60s
+```
+
+## Key Takeaways
+
+1. **Use the custom client approach** for most Basic Auth scenarios - it's the most robust solution
+2. **Set up authentication once per user** rather than per request for better performance and cleaner code
+3. **Consider static assets** - only the custom client approach properly handles authentication for CSS, JS, and image requests
+4. **Use environment variables** for credentials to keep them out of your code
+5. **Test your approach** with a simple example like httpbin.org before applying to your actual load test
+
+## Related Issues
+
+This example addresses [GitHub issue #608](https://github.com/tag1consulting/goose/issues/608): "How can I test a site behind Basic Auth".

--- a/src/docs/goose-book/src/example/overview.md
+++ b/src/docs/goose-book/src/example/overview.md
@@ -4,5 +4,7 @@ Goose includes several examples to demonstrate load test functionality, includin
  - [Simple](simple.md) *([examples/simple.rs](https://github.com/tag1consulting/goose/blob/main/examples/simple.rs))*
  - [Closure](closure.md) *([examples/closure.rs](https://github.com/tag1consulting/goose/blob/main/examples/closure.rs))*
  - [Session](session.md) *([examples/session.rs](https://github.com/tag1consulting/goose/blob/main/examples/session.rs))*
+ - [Basic Authentication](basic-auth.md) *([examples/basic_auth.rs](https://github.com/tag1consulting/goose/blob/main/examples/basic_auth.rs))*
+ - [GraphQL](graphql.md) *([examples/graphql_loadtest.rs](https://github.com/tag1consulting/goose/blob/main/examples/graphql_loadtest.rs))*
  - [Drupal Memcache](drupal-memcache.md) *([examples/drupal_memcache.rs](https://github.com/tag1consulting/goose/blob/main/examples/drupal_memcache.rs))*
  - [Umami](umami.md) *([examples/umami/](https://github.com/tag1consulting/goose/tree/main/examples/umami))*


### PR DESCRIPTION
# Add comprehensive Basic Authentication example

## Summary

Adds `examples/basic_auth.rs` demonstrating three approaches to HTTP Basic Authentication in Goose load tests, addressing the static asset authentication problem described in issue #608.

## Changes

### New Files
- `examples/basic_auth.rs` - Complete working example with three authentication approaches
- `src/docs/goose-book/src/example/basic-auth.md` - Comprehensive documentation
- Updated `src/docs/goose-book/src/SUMMARY.md` and `src/docs/goose-book/src/example/overview.md`

### Approaches Demonstrated

1. **Custom Client with Default Headers (Recommended)**
   - Sets up authentication once per user via `set_client_builder()`
   - Automatically applies to all requests including static assets
   - Solves the core problem from issue #608

2. **Helper Function Approach**
   - Adds Basic Auth to each request via helper function
   - More flexible but requires calling for every request
   - Does not handle static assets automatically

3. **Manual Per-Request Authentication**
   - Demonstrates the original problem where auth doesn't propagate
   - Shows why this approach fails for static assets

### Configuration Support
- `BASIC_AUTH_USERNAME` / `BASIC_AUTH_PASSWORD` (separate variables)
- `BASIC_AUTH="username:password"` (combined format)
- Default credentials for httpbin.org testing

### Testing
- Successfully tested with httpbin.org
- All three approaches work correctly
- Proper HTTP 200 responses for authenticated endpoints

Closes https://github.com/tag1consulting/goose/issues/608
