### PR TITLE
chore: update httpmock to 0.8, avoid deprecated function names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ cookies = ["reqwest/cookies"]
 pdf-reports = ["headless_chrome", "urlencoding"]
 
 [dev-dependencies]
-httpmock = "0.7"
+httpmock = "0.8"
 native-tls = "0.2"
 nix = { version = "0.30", features = ["signal"] }
 rustls = "0.23"

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -3593,7 +3593,7 @@ mod tests {
         });
 
         // Make a GET request to the mock http server and confirm we get a 200 response.
-        assert_eq!(index.hits(), 0);
+        assert_eq!(index.calls(), 0);
         let goose = user
             .get(INDEX_PATH)
             .await
@@ -3605,7 +3605,7 @@ mod tests {
         assert!(goose.request.success);
         assert!(!goose.request.update);
         assert_eq!(goose.request.status_code, 200);
-        assert_eq!(index.hits(), 1);
+        assert_eq!(index.calls(), 1);
 
         const NO_SUCH_PATH: &str = "/no/such/path";
         // Set up a mock http server endpoint.
@@ -3615,7 +3615,7 @@ mod tests {
         });
 
         // Make an invalid GET request to the mock http server and confirm we get a 404 response.
-        assert_eq!(not_found.hits(), 0);
+        assert_eq!(not_found.calls(), 0);
         let goose = user
             .get(NO_SUCH_PATH)
             .await
@@ -3627,7 +3627,7 @@ mod tests {
         assert!(!goose.request.success);
         assert!(!goose.request.update);
         assert_eq!(goose.request.status_code, 404,);
-        not_found.assert_hits(1);
+        not_found.assert_calls(1);
 
         // Set up a mock http server endpoint.
         const COMMENT_PATH: &str = "/comment";
@@ -3637,7 +3637,7 @@ mod tests {
         });
 
         // Make a POST request to the mock http server and confirm we get a 200 OK response.
-        assert_eq!(comment.hits(), 0);
+        assert_eq!(comment.calls(), 0);
         let goose = user
             .post(COMMENT_PATH, "foo")
             .await
@@ -3651,7 +3651,7 @@ mod tests {
         assert!(goose.request.success);
         assert!(!goose.request.update);
         assert_eq!(goose.request.status_code, 200);
-        comment.assert_hits(1);
+        comment.assert_calls(1);
     }
 
     #[test]

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -219,15 +219,15 @@ fn common_build_configuration(
 // Helper to confirm all variations generate appropriate results.
 fn validate_test(is_builder: bool, mock_endpoints: &[Mock], goose_metrics: GooseMetrics) {
     // Confirm that the on_start and on_exit transactions actually ran once per GooseUser.
-    assert!(mock_endpoints[GET_KEY].hits() > 0);
-    assert!(mock_endpoints[POST_KEY].hits() > 0);
-    assert!(mock_endpoints[HEAD_KEY].hits() > 0);
-    assert!(mock_endpoints[DELETE_KEY].hits() > 0);
+    assert!(mock_endpoints[GET_KEY].calls() > 0);
+    assert!(mock_endpoints[POST_KEY].calls() > 0);
+    assert!(mock_endpoints[HEAD_KEY].calls() > 0);
+    assert!(mock_endpoints[DELETE_KEY].calls() > 0);
 
     // PATCH and PUT are only possible when using builder.
     if is_builder {
-        assert!(mock_endpoints[PATCH_KEY].hits() > 0);
-        assert!(mock_endpoints[PUT_KEY].hits() > 0);
+        assert!(mock_endpoints[PATCH_KEY].calls() > 0);
+        assert!(mock_endpoints[PUT_KEY].calls() > 0);
     }
 
     // Validate GET requests.

--- a/tests/cancel.rs
+++ b/tests/cancel.rs
@@ -147,11 +147,11 @@ fn validate_one_scenario(
 ) {
     // The throttle limits how many hits are registered.
     if is_gaggle {
-        assert!(mock_endpoints[INDEX_KEY].hits() <= 40);
+        assert!(mock_endpoints[INDEX_KEY].calls() <= 40);
     } else {
-        assert!(mock_endpoints[INDEX_KEY].hits() <= 20);
+        assert!(mock_endpoints[INDEX_KEY].calls() <= 20);
     }
-    assert!(mock_endpoints[INDEX_KEY].hits() > 10);
+    assert!(mock_endpoints[INDEX_KEY].calls() > 10);
 
     // Get index and about out of goose metrics.
     let index_metrics = goose_metrics

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -155,7 +155,7 @@ fn validate_closer_test(
 
         // Confirm that we loaded the mock endpoint.
         assert!(
-            mock_endpoint.hits() > 0,
+            mock_endpoint.calls() > 0,
             "Endpoint was not called > 0 for item: {:#?}",
             &item
         );
@@ -178,17 +178,17 @@ fn validate_closer_test(
         let status_code: u16 = item.status_code;
 
         assert!(
-            endpoint_metrics.raw_data.counter == mock_endpoint.hits(),
+            endpoint_metrics.raw_data.counter == mock_endpoint.calls(),
             "response_time_counter != hits() for item: {:#?}",
             &item
         );
         assert!(
-            endpoint_metrics.status_code_counts[&status_code] == mock_endpoint.hits(),
+            endpoint_metrics.status_code_counts[&status_code] == mock_endpoint.calls(),
             "status_code_counts != hits() for item: {:#?}",
             &item
         );
         assert!(
-            endpoint_metrics.success_count == mock_endpoint.hits(),
+            endpoint_metrics.success_count == mock_endpoint.calls(),
             "success_count != hits() for item: {:#?}",
             &item
         );
@@ -204,8 +204,8 @@ fn validate_closer_test(
     let about = &mock_endpoints[1];
 
     // Confirm that we loaded the index roughly three times as much as the about page.
-    let one_third_index = index.hits() / 3;
-    let difference = about.hits() as i32 - one_third_index as i32;
+    let one_third_index = index.calls() / 3;
+    let difference = about.calls() as i32 - one_third_index as i32;
     assert!((-2..=2).contains(&difference));
 
     // Verify that Goose started the correct number of users.

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -121,8 +121,8 @@ fn validate_one_scenario(
     //println!("configuration: {:#?}", configuration);
 
     // Confirm that we loaded the mock endpoints.
-    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
-    assert!(mock_endpoints[ABOUT_KEY].hits() > 0);
+    assert!(mock_endpoints[INDEX_KEY].calls() > 0);
+    assert!(mock_endpoints[ABOUT_KEY].calls() > 0);
 
     // Get index and about out of goose metrics.
     let index_metrics = goose_metrics

--- a/tests/coordinated_omission_integration.rs
+++ b/tests/coordinated_omission_integration.rs
@@ -55,7 +55,7 @@ mod load_test_integration {
 
         // When CO is disabled, no CO metrics should be collected
         assert!(goose_metrics.coordinated_omission_metrics.is_none());
-        assert!(mock.hits() > 0);
+        assert!(mock.calls() > 0);
 
         // Regular metrics should still be present
         assert!(!goose_metrics.requests.is_empty());
@@ -107,7 +107,7 @@ mod load_test_integration {
 
         // With consistent 50ms delays, minimal CO events expected
         // (This test may not trigger CO events due to consistent timing)
-        assert!(mock.hits() > 0);
+        assert!(mock.calls() > 0);
     }
 
     #[tokio::test]
@@ -167,8 +167,8 @@ mod load_test_integration {
             co_metrics.synthetic_percentage
         );
 
-        assert!(mock_fast.hits() > 0);
-        assert!(mock_slow.hits() > 0);
+        assert!(mock_fast.calls() > 0);
+        assert!(mock_slow.calls() > 0);
     }
 
     #[tokio::test]

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -89,8 +89,8 @@ fn validate_test(
 ) {
     // Confirm that we loaded the mock endpoints. This confirms that we started
     // both users, which also verifies that hatch_rate was properly set.
-    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
-    assert!(mock_endpoints[ABOUT_KEY].hits() > 0);
+    assert!(mock_endpoints[INDEX_KEY].calls() > 0);
+    assert!(mock_endpoints[ABOUT_KEY].calls() > 0);
 
     let index_metrics = goose_metrics
         .requests
@@ -102,10 +102,10 @@ fn validate_test(
         .unwrap();
 
     // Confirm that Goose and the server saw the same number of page loads.
-    mock_endpoints[INDEX_KEY].assert_hits(index_metrics.raw_data.counter);
-    mock_endpoints[INDEX_KEY].assert_hits(index_metrics.success_count);
-    mock_endpoints[ABOUT_KEY].assert_hits(about_metrics.raw_data.counter);
-    mock_endpoints[ABOUT_KEY].assert_hits(about_metrics.success_count);
+    mock_endpoints[INDEX_KEY].assert_calls(index_metrics.raw_data.counter);
+    mock_endpoints[INDEX_KEY].assert_calls(index_metrics.success_count);
+    mock_endpoints[ABOUT_KEY].assert_calls(about_metrics.raw_data.counter);
+    mock_endpoints[ABOUT_KEY].assert_calls(about_metrics.success_count);
     assert!(index_metrics.fail_count == 0);
     assert!(about_metrics.fail_count == 0);
 
@@ -122,7 +122,7 @@ fn validate_test(
         assert!(std::path::Path::new(requests_file).exists());
         metrics_lines += common::file_length(requests_file);
     }
-    assert!(metrics_lines == mock_endpoints[INDEX_KEY].hits() + mock_endpoints[ABOUT_KEY].hits());
+    assert!(metrics_lines == mock_endpoints[INDEX_KEY].calls() + mock_endpoints[ABOUT_KEY].calls());
 
     // Verify that the debug file was created and is empty.
     for debug_file in debug_files {
@@ -700,8 +700,8 @@ async fn test_defaults_no_metrics() {
         .unwrap();
 
     // Confirm that we loaded the mock endpoints.
-    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
-    assert!(mock_endpoints[ABOUT_KEY].hits() > 0);
+    assert!(mock_endpoints[INDEX_KEY].calls() > 0);
+    assert!(mock_endpoints[ABOUT_KEY].calls() > 0);
 
     // Confirm that we did not track metrics.
     assert!(goose_metrics.requests.is_empty());

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -83,8 +83,8 @@ fn validate_error(
     test_type: TestType,
 ) {
     // Confirm that we loaded the mock endpoints.
-    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
-    assert!(mock_endpoints[A_404_KEY].hits() > 0);
+    assert!(mock_endpoints[INDEX_KEY].calls() > 0);
+    assert!(mock_endpoints[A_404_KEY].calls() > 0);
 
     // Get request metrics.
     let index_metrics = goose_metrics
@@ -106,11 +106,11 @@ fn validate_error(
     assert!(a_404_metrics.method == GooseMethod::Get);
 
     // All requests to the index succeeded.
-    mock_endpoints[INDEX_KEY].assert_hits(index_metrics.raw_data.counter);
-    mock_endpoints[INDEX_KEY].assert_hits(index_metrics.success_count);
+    mock_endpoints[INDEX_KEY].assert_calls(index_metrics.raw_data.counter);
+    mock_endpoints[INDEX_KEY].assert_calls(index_metrics.success_count);
     // All requests to the 404 page failed.
-    mock_endpoints[A_404_KEY].assert_hits(a_404_metrics.raw_data.counter);
-    mock_endpoints[A_404_KEY].assert_hits(a_404_metrics.fail_count);
+    mock_endpoints[A_404_KEY].assert_calls(a_404_metrics.raw_data.counter);
+    mock_endpoints[A_404_KEY].assert_calls(a_404_metrics.fail_count);
 
     match test_type {
         TestType::ErrorSummary => {

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -115,8 +115,8 @@ fn validate_test(
     // Confirm that we loaded the mock endpoints. This confirms that we started
     // both users, which also verifies that hatch_rate was properly set.
     // Confirm that we loaded the mock endpoints.
-    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
-    assert!(mock_endpoints[ERROR_KEY].hits() > 0);
+    assert!(mock_endpoints[INDEX_KEY].calls() > 0);
+    assert!(mock_endpoints[ERROR_KEY].calls() > 0);
 
     // Confirm that the test duration was correct.
     assert!(goose_metrics.duration == 2);

--- a/tests/no_normal_tasks.rs
+++ b/tests/no_normal_tasks.rs
@@ -93,8 +93,8 @@ fn common_build_configuration(
 // Helper to confirm all variations generate appropriate results.
 fn validate_test(mock_endpoints: &[Mock]) {
     // Confirm that the on_start and on_exit transactions actually ran once per GooseUser.
-    mock_endpoints[LOGIN_KEY].assert_hits(USERS);
-    mock_endpoints[LOGOUT_KEY].assert_hits(USERS);
+    mock_endpoints[LOGIN_KEY].assert_calls(USERS);
+    mock_endpoints[LOGOUT_KEY].assert_calls(USERS);
 }
 
 // Returns the appropriate scenario needed to build these tests.

--- a/tests/one_taskset.rs
+++ b/tests/one_taskset.rs
@@ -75,12 +75,12 @@ fn validate_one_scenario(
     test_type: TestType,
 ) {
     // Confirm that we loaded the mock endpoints.
-    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
-    assert!(mock_endpoints[ABOUT_KEY].hits() > 0);
+    assert!(mock_endpoints[INDEX_KEY].calls() > 0);
+    assert!(mock_endpoints[ABOUT_KEY].calls() > 0);
 
     // Confirm that we loaded the index roughly three times as much as the about page.
-    let one_third_index = mock_endpoints[INDEX_KEY].hits() / 3;
-    let difference = mock_endpoints[ABOUT_KEY].hits() as i32 - one_third_index as i32;
+    let one_third_index = mock_endpoints[INDEX_KEY].calls() / 3;
+    let difference = mock_endpoints[ABOUT_KEY].calls() as i32 - one_third_index as i32;
     assert!((-2..=2).contains(&difference));
 
     // Get index and about out of goose metrics.
@@ -107,29 +107,29 @@ fn validate_one_scenario(
             println!(
                 "raw_data.counter: {}, mock_endpoint_called: {}",
                 index_metrics.raw_data.counter,
-                mock_endpoints[INDEX_KEY].hits()
+                mock_endpoints[INDEX_KEY].calls()
             );
 
-            assert!(index_metrics.raw_data.counter < mock_endpoints[INDEX_KEY].hits());
+            assert!(index_metrics.raw_data.counter < mock_endpoints[INDEX_KEY].calls());
             assert!(
-                index_metrics.status_code_counts[&status_code] < mock_endpoints[INDEX_KEY].hits()
+                index_metrics.status_code_counts[&status_code] < mock_endpoints[INDEX_KEY].calls()
             );
-            assert!(index_metrics.success_count < mock_endpoints[INDEX_KEY].hits());
-            assert!(about_metrics.raw_data.counter < mock_endpoints[ABOUT_KEY].hits());
+            assert!(index_metrics.success_count < mock_endpoints[INDEX_KEY].calls());
+            assert!(about_metrics.raw_data.counter < mock_endpoints[ABOUT_KEY].calls());
             assert!(
-                about_metrics.status_code_counts[&status_code] < mock_endpoints[ABOUT_KEY].hits()
+                about_metrics.status_code_counts[&status_code] < mock_endpoints[ABOUT_KEY].calls()
             );
-            assert!(about_metrics.success_count < mock_endpoints[ABOUT_KEY].hits());
+            assert!(about_metrics.success_count < mock_endpoints[ABOUT_KEY].calls());
         }
         TestType::NoResetMetrics => {
             // Statistics were not reset, so Goose should report the same number of page
             // loads as the server actually saw.
-            mock_endpoints[INDEX_KEY].assert_hits(index_metrics.raw_data.counter);
-            mock_endpoints[INDEX_KEY].assert_hits(index_metrics.status_code_counts[&status_code]);
-            mock_endpoints[INDEX_KEY].assert_hits(index_metrics.success_count);
-            mock_endpoints[ABOUT_KEY].assert_hits(about_metrics.raw_data.counter);
-            mock_endpoints[ABOUT_KEY].assert_hits(about_metrics.status_code_counts[&status_code]);
-            mock_endpoints[ABOUT_KEY].assert_hits(about_metrics.success_count);
+            mock_endpoints[INDEX_KEY].assert_calls(index_metrics.raw_data.counter);
+            mock_endpoints[INDEX_KEY].assert_calls(index_metrics.status_code_counts[&status_code]);
+            mock_endpoints[INDEX_KEY].assert_calls(index_metrics.success_count);
+            mock_endpoints[ABOUT_KEY].assert_calls(about_metrics.raw_data.counter);
+            mock_endpoints[ABOUT_KEY].assert_calls(about_metrics.status_code_counts[&status_code]);
+            mock_endpoints[ABOUT_KEY].assert_calls(about_metrics.success_count);
         }
     }
 

--- a/tests/pdf_reports.rs
+++ b/tests/pdf_reports.rs
@@ -62,7 +62,7 @@ async fn test_pdf_generation_with_feature() {
     let goose_metrics = common::run_load_test(goose_attack, None).await;
 
     // Confirm that we loaded the mock endpoints
-    assert!(mock_endpoints[0].hits() > 0);
+    assert!(mock_endpoints[0].calls() > 0);
 
     // Confirm that the test duration was correct
     assert!(goose_metrics.duration == 1);
@@ -110,7 +110,7 @@ async fn test_pdf_print_html_without_feature_works() {
     let goose_metrics = common::run_load_test(goose_attack, None).await;
 
     // Verify the test ran successfully
-    assert!(mock_endpoints[0].hits() > 0);
+    assert!(mock_endpoints[0].calls() > 0);
     assert!(goose_metrics.duration == 1);
 
     // The HTML file should be created even when the pdf-reports feature is not compiled
@@ -177,7 +177,7 @@ async fn test_pdf_print_html_generation() {
     let goose_metrics = common::run_load_test(goose_attack, None).await;
 
     // Verify the test ran successfully
-    assert!(mock_endpoints[0].hits() > 0);
+    assert!(mock_endpoints[0].calls() > 0);
     assert!(goose_metrics.duration == 1);
 
     // Verify both PDF and HTML files were created
@@ -253,7 +253,7 @@ async fn test_pdf_resource_management() {
         let goose_metrics = common::run_load_test(goose_attack, None).await;
 
         // Confirm basic functionality
-        assert!(mock_endpoints[0].hits() > 0);
+        assert!(mock_endpoints[0].calls() > 0);
         assert!(goose_metrics.duration == 1);
 
         // Verify PDF file was created

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -238,55 +238,55 @@ fn validate_redirect(test_type: &TestType, mock_endpoints: &[Mock]) {
         TestType::Chain => {
             // Confirm that all pages are loaded, even those not requested directly but
             // that are only loaded due to redirects.
-            assert!(mock_endpoints[INDEX_KEY].hits() > 0);
-            assert!(mock_endpoints[REDIRECT_KEY].hits() > 0);
-            assert!(mock_endpoints[REDIRECT_KEY2].hits() > 0);
-            assert!(mock_endpoints[REDIRECT_KEY3].hits() > 0);
-            assert!(mock_endpoints[ABOUT_KEY].hits() > 0);
+            assert!(mock_endpoints[INDEX_KEY].calls() > 0);
+            assert!(mock_endpoints[REDIRECT_KEY].calls() > 0);
+            assert!(mock_endpoints[REDIRECT_KEY2].calls() > 0);
+            assert!(mock_endpoints[REDIRECT_KEY3].calls() > 0);
+            assert!(mock_endpoints[ABOUT_KEY].calls() > 0);
 
             // Confirm the entire redirect chain is loaded the same number of times.
-            mock_endpoints[REDIRECT_KEY].assert_hits(mock_endpoints[REDIRECT_KEY2].hits());
-            mock_endpoints[REDIRECT_KEY].assert_hits(mock_endpoints[REDIRECT_KEY3].hits());
-            mock_endpoints[REDIRECT_KEY].assert_hits(mock_endpoints[ABOUT_KEY].hits());
+            mock_endpoints[REDIRECT_KEY].assert_calls(mock_endpoints[REDIRECT_KEY2].calls());
+            mock_endpoints[REDIRECT_KEY].assert_calls(mock_endpoints[REDIRECT_KEY3].calls());
+            mock_endpoints[REDIRECT_KEY].assert_calls(mock_endpoints[ABOUT_KEY].calls());
         }
         TestType::Domain => {
             // All pages on Server1 are loaded.
-            assert!(mock_endpoints[SERVER1_INDEX_KEY].hits() > 0);
-            assert!(mock_endpoints[SERVER1_REDIRECT_KEY].hits() > 0);
-            assert!(mock_endpoints[SERVER1_ABOUT_KEY].hits() > 0);
+            assert!(mock_endpoints[SERVER1_INDEX_KEY].calls() > 0);
+            assert!(mock_endpoints[SERVER1_REDIRECT_KEY].calls() > 0);
+            assert!(mock_endpoints[SERVER1_ABOUT_KEY].calls() > 0);
 
             // GooseUsers are redirected to Server2 correctly.
-            assert!(mock_endpoints[SERVER2_INDEX_KEY].hits() > 0);
+            assert!(mock_endpoints[SERVER2_INDEX_KEY].calls() > 0);
 
             // GooseUsers do not stick to Server2 and load the other page.
-            mock_endpoints[SERVER2_ABOUT_KEY].assert_hits(0);
+            mock_endpoints[SERVER2_ABOUT_KEY].assert_calls(0);
         }
         TestType::Sticky => {
             // Each GooseUser loads the redirect on Server1 one time.
             println!(
                 "SERVER1_REDIRECT: {}, USERS: {}",
-                mock_endpoints[SERVER1_REDIRECT_KEY].hits(),
+                mock_endpoints[SERVER1_REDIRECT_KEY].calls(),
                 USERS,
             );
             println!(
                 "SERVER1_INDEX: {}, SERVER1_ABOUT: {}",
-                mock_endpoints[SERVER1_INDEX_KEY].hits(),
-                mock_endpoints[SERVER1_ABOUT_KEY].hits(),
+                mock_endpoints[SERVER1_INDEX_KEY].calls(),
+                mock_endpoints[SERVER1_ABOUT_KEY].calls(),
             );
             println!(
                 "SERVER2_INDEX: {}, SERVER2_ABOUT: {}",
-                mock_endpoints[SERVER2_INDEX_KEY].hits(),
-                mock_endpoints[SERVER2_ABOUT_KEY].hits(),
+                mock_endpoints[SERVER2_INDEX_KEY].calls(),
+                mock_endpoints[SERVER2_ABOUT_KEY].calls(),
             );
-            mock_endpoints[SERVER1_REDIRECT_KEY].assert_hits(USERS);
+            mock_endpoints[SERVER1_REDIRECT_KEY].assert_calls(USERS);
 
             // Redirected to Server2, no user load anything else on Server1.
-            mock_endpoints[SERVER1_INDEX_KEY].assert_hits(0);
-            mock_endpoints[SERVER1_ABOUT_KEY].assert_hits(0);
+            mock_endpoints[SERVER1_INDEX_KEY].assert_calls(0);
+            mock_endpoints[SERVER1_ABOUT_KEY].assert_calls(0);
 
             // All GooseUsers go on to load pages on Server2.
-            assert!(mock_endpoints[SERVER2_INDEX_KEY].hits() > 0);
-            assert!(mock_endpoints[SERVER2_ABOUT_KEY].hits() > 0);
+            assert!(mock_endpoints[SERVER2_INDEX_KEY].calls() > 0);
+            assert!(mock_endpoints[SERVER2_ABOUT_KEY].calls() > 0);
         }
     }
 }

--- a/tests/scenarios.rs
+++ b/tests/scenarios.rs
@@ -142,7 +142,7 @@ fn validate_loadtest(
             // There should not have been any failures during this test.
             assert!(scenarioa1_metrics.fail_count == 0);
             // Confirm Goose and the mock endpoint agree on the number of requests made.
-            assert!(mock_endpoints[SCENARIOA1_KEY].hits() <= scenarioa1_metrics.success_count);
+            assert!(mock_endpoints[SCENARIOA1_KEY].calls() <= scenarioa1_metrics.success_count);
 
             // Get scenarioa2 metrics.
             let scenarioa2_metrics = goose_metrics
@@ -155,18 +155,18 @@ fn validate_loadtest(
             // There should not have been any failures during this test.
             assert!(scenarioa2_metrics.fail_count == 0);
             // Confirm Goose and the mock endpoint agree on the number of requests made.
-            assert!(mock_endpoints[SCENARIOA2_KEY].hits() <= scenarioa2_metrics.success_count);
+            assert!(mock_endpoints[SCENARIOA2_KEY].calls() <= scenarioa2_metrics.success_count);
 
             // scenariob1 and scenariob2 should not have been loaded due to `--scenarios scenarioa`.
-            assert!(mock_endpoints[SCENARIOB1_KEY].hits() == 0);
-            assert!(mock_endpoints[SCENARIOB2_KEY].hits() == 0);
+            assert!(mock_endpoints[SCENARIOB1_KEY].calls() == 0);
+            assert!(mock_endpoints[SCENARIOB2_KEY].calls() == 0);
         }
         TestType::ScenariosDefault => {
             // scenarioa1 and scenarioa2 should not have been loaded due to `GooseDefault::Scenarios`.
-            assert!(mock_endpoints[SCENARIOA1_KEY].hits() == 0);
-            assert!(mock_endpoints[SCENARIOA2_KEY].hits() == 0);
-            assert!(mock_endpoints[SCENARIOB1_KEY].hits() > 0);
-            assert!(mock_endpoints[SCENARIOB2_KEY].hits() > 0);
+            assert!(mock_endpoints[SCENARIOA1_KEY].calls() == 0);
+            assert!(mock_endpoints[SCENARIOA2_KEY].calls() == 0);
+            assert!(mock_endpoints[SCENARIOB1_KEY].calls() > 0);
+            assert!(mock_endpoints[SCENARIOB2_KEY].calls() > 0);
         }
     }
 }

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -158,7 +158,7 @@ fn common_build_configuration(
 // Helper to confirm all variations generate appropriate results.
 fn validate_test(test_type: &TestType, scheduler: &GooseScheduler, mock_endpoints: &[Mock]) {
     // START_ONE_PATH is loaded one and only one time on all variations.
-    mock_endpoints[START_ONE_KEY].assert_hits(1);
+    mock_endpoints[START_ONE_KEY].assert_calls(1);
 
     match test_type {
         TestType::ScenariosLimitIterations => {
@@ -167,21 +167,21 @@ fn validate_test(test_type: &TestType, scheduler: &GooseScheduler, mock_endpoint
                 GooseScheduler::RoundRobin => {
                     // We launch an equal number of each scenario, so we call both endpoints
                     // an equal number of times.
-                    mock_endpoints[TWO_KEY].assert_hits(mock_endpoints[ONE_KEY].hits());
-                    mock_endpoints[ONE_KEY].assert_hits(USERS);
+                    mock_endpoints[TWO_KEY].assert_calls(mock_endpoints[ONE_KEY].calls());
+                    mock_endpoints[ONE_KEY].assert_calls(USERS);
                 }
                 GooseScheduler::Serial => {
                     // As we only launch as many users as the weight of the first scenario, we only
                     // call the first endpoint, never the second endpoint.
-                    mock_endpoints[ONE_KEY].assert_hits(USERS * 2);
-                    mock_endpoints[TWO_KEY].assert_hits(0);
+                    mock_endpoints[ONE_KEY].assert_calls(USERS * 2);
+                    mock_endpoints[TWO_KEY].assert_calls(0);
                 }
                 GooseScheduler::Random => {
                     // When scheduling scenarios randomly, we don't know how many of each will get
                     // launched, but we do now that added together they will equal the total number
                     // of users.
                     assert!(
-                        mock_endpoints[ONE_KEY].hits() + mock_endpoints[TWO_KEY].hits()
+                        mock_endpoints[ONE_KEY].calls() + mock_endpoints[TWO_KEY].calls()
                             == USERS * 2
                     );
                 }
@@ -193,21 +193,21 @@ fn validate_test(test_type: &TestType, scheduler: &GooseScheduler, mock_endpoint
                 GooseScheduler::RoundRobin => {
                     // We launch an equal number of each scenario, so we call both endpoints
                     // an equal number of times.
-                    mock_endpoints[TWO_KEY].assert_hits(mock_endpoints[ONE_KEY].hits());
-                    mock_endpoints[ONE_KEY].assert_hits(USERS / 2);
+                    mock_endpoints[TWO_KEY].assert_calls(mock_endpoints[ONE_KEY].calls());
+                    mock_endpoints[ONE_KEY].assert_calls(USERS / 2);
                 }
                 GooseScheduler::Serial => {
                     // As we only launch as many users as the weight of the first scenario, we only
                     // call the first endpoint, never the second endpoint.
-                    mock_endpoints[ONE_KEY].assert_hits(USERS);
-                    mock_endpoints[TWO_KEY].assert_hits(0);
+                    mock_endpoints[ONE_KEY].assert_calls(USERS);
+                    mock_endpoints[TWO_KEY].assert_calls(0);
                 }
                 GooseScheduler::Random => {
                     // When scheduling scenarios randomly, we don't know how many of each will get
                     // launched, but we do now that added together they will equal the total number
                     // of users.
                     assert!(
-                        mock_endpoints[ONE_KEY].hits() + mock_endpoints[TWO_KEY].hits() == USERS
+                        mock_endpoints[ONE_KEY].calls() + mock_endpoints[TWO_KEY].calls() == USERS
                     );
                 }
             }
@@ -219,24 +219,24 @@ fn validate_test(test_type: &TestType, scheduler: &GooseScheduler, mock_endpoint
                     // Tests are allocated round robin THREE, TWO, ONE. There's no delay
                     // in THREE, so the test runs THREE and TWO which then times things out
                     // and prevents ONE from running.
-                    mock_endpoints[ONE_KEY].assert_hits(0);
-                    mock_endpoints[TWO_KEY].assert_hits(USERS);
-                    mock_endpoints[THREE_KEY].assert_hits(USERS);
+                    mock_endpoints[ONE_KEY].assert_calls(0);
+                    mock_endpoints[TWO_KEY].assert_calls(USERS);
+                    mock_endpoints[THREE_KEY].assert_calls(USERS);
                 }
                 GooseScheduler::Serial => {
                     // Tests are allocated sequentally THREE, TWO, ONE. There's no delay
                     // in THREE and it has a weight of 2, so the test runs THREE twice and
                     // TWO which then times things out and prevents ONE from running.
-                    mock_endpoints[ONE_KEY].assert_hits(0);
-                    mock_endpoints[TWO_KEY].assert_hits(USERS);
-                    mock_endpoints[THREE_KEY].assert_hits(USERS * 2);
+                    mock_endpoints[ONE_KEY].assert_calls(0);
+                    mock_endpoints[TWO_KEY].assert_calls(USERS);
+                    mock_endpoints[THREE_KEY].assert_calls(USERS * 2);
                 }
                 GooseScheduler::Random => {
                     // When scheduling scenarios randomly, we don't know how many of each will get
                     // launched, but we do now that added together they will equal the total number
                     // of users (THREE_KEY isn't counted as there's no delay).
                     assert!(
-                        mock_endpoints[ONE_KEY].hits() + mock_endpoints[TWO_KEY].hits() == USERS
+                        mock_endpoints[ONE_KEY].calls() + mock_endpoints[TWO_KEY].calls() == USERS
                     );
                 }
             }
@@ -244,7 +244,7 @@ fn validate_test(test_type: &TestType, scheduler: &GooseScheduler, mock_endpoint
     }
 
     // STOP_ONE_PATH is loaded one and only one time on all variations.
-    mock_endpoints[STOP_ONE_KEY].assert_hits(1);
+    mock_endpoints[STOP_ONE_KEY].assert_calls(1);
 }
 
 // Returns the appropriate scenario, start_transaction and stop_transaction needed to build these tests.

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -151,39 +151,39 @@ fn common_build_configuration(
 // Helper to confirm all variations generate appropriate results.
 fn validate_test(test_type: &TestType, mock_endpoints: &[Mock]) {
     // START_ONE_PATH is loaded one and only one time on all variations.
-    mock_endpoints[START_ONE_KEY].assert_hits(1);
+    mock_endpoints[START_ONE_KEY].assert_calls(1);
 
     // Now confirm TestType-specific counters.
     match test_type {
         TestType::NotSequenced => {
             // All transactions run one time, as they are launched RoundRobin in the order
             // defined (and importantly three is defined before two in this test).
-            mock_endpoints[ONE_KEY].assert_hits(USERS);
-            mock_endpoints[THREE_KEY].assert_hits(USERS);
-            mock_endpoints[TWO_KEY].assert_hits(USERS);
+            mock_endpoints[ONE_KEY].assert_calls(USERS);
+            mock_endpoints[THREE_KEY].assert_calls(USERS);
+            mock_endpoints[TWO_KEY].assert_calls(USERS);
         }
         TestType::SequencedRoundRobin => {
             // Transaction ONE runs twice as it's scheduled first with a weight of 2. It then
             // runs one more time in the next scheduling as it then round robins between
             // ONE and TWO. When TWO runs it runs out the clock.
-            mock_endpoints[ONE_KEY].assert_hits(USERS * 3);
+            mock_endpoints[ONE_KEY].assert_calls(USERS * 3);
             // Two runs out the clock, so three never runs.
-            mock_endpoints[TWO_KEY].assert_hits(USERS);
-            mock_endpoints[THREE_KEY].assert_hits(0);
+            mock_endpoints[TWO_KEY].assert_calls(USERS);
+            mock_endpoints[THREE_KEY].assert_calls(0);
         }
         TestType::SequencedSerial => {
             // Transaction ONE runs twice as it's scheduled first with a weight of 2. It then
             // runs two more times in the next scheduling as runs transaction serially as
             // defined.
-            mock_endpoints[ONE_KEY].assert_hits(USERS * 4);
+            mock_endpoints[ONE_KEY].assert_calls(USERS * 4);
             // Two runs out the clock, so three never runs.
-            mock_endpoints[TWO_KEY].assert_hits(USERS);
-            mock_endpoints[THREE_KEY].assert_hits(0);
+            mock_endpoints[TWO_KEY].assert_calls(USERS);
+            mock_endpoints[THREE_KEY].assert_calls(0);
         }
     }
 
     // STOP_ONE_PATH is loaded one and only one time on all variations.
-    mock_endpoints[STOP_ONE_KEY].assert_hits(1);
+    mock_endpoints[STOP_ONE_KEY].assert_calls(1);
 }
 
 // Returns the appropriate scenario, start_transaction and stop_transaction needed to build these tests.

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -343,22 +343,22 @@ fn validate_requests(test_type: TestType, goose_metrics: &GooseMetrics, mock_end
     match test_type {
         TestType::Session => {
             // Confirm that each user set a session one and only one time.
-            assert!(mock_endpoints[POST_SESSION_KEY].hits() == users);
+            assert!(mock_endpoints[POST_SESSION_KEY].calls() == users);
             // Confirm that each user validated their session multiple times.
-            assert!(mock_endpoints[GET_SESSION_KEY].hits() > users);
+            assert!(mock_endpoints[GET_SESSION_KEY].calls() > users);
         }
         #[cfg(feature = "cookies")]
         TestType::Cookie => {
             // Confirm that each user set a cookie one and only one time.
-            assert!(mock_endpoints[POST_COOKIE_KEY_0].hits() == 1);
-            assert!(mock_endpoints[POST_COOKIE_KEY_1].hits() == 1);
-            assert!(mock_endpoints[POST_COOKIE_KEY_2].hits() == 1);
-            assert!(mock_endpoints[POST_COOKIE_KEY_3].hits() == 1);
+            assert!(mock_endpoints[POST_COOKIE_KEY_0].calls() == 1);
+            assert!(mock_endpoints[POST_COOKIE_KEY_1].calls() == 1);
+            assert!(mock_endpoints[POST_COOKIE_KEY_2].calls() == 1);
+            assert!(mock_endpoints[POST_COOKIE_KEY_3].calls() == 1);
             // Confirm that each user validated their cookie multiple times.
-            assert!(mock_endpoints[GET_COOKIE_KEY_0].hits() > 1);
-            assert!(mock_endpoints[GET_COOKIE_KEY_1].hits() > 1);
-            assert!(mock_endpoints[GET_COOKIE_KEY_2].hits() > 1);
-            assert!(mock_endpoints[GET_COOKIE_KEY_3].hits() > 1);
+            assert!(mock_endpoints[GET_COOKIE_KEY_0].calls() > 1);
+            assert!(mock_endpoints[GET_COOKIE_KEY_1].calls() > 1);
+            assert!(mock_endpoints[GET_COOKIE_KEY_2].calls() > 1);
+            assert!(mock_endpoints[GET_COOKIE_KEY_3].calls() > 1);
         }
     }
 

--- a/tests/setup_teardown.rs
+++ b/tests/setup_teardown.rs
@@ -104,27 +104,27 @@ fn common_build_configuration(
 // Helper to confirm all variations generate appropriate results.
 fn validate_test(test_type: &TestType, mock_endpoints: &[Mock]) {
     // Confirm the load test ran.
-    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
+    assert!(mock_endpoints[INDEX_KEY].calls() > 0);
 
     // Now confirm TestType-specific counters.
     match test_type {
         TestType::Start => {
             // Confirm setup ran one time.
-            mock_endpoints[SETUP_KEY].assert_hits(1);
+            mock_endpoints[SETUP_KEY].assert_calls(1);
             // Confirm teardown did not run.
-            mock_endpoints[TEARDOWN_KEY].assert_hits(0);
+            mock_endpoints[TEARDOWN_KEY].assert_calls(0);
         }
         TestType::Stop => {
             // Confirm setup did not run.
-            mock_endpoints[SETUP_KEY].assert_hits(0);
+            mock_endpoints[SETUP_KEY].assert_calls(0);
             // Confirm teardown ran one time.
-            mock_endpoints[TEARDOWN_KEY].assert_hits(1);
+            mock_endpoints[TEARDOWN_KEY].assert_calls(1);
         }
         TestType::StartAndStop => {
             // Confirm setup ran one time.
-            mock_endpoints[SETUP_KEY].assert_hits(1);
+            mock_endpoints[SETUP_KEY].assert_calls(1);
             // Confirm teardown ran one time.
-            mock_endpoints[TEARDOWN_KEY].assert_hits(1);
+            mock_endpoints[TEARDOWN_KEY].assert_calls(1);
         }
     }
 }

--- a/tests/throttle.rs
+++ b/tests/throttle.rs
@@ -125,8 +125,8 @@ fn validate_test(
     }
 
     // Confirm that we loaded the mock endpoints.
-    assert!(mock_endpoints[INDEX_KEY].hits() > 0);
-    assert!(mock_endpoints[ABOUT_KEY].hits() > 0);
+    assert!(mock_endpoints[INDEX_KEY].calls() > 0);
+    assert!(mock_endpoints[ABOUT_KEY].calls() > 0);
 
     // Requests are made while GooseUsers are hatched, and then for RUN_TIME seconds.
     assert!(current_requests_file_lines <= (RUN_TIME + 1) * throttle_value);


### PR DESCRIPTION
Basically what the title says. Since httpmock 0.8, the `.hits()` and `.assert_hits()` calls were deprecated so I replaced them.