### PR TITLE
fix: resolve clippy unnecessary_unwrap warning

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3044,8 +3044,8 @@ impl GooseAttack {
     // Update metrics showing how long the load test has been running.
     // 1.2 seconds will round down to 1 second. 1.6 seconds will round up to 2 seconds.
     pub(crate) fn update_duration(&mut self) {
-        self.metrics.duration = if self.started.is_some() {
-            self.started.unwrap().elapsed().as_secs_f32().round() as usize
+        self.metrics.duration = if let Some(started) = self.started {
+            started.elapsed().as_secs_f32().round() as usize
         } else {
             0
         };


### PR DESCRIPTION
## Summary
- Fixes `clippy::unnecessary_unwrap` lint error introduced in Rust 1.93 that causes CI to fail with `-D warnings`
- Replaces `is_some()` + `unwrap()` pattern with idiomatic `if let Some(started)` in `update_duration()`

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo test --all-features` passes (one pre-existing flaky test unrelated to this change)