### PR TITLE
chore: update reqwest to 0.13

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -116,7 +116,6 @@ When implementing new features:
 ### Version Requirements
 **Maintain compatibility**:
 - Rust edition 2021
-- Support both native-tls and rustls
 - Optional dependencies via feature flags
 - Document minimum supported Rust version (MSRV)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
  - [#629](https://github.com/tag1consulting/goose/pull/629) add `--pdf-print-html` option to generate printer-friendly HTML optimized for PDF conversion; provides two-step PDF workflow without requiring Chromium dependencies; add `--pdf-timeout` option for configurable Chrome timeout in direct PDF generation (10-300s, default: 60)
  - [#663](https://github.com/tag1consulting/goose/pull/663) add response time breakdowns grouped by HTTP status code in CLI and HTML/markdown reports; breakdowns only appear when a request returns multiple different status codes
  - [#657](https://github.com/tag1consulting/goose/pull/657) add comprehensive Basic Authentication example demonstrating three approaches: custom client with default headers (recommended), helper function per-request, and manual per-request; includes flexible credential configuration and complete documentation
+ - [#669](https://github.com/tag1consulting/goose/pull/669) update reqwest to 0.13, switching the default TLS backend from native-tls to rustls. HTTP/2 and post-quantum cryptography are now advertised by default, which may increase connection handshake overhead when a computationally expensive cipher suite is negotiated.
+   **Breaking changes**: Certificate validation now uses bundled rustls/webpki roots instead of the OS-native certificate store, which may affect environments with custom system CAs. `--accept-invalid-certs` now works unconditionally (previously it was silently ignored unless the `rustls-tls` feature was enabled).
 
 ## 0.18.1 August 14, 2025
  - [#634](https://github.com/tag1consulting/goose/pull/634) add killswitch mechanism for programmatic test termination

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ctrlc = "3"
 downcast-rs = "2.0"
-flume = "0.11"
+flume = "0.12"
 futures = "0.3"
 gumdrop = "0.8"
 http = "1.1"
@@ -26,7 +26,9 @@ log = "0.4"
 num-format = "0.4"
 rand = "0.9"
 regex = "1"
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
+    "default-tls",
+    "form",
     "gzip",
     "json",
 ] }
@@ -46,26 +48,22 @@ tokio = { version = "1", features = [
     "time",
     "sync",
 ] }
-tokio-tungstenite = "0.27"
-tungstenite = "0.27"
+tokio-tungstenite = "0.28"
 url = "2"
 headless_chrome = { version = "1.0", features = ["fetch"], optional = true }
 urlencoding = { version = "2.1", optional = true }
 
 [features]
 # Include cookies by default for backward compatibility and expected behavior in web load testing
-default = ["reqwest/default-tls", "cookies"]
-# Include cookies with rustls-tls to maintain consistent behavior regardless of TLS backend choice.
-# This ensures users don't lose cookie functionality when switching from native-tls to rustls-tls
-# for performance or dependency reasons. Cookie handling is logically independent of TLS implementation.
-rustls-tls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls", "cookies"]
+default = ["cookies"]
+# reqwest >==0.13 already defaults to rustls
+rustls-tls = ["tokio-tungstenite/rustls"]
 # Cookie support - can be completely disabled by compiling with --no-default-features for maximum performance
 cookies = ["reqwest/cookies"]
 pdf-reports = ["headless_chrome", "urlencoding"]
 
 [dev-dependencies]
 httpmock = "0.8"
-native-tls = "0.2"
 nix = { version = "0.30", features = ["signal"] }
 rustls = "0.23"
 serial_test = "3.2"

--- a/context7.json
+++ b/context7.json
@@ -31,7 +31,6 @@
     "PDF report generation coming soon (see issue #628)",
     "Includes WebSocket and Telnet controllers for runtime control",
     "Features flexible test plans with complex load patterns",
-    "Supports both native-tls and rustls for HTTPS requests"
   ],
   "previousVersions": []
 }

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -24,7 +24,7 @@
 ### Client Capabilities
 - **Cookie Management**: Automatic cookie handling across requests
 - **Header Management**: Custom HTTP headers for requests
-- **TLS Support**: Support for both native-tls and rustls
+- **TLS Support**: Support for rustls
 - **Custom Clients**: Ability to build custom Reqwest clients
 - **Request Customization**: Timeouts, redirects, and other options
 - **✓ Type-Safe Client Builder**: Phantom type system preventing invalid cookie configurations at compile time

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -21,7 +21,7 @@
 - **Tungstenite**: WebSocket protocol implementation
 
 ### Optional Features
-- **rustls-tls**: Alternative TLS implementation (feature flag)
+- **rustls-tls**: backwards-compatible feature for enabling rustls (feature flag)
 - **gaggle**: Distributed load testing capability (feature flag)
 
 ## Development Setup
@@ -29,14 +29,14 @@
 ### Build System
 - **Cargo**: Rust's package manager and build tool
 - **Feature Flags**: Optional functionality through conditional compilation
-  - `default`: Uses native-tls for HTTPS
-  - `rustls-tls`: Uses rustls for HTTPS instead of native-tls
+  - `default`: Uses rustls for HTTPS
+  - `rustls-tls`: additionally enables rustls for websockets
   - `gaggle`: Enables distributed load testing
 
 ### Testing
 - **HTTPMock**: For mocking HTTP responses in tests
 - **Serial_test**: For tests that cannot run in parallel
-- **Native-tls/Rustls**: For testing TLS functionality
+- **Rustls**: For testing TLS functionality
 - **Nix**: For signal handling in tests
 
 ## Technical Constraints

--- a/src/client.rs
+++ b/src/client.rs
@@ -300,12 +300,8 @@ pub(crate) fn create_reqwest_client_without_cookies(
 ) -> Result<Client, reqwest::Error> {
     let mut client_builder = Client::builder()
         .user_agent(&config.user_agent)
-        .gzip(config.gzip);
-
-    #[cfg(feature = "rustls-tls")]
-    {
-        client_builder = client_builder.danger_accept_invalid_certs(config.accept_invalid_certs);
-    }
+        .gzip(config.gzip)
+        .danger_accept_invalid_certs(config.accept_invalid_certs);
 
     if let Some(timeout) = config.timeout {
         client_builder = client_builder.timeout(timeout);
@@ -322,12 +318,8 @@ pub(crate) fn create_reqwest_client_with_cookies(
 ) -> Result<Client, reqwest::Error> {
     let mut client_builder = Client::builder()
         .user_agent(&config.user_agent)
-        .gzip(config.gzip);
-
-    #[cfg(feature = "rustls-tls")]
-    {
-        client_builder = client_builder.danger_accept_invalid_certs(config.accept_invalid_certs);
-    }
+        .gzip(config.gzip)
+        .danger_accept_invalid_certs(config.accept_invalid_certs);
 
     if let Some(timeout) = config.timeout {
         client_builder = client_builder.timeout(timeout);

--- a/src/docs/goose-book/src/SUMMARY.md
+++ b/src/docs/goose-book/src/SUMMARY.md
@@ -43,7 +43,6 @@
     - [Defaults](config/defaults.md)
     - [Scheduling Scenarios And Transactions](config/scheduler.md)
     - [Proxy](config/proxy.md)
-    - [RustLS](config/rustls.md)
 
 - [Examples](example/overview.md)
     - [Simple](example/simple.md)

--- a/src/docs/goose-book/src/config/cookie.md
+++ b/src/docs/goose-book/src/config/cookie.md
@@ -123,10 +123,10 @@ For ultra-high-scale testing where even the shared client approach isn't suffici
 
 ```bash
 # Compile without any cookies dependency
-cargo build --no-default-features --features "rustls-tls"
+cargo build --no-default-features
 
 # Run tests without cookies
-cargo run --no-default-features --features "rustls-tls" -- --host https://example.com
+cargo run --no-default-features -- --host https://example.com
 ```
 
 **Important**: This removes cookie functionality completely - you cannot use `.set_client_builder_with_cookies()` or any cookie-related methods when compiled this way. This is only for specialized use cases where maximum performance and minimal binary size are critical.

--- a/src/docs/goose-book/src/config/proxy.md
+++ b/src/docs/goose-book/src/config/proxy.md
@@ -33,7 +33,7 @@ Add reqwest with the `socks` feature to your `Cargo.toml`:
 [dependencies]
 goose = "^0.19"
 tokio = "^1"
-reqwest = { version = "0.12", features = ["socks"] }
+reqwest = { version = "0.13", features = ["socks"] }
 ```
 
 **Note**: Cargo automatically unifies features across all dependencies. Since Goose already requires `gzip` and `json` features from reqwest, adding just `socks` will result in reqwest being compiled with `["gzip", "json", "socks"]`.
@@ -146,7 +146,7 @@ edition = "2021"
 goose = "^0.19"
 tokio = { version = "^1", features = ["macros", "rt-multi-thread"] }
 # Add socks feature - Cargo will unify with Goose's gzip+json features
-reqwest = { version = "0.12", features = ["socks"] }
+reqwest = { version = "0.13", features = ["socks"] }
 ```
 
 **src/main.rs (same as above):**
@@ -194,7 +194,7 @@ For proxies requiring authentication:
 
 ### Feature Not Available
 If you get compilation errors about SOCKS features:
-- Verify `reqwest = { version = "0.12", features = ["socks"] }` is in your Cargo.toml
+- Verify `reqwest = { version = "0.13", features = ["socks"] }` is in your Cargo.toml
 - Run `cargo clean` and rebuild your project
 
 ## Additional Resources

--- a/src/docs/goose-book/src/config/rustls.md
+++ b/src/docs/goose-book/src/config/rustls.md
@@ -1,8 +1,0 @@
-# RustLS
-
-By default Reqwest (and therefore Goose) uses the system-native transport layer security to make HTTPS requests. This means `schannel` on Windows, `Security-Framework` on macOS, and `OpenSSL` on Linux. If you'd prefer to use a [pure Rust TLS implementation](https://github.com/ctz/rustls), disable default features and enable `rustls-tls` in `Cargo.toml` as follows:
-
-```toml
-[dependencies]
-goose = { version = "^0.18", default-features = false, features = ["rustls-tls"] }
-```

--- a/src/goose.rs
+++ b/src/goose.rs
@@ -2572,26 +2572,13 @@ pub(crate) fn create_reqwest_client(
         GOOSE_REQUEST_TIMEOUT
     };
 
-    #[cfg(feature = "rustls-tls")]
-    let mut client_builder = Client::builder()
-        .user_agent(APP_USER_AGENT)
-        .timeout(Duration::from_millis(timeout))
-        // Enable gzip unless `--no-gzip` flag is enabled.
-        .gzip(!configuration.no_gzip);
-
-    #[cfg(not(feature = "rustls-tls"))]
     let client_builder = Client::builder()
         .user_agent(APP_USER_AGENT)
         .timeout(Duration::from_millis(timeout))
         // Enable gzip unless `--no-gzip` flag is enabled.
-        .gzip(!configuration.no_gzip);
-
-    #[cfg(feature = "rustls-tls")]
-    {
+        .gzip(!configuration.no_gzip)
         // Validate https certificates unless `--accept-invalid-certs` is enabled.
-        client_builder =
-            client_builder.danger_accept_invalid_certs(configuration.accept_invalid_certs);
-    }
+        .danger_accept_invalid_certs(configuration.accept_invalid_certs);
 
     #[cfg(feature = "cookies")]
     let client_builder = client_builder.cookie_store(true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1118,7 +1118,10 @@ impl GooseAttack {
                             return Err(GooseError::InvalidOption {
                                 option: "--host".to_string(),
                                 value: "".to_string(),
-                                detail: format!("A host must be defined via the --host option, the GooseAttack.set_default() function, or the Scenario.set_host() function (no host defined for {}).", scenario.name)
+                                detail: format!(
+                                    "A host must be defined via the --host option, the GooseAttack.set_default() function, or the Scenario.set_host() function (no host defined for {}).",
+                                    scenario.name
+                                ),
                             });
                         }
                     },


### PR DESCRIPTION
This PR updates reqwest to 0.13 which uses rustls by default.

I have observed the per-connection overhead to be greater than before because HTTP/2 + post-quantum cryptography is advertised / accepted depending on the remote server.
This would have likely happened with `native-tls` as well, because ALPN is enabled for it by default as well so IMHO it doesn't make sense to add another feature flag for `native-tls`.